### PR TITLE
fix: tabindex on scrollable datatable body

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -25,6 +25,7 @@
   >
   </datatable-header>
   <datatable-body
+    tabindex="0"
     role="rowgroup"
     [groupRowsBy]="groupRowsBy"
     [groupedRows]="groupedRows"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
No tabindex on the scrollable body of the datatable, therefore can't be selected (tabbed into).
And according to:
https://dequeuniversity.com/rules/axe/4.3/scrollable-region-focusable?application=axeAPI
The tabindex is expected on the scrollable part.

**What is the new behavior?**
Can now jump into the datatable and scroll with keyboard interactions.


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
-