### PR TITLE
fix: emit page event on page size change for virtual paging

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -153,6 +153,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
       this.recalcLayout();
 
       // Emits the page event if page size has been changed
+      this._offsetEvent = -1;
       this.updatePage('up');
       this.updatePage('down');
     }
@@ -279,6 +280,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   _rowCount: number;
   _offset: number;
   _pageSize: number;
+  _offsetEvent = -1;
 
   /**
    * Creates an instance of DataTableBodyComponent.
@@ -400,7 +402,8 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
       offset = Math.floor(offset);
     }
 
-    if (direction !== undefined && !isNaN(offset)) {
+    if (direction !== undefined && !isNaN(offset) && offset !== this._offsetEvent) {
+      this._offsetEvent = offset;
       this.page.emit({ offset });
     }
   }

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -148,8 +148,14 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() summaryHeight: number;
 
   @Input() set pageSize(val: number) {
-    this._pageSize = val;
-    this.recalcLayout();
+    if (val !== this._pageSize) {
+      this._pageSize = val;
+      this.recalcLayout();
+
+      // Emits the page event if page size has been changed
+      this.updatePage('up');
+      this.updatePage('down');
+    }
   }
 
   get pageSize(): number {
@@ -157,8 +163,10 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   }
 
   @Input() set rows(val: any[]) {
-    this._rows = val;
-    this.recalcLayout();
+    if (val !== this._rows) {
+      this._rows = val;
+      this.recalcLayout();
+    }
   }
 
   get rows(): any[] {
@@ -166,9 +174,11 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   }
 
   @Input() set columns(val: any[]) {
-    this._columns = val;
-    const colsByPin = columnsByPin(val);
-    this.columnGroupWidths = columnGroupWidths(colsByPin, val);
+    if (val !== this._columns) {
+      this._columns = val;
+      const colsByPin = columnsByPin(val);
+      this.columnGroupWidths = columnGroupWidths(colsByPin, val);
+    }
   }
 
   get columns(): any[] {
@@ -176,8 +186,10 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   }
 
   @Input() set offset(val: number) {
-    this._offset = val;
-    if (!this.scrollbarV || (this.scrollbarV && !this.virtualization)) this.recalcLayout();
+    if (val !== this._offset) {
+      this._offset = val;
+      if (!this.scrollbarV || (this.scrollbarV && !this.virtualization)) this.recalcLayout();
+    }
   }
 
   get offset(): number {
@@ -185,8 +197,10 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   }
 
   @Input() set rowCount(val: number) {
-    this._rowCount = val;
-    this.recalcLayout();
+    if (val !== this._rowCount) {
+      this._rowCount = val;
+      this.recalcLayout();
+    }
   }
 
   get rowCount(): number {

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -880,12 +880,14 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
 
     this.offset = offset;
 
-    this.page.emit({
-      count: this.count,
-      pageSize: this.pageSize,
-      limit: this.limit,
-      offset: this.offset
-    });
+    if (!isNaN(this.offset)) {
+      this.page.emit({
+        count: this.count,
+        pageSize: this.pageSize,
+        limit: this.limit,
+        offset: this.offset
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
Ensures that the rows (data) are loaded correctly when the layout of the
table has changed. This applies especially to changes for resizing the
view port which let page size increase or decrease.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Page event is not fired when page size changes due to resize of the table body.

**What is the new behavior?**

Fires page event when page size changes. Avoids display data/row gaps on table resize.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
