### PR TITLE
fix: fix clearTimeout/_destroySubscription race

### DIFF
--- a/projects/ngx-datatable/src/lib/directives/long-press.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/long-press.directive.ts
@@ -107,6 +107,7 @@ export class LongPressDirective implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    clearTimeout(this.timeout);
     this._destroySubscription();
   }
 


### PR DESCRIPTION
Before this patch, when an Angular component gets destroyed (e.g. for
recreation by parent) while a long-click is in progress, a TypeError
could be thrown.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

See swimlane#1763

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
