### PR TITLE
feat: support custom content for empty table

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -113,7 +113,15 @@ import { translateXY } from '../../utils/translate';
         >
         </datatable-summary-row>
       </datatable-scroller>
-      <div class="empty-row" *ngIf="!rows?.length && !loadingIndicator" [innerHTML]="emptyMessage"></div>
+      <div
+        class="empty-row"
+        *ngIf="!rows?.length && !loadingIndicator && !emptyCustomContent"
+        [innerHTML]="emptyMessage"
+      ></div>
+      <ng-content
+        select="[empty-content]"
+        *ngIf="!rows?.length && !loadingIndicator && emptyCustomContent"
+      ></ng-content>
     </datatable-selection>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -129,6 +137,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() rowHeight: number | 'auto' | ((row?: any) => number);
   @Input() offsetX: number;
   @Input() emptyMessage: string;
+  @Input() emptyCustomContent: boolean;
   @Input() selectionType: SelectionType;
   @Input() selected: any[] = [];
   @Input() rowIdentity: any;

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -50,6 +50,7 @@
     [bodyHeight]="bodyHeight"
     [selectionType]="selectionType"
     [emptyMessage]="messages.emptyMessage"
+    [emptyCustomContent]="emptyCustomContent"
     [rowIdentity]="rowIdentity"
     [rowClass]="rowClass"
     [selectCheck]="selectCheck"
@@ -64,6 +65,7 @@
     (scroll)="onBodyScroll($event)"
     (treeAction)="onTreeAction($event)"
   >
+    <ng-content select="[empty-content]" ngProjectAs="[empty-content]"></ng-content>
   </datatable-body>
   <datatable-footer
     *ngIf="footerHeight"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -332,6 +332,17 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   };
 
   /**
+   * A flag to display custom content instead of emptyMessage,
+   * when rows array contains no values. Assumes that custom content has been
+   * provided with the appropriate `empty-content` attribute.
+   *
+   *    <ngx-datatable>
+   *      <div empty-content>...</div>
+   *    </ngx-datatable>
+   */
+  @Input() emptyCustomContent: boolean = false;
+
+  /**
    * Row specific classes.
    * Similar implementation to ngClass.
    *


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Empty table does not support custom content. Only possible to display the value of `emptyMessage` of type string.

**What is the new behavior?**

Supports now custom content for an empty table within the table body. Gives the consumer the possibility to use additional components within the table. In our case, for example, a component that contains text and an icon to display empty data in a table.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
