### PR TITLE
refactor(custom-empty-component): use custom empty component if existent

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -115,13 +115,12 @@ import { translateXY } from '../../utils/translate';
       </datatable-scroller>
       <div
         class="empty-row"
-        *ngIf="!rows?.length && !loadingIndicator && !emptyCustomContent"
+        *ngIf="!rows?.length && !loadingIndicator && !customEmptyContent?.hasChildNodes()"
         [innerHTML]="emptyMessage"
       ></div>
-      <ng-content
-        select="[empty-content]"
-        *ngIf="!rows?.length && !loadingIndicator && emptyCustomContent"
-      ></ng-content>
+      <div #customEmptyContent>
+        <ng-content select="[empty-content]" *ngIf="!rows?.length && !loadingIndicator"></ng-content>
+      </div>
     </datatable-selection>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -137,7 +136,6 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() rowHeight: number | 'auto' | ((row?: any) => number);
   @Input() offsetX: number;
   @Input() emptyMessage: string;
-  @Input() emptyCustomContent: boolean;
   @Input() selectionType: SelectionType;
   @Input() selected: any[] = [];
   @Input() rowIdentity: any;

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -51,7 +51,6 @@
     [bodyHeight]="bodyHeight"
     [selectionType]="selectionType"
     [emptyMessage]="messages.emptyMessage"
-    [emptyCustomContent]="emptyCustomContent"
     [rowIdentity]="rowIdentity"
     [rowClass]="rowClass"
     [selectCheck]="selectCheck"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -332,17 +332,6 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit {
   };
 
   /**
-   * A flag to display custom content instead of emptyMessage,
-   * when rows array contains no values. Assumes that custom content has been
-   * provided with the appropriate `empty-content` attribute.
-   *
-   *    <ngx-datatable>
-   *      <div empty-content>...</div>
-   *    </ngx-datatable>
-   */
-  @Input() emptyCustomContent: boolean = false;
-
-  /**
    * Row specific classes.
    * Similar implementation to ngClass.
    *

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -43,6 +43,9 @@
           <li>
             <a href="#footer" (click)="state = 'footer'">Footer Template</a>
           </li>
+          <li>
+            <a href="#empty" (click)="state = 'empty'">Empty Template</a>
+          </li>
         </ul>
       </li>
       <li>
@@ -209,6 +212,7 @@
     <row-css-demo *ngIf="state === 'css'"></row-css-demo>
     <dynamic-height-demo *ngIf="state === 'dynamic'"></dynamic-height-demo>
     <footer-demo *ngIf="state === 'footer'"></footer-demo>
+    <empty-demo *ngIf="state === 'empty'"></empty-demo>
 
     <!-- Themes -->
     <basic-dark-theme-demo *ngIf="state === 'dark'"></basic-dark-theme-demo>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { RowCssComponent } from './basic/css.component';
 import { DynamicHeightComponent } from './basic/dynamic-height.component';
 import { FooterDemoComponent } from './basic/footer.component';
 import { RowGroupingComponent } from './basic/row-grouping.component';
+import { BasicEmptyComponent } from './basic/empty.component';
 
 // -- Themes
 import { BootstrapThemeComponent } from './basic/bootstrap.component';
@@ -121,6 +122,7 @@ import { CommonModule } from '@angular/common';
     DynamicHeightComponent,
     FooterDemoComponent,
     RowGroupingComponent,
+    BasicEmptyComponent,
     BootstrapThemeComponent,
     ClientTreeComponent,
     SummaryRowSimpleComponent,

--- a/src/app/basic/empty.component.ts
+++ b/src/app/basic/empty.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+
+@Component({
+  selector: 'empty-demo',
+  template: `
+    <div>
+      <h3>
+        Custom Empty Component
+        <small>
+          <a
+            href="https://github.com/siemens/ngx-datatable/blob/master/src/app/basic/empty.component.ts"
+            target="_blank"
+          >
+            Source
+          </a>
+        </small>
+      </h3>
+      <ngx-datatable
+        class="material"
+        [rows]="[]"
+        [columns]="columns"
+        [columnMode]="ColumnMode.force"
+        [headerHeight]="50"
+        [footerHeight]="50"
+      >
+        <div empty-content style="text-align: center;">My custom empty component<br />uses two lines.</div>
+      </ngx-datatable>
+    </div>
+  `
+})
+export class BasicEmptyComponent {
+  columns = [{ prop: 'name' }, { name: 'Gender' }, { name: 'Company', sortable: false }];
+  ColumnMode = ColumnMode;
+}


### PR DESCRIPTION
Before, the developer had to specify a flag, if the table shall use a custom empty
comonent. Now the flag is not needed any more. Makes the API cleaner. Either
a custom empty component is available or not.

BREAKING-CHANGE: remove usage of emptyCustomContent input
