### PR TITLE
feat: decouple checkboxable and headerCheckboxable from SelectionType…

### DIFF
--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -151,7 +151,7 @@ export class DataTableHeaderCellComponent {
   }
 
   get isCheckboxable(): boolean {
-    return this.column.checkboxable && this.column.headerCheckboxable && this.selectionType === SelectionType.checkbox;
+    return this.column.headerCheckboxable;
   }
 
   sortFn = this.onSort.bind(this);

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -152,6 +152,11 @@
           <li>
             <a href="#chkbox-selection-template" (click)="state = 'chkbox-selection-template'">Custom Checkbox</a>
           </li>
+          <li>
+            <a href="#multi-click-chkbox-selection" (click)="state = 'multi-click-chkbox-selection'"
+              >Multi Click & Chkbox</a
+            >
+          </li>
         </ul>
       </li>
       <li>
@@ -242,10 +247,13 @@
     <cell-selection-demo *ngIf="state === 'cell-selection'"></cell-selection-demo>
     <single-selection-demo *ngIf="state === 'single-selection'"></single-selection-demo>
     <multi-selection-demo *ngIf="state === 'multi-selection'"></multi-selection-demo>
+    <multi-click-selection-demo *ngIf="state === 'multi-click-selection'"></multi-click-selection-demo>
     <multidisable-selection-demo *ngIf="state === 'multidisable-selection'"></multidisable-selection-demo>
     <chkbox-selection-demo *ngIf="state === 'chkbox-selection'"></chkbox-selection-demo>
     <chkbox-selection-template-demo *ngIf="state === 'chkbox-selection-template'"></chkbox-selection-template-demo>
-    <multi-click-selection-demo *ngIf="state === 'multi-click-selection'"></multi-click-selection-demo>
+    <multi-click-chkbox-selection-demo
+      *ngIf="state === 'multi-click-chkbox-selection'"
+    ></multi-click-chkbox-selection-demo>
 
     <!-- Templates -->
     <template-ref-demo *ngIf="state === 'templateref'"></template-ref-demo>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -57,6 +57,7 @@ import { SingleSelectionComponent } from './selection/selection-single.component
 import { MultiDisableSelectionComponent } from './selection/selection-disabled.component';
 import { CheckboxSelectionComponent } from './selection/selection-chkbox.component';
 import { MultiClickSelectionComponent } from './selection/selection-multi-click.component';
+import { MultiClickCheckboxSelectionComponent } from './selection/selection-multi-click-chkbox.component';
 import { CustomCheckboxSelectionComponent } from './selection/selection-chkbox-template.component';
 
 // -- Columns
@@ -98,6 +99,7 @@ import { CommonModule } from '@angular/common';
     SortingComparatorComponent,
     CellSelectionComponent,
     MultiSelectionComponent,
+    MultiClickCheckboxSelectionComponent,
     InlineTemplatesComponent,
     TemplateRefTemplatesComponent,
     ColumnFlexComponent,

--- a/src/app/selection/selection-multi-click-chkbox.component.ts
+++ b/src/app/selection/selection-multi-click-chkbox.component.ts
@@ -1,0 +1,122 @@
+import { Component } from '@angular/core';
+import { ColumnMode, SelectionType } from 'projects/ngx-datatable/src/public-api';
+
+@Component({
+  selector: 'multi-click-chkbox-selection-demo',
+  template: `
+    <div>
+      <h3>
+        Multi Click with Checkbox Selection
+        <small>
+          <a
+            href="https://github.com/siemens/ngx-datatable/blob/master/src/app/selection/selection-chkbox.component.ts"
+            target="_blank"
+          >
+            Source
+          </a>
+        </small>
+        <small>
+          <a href="javascript:void(0)" (click)="add()">Add</a> |
+          <a href="javascript:void(0)" (click)="update()">Update</a> |
+          <a href="javascript:void(0)" (click)="remove()">Remove</a>
+        </small>
+      </h3>
+      <div style="float:left;width:75%">
+        <ngx-datatable
+          style="width: 90%"
+          class="material"
+          [rows]="rows"
+          [columnMode]="ColumnMode.force"
+          [headerHeight]="50"
+          [footerHeight]="50"
+          rowHeight="auto"
+          [limit]="5"
+          [selected]="selected"
+          [selectionType]="SelectionType.multiClick"
+          [selectAllRowsOnPage]="false"
+          [displayCheck]="allowSelection"
+          [selectCheck]="allowSelection"
+          (activate)="onActivate($event)"
+          (select)="onSelect($event)"
+        >
+          <ngx-datatable-column
+            [width]="30"
+            [sortable]="false"
+            [canAutoResize]="false"
+            [draggable]="false"
+            [resizeable]="false"
+            [headerCheckboxable]="true"
+            [checkboxable]="true"
+          >
+          </ngx-datatable-column>
+          <ngx-datatable-column name="Name"></ngx-datatable-column>
+          <ngx-datatable-column name="Gender"></ngx-datatable-column>
+          <ngx-datatable-column name="Company"></ngx-datatable-column>
+        </ngx-datatable>
+      </div>
+
+      <div class="selected-column">
+        <h4>
+          Selections <small>({{ selected?.length }})</small>
+        </h4>
+        <ul>
+          <li *ngFor="let sel of selected">
+            {{ sel.name }}
+          </li>
+          <li *ngIf="!selected?.length">No Selections</li>
+        </ul>
+      </div>
+    </div>
+  `
+})
+export class MultiClickCheckboxSelectionComponent {
+  rows = [];
+  selected = [];
+
+  ColumnMode = ColumnMode;
+  SelectionType = SelectionType;
+
+  constructor() {
+    this.fetch(data => {
+      this.rows = data;
+    });
+  }
+
+  fetch(cb) {
+    const req = new XMLHttpRequest();
+    req.open('GET', `assets/data/company.json`);
+
+    req.onload = () => {
+      cb(JSON.parse(req.response));
+    };
+
+    req.send();
+  }
+
+  onSelect({ selected }) {
+    console.log('Select Event', selected, this.selected);
+
+    this.selected.splice(0, this.selected.length);
+    this.selected.push(...selected);
+  }
+
+  onActivate(event) {
+    console.log('Activate Event', event);
+  }
+
+  add() {
+    this.selected.push(this.rows[1], this.rows[3]);
+  }
+
+  update() {
+    this.selected = [this.rows[1], this.rows[3]];
+  }
+
+  remove() {
+    this.selected = [];
+  }
+
+  allowSelection(row) {
+    return row.name !== 'Beryl Rice';
+  }
+}


### PR DESCRIPTION
….checkbox

This change enables the datatable user to programatically set header checkbox and
column checkbox without the need of using the SelectionType.checkbox. This supports
use cases by combining multi row selection with an additional checkbox view.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Header checkbox is only visible with selection type checkbox.

**What is the new behavior?**

Can combine multi row selection with check box visualisation and header selection.
All controllable by the datatable user.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
