### PR TITLE
fix: fix loading indicator to support ghost loader

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -25,6 +25,7 @@ export type TreeStatus = 'collapsed' | 'expanded' | 'loading' | 'disabled';
   selector: 'datatable-body-cell',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
+  <ng-container *ngIf="row else ghostLoaderTemplate;">
     <div class="datatable-body-cell-label" [style.margin-left.px]="calcLeftMargin(column, row)">
       <label
         *ngIf="column.checkboxable && (!displayCheck || displayCheck(row, column, value))"
@@ -62,6 +63,10 @@ export type TreeStatus = 'collapsed' | 'expanded' | 'loading' | 'disabled';
       >
       </ng-template>
     </div>
+  </ng-container>
+  <ng-template #ghostLoaderTemplate>
+    <ghost-loader [columns]="[column]" [pageSize]="1"></ghost-loader>
+  </ng-template>
   `
 })
 export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
@@ -172,6 +177,9 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
 
   @ViewChild('cellTemplate', { read: ViewContainerRef, static: true })
     cellTemplate: ViewContainerRef;
+
+  @ViewChild('ghostLoaderTemplate', { read: ViewContainerRef, static: true })
+    ghostLoaderTemplate: ViewContainerRef;
 
   @HostBinding('class')
   get columnCssClasses(): any {
@@ -285,6 +293,9 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
   ngOnDestroy(): void {
     if (this.cellTemplate) {
       this.cellTemplate.clear();
+    }
+    if (this.ghostLoaderTemplate) {
+      this.ghostLoaderTemplate.clear();
     }
   }
 

--- a/projects/ngx-datatable/src/lib/components/body/ghost-loader/ghost-loader.component.html
+++ b/projects/ngx-datatable/src/lib/components/body/ghost-loader/ghost-loader.component.html
@@ -1,0 +1,13 @@
+<div [style.height]="ghostBodyHeight + 'px'" class="ghost-loader ghost-cell-container">
+  <div [style.height]="rowHeight + 'px'" class="ghost-element" *ngFor="let item of [].constructor(pageSize)">
+    <ng-container *ngFor="let col of columns">
+      <div class="line ghost-cell-strip" *ngIf="!col.ghostCellTemplate else ghostCellTemplate;" [style.width]="col?.width + 'px'" >
+      </div>
+      <ng-template
+        #ghostCellTemplate
+        [ngTemplateOutlet]="col.ghostCellTemplate"
+      >
+      </ng-template>
+    </ng-container>
+  </div>
+</div>

--- a/projects/ngx-datatable/src/lib/components/body/ghost-loader/ghost-loader.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/ghost-loader/ghost-loader.component.scss
@@ -1,0 +1,38 @@
+/**
+ * Ghost loader animation
+ */
+@keyframes ghost {
+  from {
+    background-position: 0vw 0;
+  }
+  to {
+    background-position: 100vw 0;
+  }
+}
+
+.ghost-loader {
+  overflow: hidden;
+
+  .line {
+    width: 100%;
+    height: 12px;
+    animation-name: ghost;
+    animation-iteration-count: infinite; 
+    animation-timing-function: linear;
+  }
+
+  .ghost-element {
+    display: flex;
+  }
+}
+
+:host.ghost-overlay {
+  position: sticky;
+  top: 20px;
+
+  .ghost-loader {
+    .line {
+      margin: 0.9rem 1.2rem;
+    }
+  }
+}

--- a/projects/ngx-datatable/src/lib/components/body/ghost-loader/ghost-loader.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/ghost-loader/ghost-loader.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { DataTableGhostLoaderComponent } from './ghost-loader.component';
+
+describe('DataTableGhostLoaderComponent', () => {
+  let fixture: ComponentFixture<DataTableGhostLoaderComponent>;
+  let component: DataTableGhostLoaderComponent;
+  let element;
+
+  // provide our implementations or mocks to the dependency injector
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [DataTableGhostLoaderComponent]
+    });
+  });
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.compileComponents().then(() => {
+        fixture = TestBed.createComponent(DataTableGhostLoaderComponent);
+        component = fixture.componentInstance;
+        element = fixture.nativeElement;
+      });
+    })
+  );
+
+  describe('fixture', () => {
+    it('should have a component instance', () => {
+      expect(component).toBeTruthy();
+    });
+  });
+});

--- a/projects/ngx-datatable/src/lib/components/body/ghost-loader/ghost-loader.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/ghost-loader/ghost-loader.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  selector: `ghost-loader`,
+  templateUrl: `./ghost-loader.component.html`,
+  styleUrls: [`./ghost-loader.component.scss`],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DataTableGhostLoaderComponent {
+  @Input() columns;
+  @Input() pageSize;
+  @Input() rowHeight;
+  @Input() ghostBodyHeight;
+}

--- a/projects/ngx-datatable/src/lib/components/columns/column-ghost-cell.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/column-ghost-cell.directive.ts
@@ -1,0 +1,6 @@
+import { Directive, TemplateRef } from '@angular/core';
+
+@Directive({ selector: '[ngx-datatable-ghost-cell-template]' })
+export class DataTableColumnGhostCellDirective {
+  constructor(public template: TemplateRef<any>) {}
+}

--- a/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
@@ -4,6 +4,7 @@ import { DataTableColumnCellDirective } from './column-cell.directive';
 import { DataTableColumnCellTreeToggle } from './tree.directive';
 import { ColumnChangesService } from '../../services/column-changes.service';
 import { TableColumnProp } from '../../types/table-column.type';
+import { DataTableColumnGhostCellDirective } from './column-ghost-cell.directive';
 
 @Directive({ selector: 'ngx-datatable-column' })
 export class DataTableColumnDirective implements OnChanges {
@@ -58,6 +59,16 @@ export class DataTableColumnDirective implements OnChanges {
 
   get treeToggleTemplate(): TemplateRef<any> {
     return this._treeToggleTemplateInput || this._treeToggleTemplateQuery;
+  }
+
+  @Input('ghostCellTemplate')
+    _ghostCellTemplateInput: TemplateRef<any>;
+
+  @ContentChild(DataTableColumnGhostCellDirective, { read: TemplateRef, static: true })
+    _ghostCellTemplateQuery: TemplateRef<any>;
+
+  get ghostCellTemplate(): TemplateRef<any> {
+    return this._ghostCellTemplateInput || this._ghostCellTemplateQuery;
   }
 
   private isFirstChange = true;

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -36,6 +36,7 @@
     [scrollbarH]="scrollbarH"
     [virtualization]="virtualization"
     [loadingIndicator]="loadingIndicator"
+    [ghostLoadingIndicator]="ghostLoadingIndicator"
     [externalPaging]="externalPaging"
     [rowHeight]="rowHeight"
     [rowCount]="rowCount"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.scss
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.scss
@@ -216,6 +216,7 @@
     position: relative;
     z-index: 10;
     display: block;
+    overflow: hidden;
 
     .datatable-scroll {
       display: inline-block;

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -266,6 +266,21 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
   @Input() loadingIndicator = false;
 
   /**
+   * Show ghost loaders on each cell.
+   * Default value: `false`
+   */
+  @Input() set ghostLoadingIndicator(val: boolean) {
+    this._ghostLoadingIndicator = val;
+    if (val && this.scrollbarV && !this.externalPaging) {
+      // in case where we don't have predefined total page length
+      this.rows = [...this.rows, undefined]; // undefined row will render ghost cell row at the end of the page
+    }
+  };
+  get ghostLoadingIndicator(): boolean {
+    return this._ghostLoadingIndicator;
+  }
+
+  /**
    * Type of row selection. Options are:
    *
    *  - `single`
@@ -638,6 +653,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
   _columns: TableColumn[];
   _columnTemplates: QueryList<DataTableColumnDirective>;
   _subscriptions: Subscription[] = [];
+  _ghostLoadingIndicator = false;
 
   constructor(
     @SkipSelf() private scrollbarHelper: ScrollbarHelper,

--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -27,10 +27,12 @@ import { DataTableBodyCellComponent } from './components/body/body-cell.componen
 import { DataTableSelectionComponent } from './components/body/selection.component';
 import { DataTableColumnHeaderDirective } from './components/columns/column-header.directive';
 import { DataTableColumnCellDirective } from './components/columns/column-cell.directive';
+import { DataTableColumnGhostCellDirective } from './components/columns/column-ghost-cell.directive';
 import { DataTableColumnCellTreeToggle } from './components/columns/tree.directive';
 import { DatatableFooterDirective } from './components/footer/footer.directive';
 import { DatatableGroupHeaderTemplateDirective } from './components/body/body-group-header-template.directive';
 import { DataTableSummaryRowComponent } from './components/body/summary/summary-row.component';
+import { DataTableGhostLoaderComponent } from './components/body/ghost-loader/ghost-loader.component';
 
 @NgModule({
   imports: [CommonModule],
@@ -60,10 +62,12 @@ import { DataTableSummaryRowComponent } from './components/body/summary/summary-
     DataTableSelectionComponent,
     DataTableColumnHeaderDirective,
     DataTableColumnCellDirective,
+    DataTableColumnGhostCellDirective,
     DataTableColumnCellTreeToggle,
     DatatableFooterDirective,
     DatatableGroupHeaderTemplateDirective,
-    DataTableSummaryRowComponent
+    DataTableSummaryRowComponent,
+    DataTableGhostLoaderComponent
   ],
   exports: [
     DatatableComponent,
@@ -73,6 +77,7 @@ import { DataTableSummaryRowComponent } from './components/body/summary/summary-
     DataTableColumnDirective,
     DataTableColumnHeaderDirective,
     DataTableColumnCellDirective,
+    DataTableColumnGhostCellDirective,
     DataTableColumnCellTreeToggle,
     DataTableFooterTemplateDirective,
     DatatableFooterDirective,

--- a/projects/ngx-datatable/src/lib/themes/_ghost.scss
+++ b/projects/ngx-datatable/src/lib/themes/_ghost.scss
@@ -1,0 +1,16 @@
+$datatable-ghost-cell-container-background: #fff !default;
+$datatable-ghost-cell-strip-background: #dee2e5 !default;
+$datatable-ghost-cell-strip-background-image: linear-gradient(to right, #dee2e5 0%, #dee2e5 10%, #f0f2f5, transparent) !default;
+$datatable-ghost-cell-strip-radius: 4px !default;
+$datatble-ghost-cell-animation-duration: 10s;
+
+.ghost-cell-container {
+  background: $datatable-ghost-cell-container-background;
+}
+
+.ghost-cell-strip {
+  background: $datatable-ghost-cell-strip-background;
+  background-image: $datatable-ghost-cell-strip-background-image;
+  border-radius: $datatable-ghost-cell-strip-radius;
+  animation-duration: $datatble-ghost-cell-animation-duration;
+}

--- a/projects/ngx-datatable/src/lib/themes/bootstrap.scss
+++ b/projects/ngx-datatable/src/lib/themes/bootstrap.scss
@@ -1,6 +1,11 @@
-/*
-bootstrap table theme
-*/
+$datatable-ghost-cell-container-background: #fff !default;
+
+$datatable-ghost-cell-strip-background: #dee2e5 !default;
+$datatable-ghost-cell-strip-background-image: linear-gradient(to right, $datatable-ghost-cell-strip-background 0%, $datatable-ghost-cell-strip-background 10%, #fff, transparent) !default;
+$datatable-ghost-cell-strip-radius: 0 !default;
+$datatble-ghost-cell-animation-duration: 10s;
+
+@import './ghost';
 
 .ngx-datatable.bootstrap {
   box-shadow: none;

--- a/projects/ngx-datatable/src/lib/themes/material.scss
+++ b/projects/ngx-datatable/src/lib/themes/material.scss
@@ -66,6 +66,14 @@ $datatable-pager-active-background: rgba(158, 158, 158, 0.2) !default;
 $datatable-summary-row-background: #ddd !default;
 $datatable-summary-row-background-hover: #ddd !default;
 
+$datatable-ghost-cell-container-background: $ngx-datatable-background !default;
+$datatable-ghost-cell-strip-background: #d9d8d9 !default;
+$datatable-ghost-cell-strip-background-image: linear-gradient(to right, $datatable-ghost-cell-strip-background 0%, $datatable-ghost-cell-strip-background 10%, $ngx-datatable-background, transparent) !default;
+$datatable-ghost-cell-strip-radius: 0 !default;
+$datatble-ghost-cell-animation-duration: 10s;
+
+@import './ghost';
+
 .ngx-datatable.material {
   background: $ngx-datatable-background;
   box-shadow: $ngx-datatable-box-shadow;

--- a/projects/ngx-datatable/src/lib/types/table-column.type.ts
+++ b/projects/ngx-datatable/src/lib/types/table-column.type.ts
@@ -153,6 +153,13 @@ export interface TableColumn {
   cellTemplate?: any;
 
   /**
+   * Ghost Cell template ref
+   *
+   * @memberOf TableColumn
+   */
+  ghostCellTemplate?: any;
+
+  /**
    * Header template ref
    *
    * @memberOf TableColumn

--- a/projects/ngx-datatable/src/lib/utils/column-helper.ts
+++ b/projects/ngx-datatable/src/lib/utils/column-helper.ts
@@ -100,6 +100,10 @@ export function translateTemplates(templates: DataTableColumnDirective[]): any[]
       col.cellTemplate = temp.cellTemplate;
     }
 
+    if (temp.ghostCellTemplate) {
+      col.ghostCellTemplate = temp.ghostCellTemplate;
+    }
+
     if (temp.summaryFunc) {
       col.summaryFunc = temp.summaryFunc;
     }

--- a/projects/ngx-datatable/src/public-api.ts
+++ b/projects/ngx-datatable/src/public-api.ts
@@ -24,6 +24,7 @@ export * from './lib/components/footer/footer-template.directive';
 export * from './lib/components/columns/column.directive';
 export * from './lib/components/columns/column-header.directive';
 export * from './lib/components/columns/column-cell.directive';
+export * from './lib/components/columns/column-ghost-cell.directive';
 export * from './lib/components/columns/tree.directive';
 export * from './lib/components/row-detail/row-detail.directive';
 export * from './lib/components/row-detail/row-detail-template.directive';

--- a/src/app/paging/paging-virtual.component.ts
+++ b/src/app/paging/paging-virtual.component.ts
@@ -39,6 +39,7 @@ interface PageInfo {
         [columnMode]="ColumnMode.force"
         [headerHeight]="50"
         [loadingIndicator]="isLoading > 0"
+        [ghostLoadingIndicator]="isLoading > 0"
         [scrollbarV]="true"
         [footerHeight]="50"
         [rowHeight]="50"

--- a/src/app/paging/scrolling-server.component.ts
+++ b/src/app/paging/scrolling-server.component.ts
@@ -48,6 +48,7 @@ export class MockServerResultsService {
         [headerHeight]="headerHeight"
         [rowHeight]="rowHeight"
         [loadingIndicator]="isLoading"
+        [ghostLoadingIndicator]="isLoading"
         [scrollbarV]="true"
         (scroll)="onScroll($event.offsetY)"
       ></ngx-datatable>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Today, datatable with pagination on server side doesn't have ghost loaders to indicate data is being loaded.

**What is the new behavior?**
This PR adds option to enable ghost loader which can be used to indicate data is being loaded from server while doing pagination

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

https://user-images.githubusercontent.com/3906709/153598878-93bf579e-2dc0-4389-bfae-9389cd22e762.mov



