### PR TITLE
fix(ngx-datatable): hide ghost cells based on ghosLoadingIndicator flag

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -65,7 +65,7 @@ export type TreeStatus = 'collapsed' | 'expanded' | 'loading' | 'disabled';
     </div>
   </ng-container>
   <ng-template #ghostLoaderTemplate>
-    <ghost-loader [columns]="[column]" [pageSize]="1"></ghost-loader>
+    <ghost-loader *ngIf="ghostLoadingIndicator" [columns]="[column]" [pageSize]="1"></ghost-loader>
   </ng-template>
   `
 })
@@ -170,6 +170,8 @@ export class DataTableBodyCellComponent implements DoCheck, OnDestroy {
   get treeStatus(): TreeStatus {
     return this._treeStatus;
   }
+
+  @Input() ghostLoadingIndicator = false;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
 

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -42,6 +42,7 @@ import { translateXY } from '../../utils/translate';
         [rowHeight]="rowHeight"
         [displayCheck]="displayCheck"
         [treeStatus]="treeStatus"
+        [ghostLoadingIndicator]="ghostLoadingIndicator"
         (activate)="onActivate($event, ii)"
         (treeAction)="onTreeAction()"
       >
@@ -83,6 +84,7 @@ export class DataTableBodyRowComponent implements DoCheck {
   @Input() rowIndex: number;
   @Input() displayCheck: any;
   @Input() treeStatus: TreeStatus = 'collapsed';
+  @Input() ghostLoadingIndicator = false;
 
   @Input()
   set offsetX(val: number) {

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -93,6 +93,7 @@ import { translateXY } from '../../utils/translate';
             [rowClass]="rowClass"
             [displayCheck]="displayCheck"
             [treeStatus]="group && group.treeStatus"
+            [ghostLoadingIndicator]="ghostLoadingIndicator"
             (treeAction)="onTreeAction(group)"
             (activate)="selector.onActivate($event, indexes.first + i)"
           >
@@ -112,6 +113,7 @@ import { translateXY } from '../../utils/translate';
               [rowIndex]="getRowIndex(row)"
               [expanded]="getRowExpanded(row)"
               [rowClass]="rowClass"
+              [ghostLoadingIndicator]="ghostLoadingIndicator"
               (activate)="selector.onActivate($event, i)"
             >
             </datatable-body-row>
@@ -498,7 +500,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
           // add indexes for each row
           this.rowIndexes.set(row, rowIndex);
           temp[idx] = row;
-        } else if (this.virtualization) {
+        } else if (this.ghostLoadingIndicator && this.virtualization) {
           temp[idx] = undefined;
         }
 


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Ghost cells shows up by default when data is loading
**What is the new behavior?**
Ghost cells appear only if ghostLoadingIndicator is true

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
