### PR TITLE
fix(scaleColumns): adjust for overflow when scaling columns in flex mode

### DIFF
--- a/projects/ngx-datatable/src/lib/utils/math.spec.ts
+++ b/projects/ngx-datatable/src/lib/utils/math.spec.ts
@@ -1,4 +1,4 @@
-import { forceFillColumnWidths } from './math';
+import { adjustColumnWidths, forceFillColumnWidths } from './math';
 
 describe('Math function', () => {
   describe('forceFillColumnWidths', () => {
@@ -31,6 +31,29 @@ describe('Math function', () => {
         expect(columns[0].width).toBe(250); // Not changed
         expect(columns[1].width).toBe(180);
         expect(columns[2].width).toBe(320);
+      });
+    });
+  });
+
+  describe('adjustColumnWidths', () => {
+    describe('flex mode', () => {
+      it('should not go overflow/underflow compared to given max width', () => {
+        const cols = {
+          center: [
+            { prop: 'id1', width: 287, maxWidth: undefined, minWidth: 175, flexGrow: 2, canAutoResize: true },
+            { prop: 'id2', width: 215, maxWidth: undefined, minWidth: 200, flexGrow: 1.5, canAutoResize: true },
+            { prop: 'id3', width: 287, maxWidth: undefined, minWidth: 150, flexGrow: 2, canAutoResize: true },
+            { prop: 'id4', width: 175, maxWidth: undefined, minWidth: 175, flexGrow: 1, canAutoResize: true },
+            { prop: 'id5', width: 143, maxWidth: undefined, minWidth: 120, flexGrow: 1, canAutoResize: true }
+          ]
+        };
+
+        const givenTableWidth = 1180;
+
+        adjustColumnWidths(cols.center, givenTableWidth);
+
+        const totalAdjustedColumnWidths = cols.center.map(c => c.width).reduce((p, c) => p + c, 0)
+        expect(totalAdjustedColumnWidths).toBeCloseTo(givenTableWidth, 0.001);
       });
     });
   });

--- a/projects/ngx-datatable/src/lib/utils/math.spec.ts
+++ b/projects/ngx-datatable/src/lib/utils/math.spec.ts
@@ -38,21 +38,19 @@ describe('Math function', () => {
   describe('adjustColumnWidths', () => {
     describe('flex mode', () => {
       it('should not go overflow/underflow compared to given max width', () => {
-        const cols = {
-          center: [
-            { prop: 'id1', width: 287, maxWidth: undefined, minWidth: 175, flexGrow: 2, canAutoResize: true },
-            { prop: 'id2', width: 215, maxWidth: undefined, minWidth: 200, flexGrow: 1.5, canAutoResize: true },
-            { prop: 'id3', width: 287, maxWidth: undefined, minWidth: 150, flexGrow: 2, canAutoResize: true },
-            { prop: 'id4', width: 175, maxWidth: undefined, minWidth: 175, flexGrow: 1, canAutoResize: true },
-            { prop: 'id5', width: 143, maxWidth: undefined, minWidth: 120, flexGrow: 1, canAutoResize: true }
-          ]
-        };
+        const cols = [
+          { prop: 'id1', width: 287, maxWidth: undefined, minWidth: 175, flexGrow: 2, canAutoResize: true },
+          { prop: 'id2', width: 215, maxWidth: undefined, minWidth: 200, flexGrow: 1.5, canAutoResize: true },
+          { prop: 'id3', width: 287, maxWidth: undefined, minWidth: 150, flexGrow: 2, canAutoResize: true },
+          { prop: 'id4', width: 175, maxWidth: undefined, minWidth: 175, flexGrow: 1, canAutoResize: true },
+          { prop: 'id5', width: 143, maxWidth: undefined, minWidth: 120, flexGrow: 1, canAutoResize: true }
+        ];
 
         const givenTableWidth = 1180;
 
-        adjustColumnWidths(cols.center, givenTableWidth);
+        adjustColumnWidths(cols, givenTableWidth);
 
-        const totalAdjustedColumnWidths = cols.center.map(c => c.width).reduce((p, c) => p + c, 0)
+        const totalAdjustedColumnWidths = cols.map(c => c.width).reduce((p, c) => p + c, 0);
         expect(totalAdjustedColumnWidths).toBeCloseTo(givenTableWidth, 0.001);
       });
     });

--- a/projects/ngx-datatable/src/lib/utils/math.spec.ts
+++ b/projects/ngx-datatable/src/lib/utils/math.spec.ts
@@ -37,7 +37,7 @@ describe('Math function', () => {
 
   describe('adjustColumnWidths', () => {
     describe('flex mode', () => {
-      it('should not go overflow/underflow compared to given max width', () => {
+      it('should not go over/under compared to given max width', () => {
         const cols = [
           { prop: 'id1', width: 287, maxWidth: undefined, minWidth: 175, flexGrow: 2, canAutoResize: true },
           { prop: 'id2', width: 215, maxWidth: undefined, minWidth: 200, flexGrow: 1.5, canAutoResize: true },
@@ -52,6 +52,32 @@ describe('Math function', () => {
 
         const totalAdjustedColumnWidths = cols.map(c => c.width).reduce((p, c) => p + c, 0);
         expect(totalAdjustedColumnWidths).toBeCloseTo(givenTableWidth, 0.001);
+      });
+
+      it('should overflow if the total of given min widths is bigger than given max width', () => {
+        const cols = [
+          { prop: 'id1', width: 100, maxWidth: undefined, minWidth: 100, flexGrow: 1, canAutoResize: true },
+          { prop: 'id2', width: 100, maxWidth: undefined, minWidth: 100, flexGrow: 1, canAutoResize: true }
+        ];
+        const maxWidth = 199;
+
+        adjustColumnWidths(cols, maxWidth);
+
+        const totalAdjustedColumnWidths = cols.map(c => c.width).reduce((p, c) => p + c, 0);
+        expect(totalAdjustedColumnWidths).toBeGreaterThan(maxWidth);
+      });
+
+      it('should respect min widths', () => {
+        const cols = [
+          { prop: 'id1', width: 0, maxWidth: undefined, minWidth: 10, flexGrow: 3.0000000000000075, canAutoResize: true },
+          { prop: 'id2', width: 0, maxWidth: undefined, minWidth: 10, flexGrow: 1, canAutoResize: true }
+        ];
+
+        adjustColumnWidths(cols, 40);
+
+        for (const col of cols) {
+          expect(col.width - col.minWidth).toBeGreaterThanOrEqual(0);
+        }
       });
     });
   });

--- a/projects/ngx-datatable/src/lib/utils/math.ts
+++ b/projects/ngx-datatable/src/lib/utils/math.ts
@@ -89,13 +89,15 @@ function scaleColumns(colsByGroup: any, maxWidth: any, totalFlexGrow: any) {
         totalWidthAchieved += column.width;
 
         if (column.width > biggestColumnRef.width) {
-          biggestColumnRef.ref = column
+          biggestColumnRef.ref = column;
         }
       }
     }
   }
-  const remainingDelta = maxWidth - totalWidthAchieved;
-  biggestColumnRef.ref.width += remainingDelta;
+
+  if (biggestColumnRef.ref) {
+    biggestColumnRef.ref.width += maxWidth - totalWidthAchieved;
+  }
 }
 
 /**

--- a/projects/ngx-datatable/src/lib/utils/math.ts
+++ b/projects/ngx-datatable/src/lib/utils/math.ts
@@ -31,9 +31,9 @@ export function adjustColumnWidths(allColumns: any, expectedWidth: any) {
  * Resizes columns based on the flexGrow property, while respecting manually set widths
  */
 function scaleColumns(colsByGroup: any, maxWidth: any, totalFlexGrow: any) {
-  // calculate total width and flexgrow points for coulumns that can be resized
+  // calculate total width and flexgrow points for columns that can be resized
   for (const attr in colsByGroup) {
-    if (colsByGroup.hasOwnProperty(attr)){
+    if (colsByGroup.hasOwnProperty(attr)) {
       for (const column of colsByGroup[attr]) {
         if (column.$$oldWidth) {
           // when manually resized, switch off auto-resize
@@ -58,9 +58,9 @@ function scaleColumns(colsByGroup: any, maxWidth: any, totalFlexGrow: any) {
     remainingWidth = 0;
 
     for (const attr in colsByGroup) {
-      if (colsByGroup.hasOwnProperty(attr)){
+      if (colsByGroup.hasOwnProperty(attr)) {
         for (const column of colsByGroup[attr]) {
-        // if the column can be resize and it hasn't reached its minimum width yet
+          // if the column can be resize and it hasn't reached its minimum width yet
           if (column.canAutoResize && !hasMinWidth[column.prop]) {
             const newWidth = column.width + column.flexGrow * widthPerFlexPoint;
             if (column.minWidth !== undefined && newWidth < column.minWidth) {
@@ -75,6 +75,27 @@ function scaleColumns(colsByGroup: any, maxWidth: any, totalFlexGrow: any) {
       }
     }
   } while (remainingWidth !== 0);
+
+  // Adjust for any remaining offset in computed widths vs maxWidth by tweaking the biggest column
+  let totalWidthAchieved = 0;
+  const biggestColumnRef = {
+    width: 0,
+    ref: null
+  };
+
+  for (const attr in colsByGroup) {
+    if (colsByGroup.hasOwnProperty(attr)) {
+      for (const column of colsByGroup[attr]) {
+        totalWidthAchieved += column.width;
+
+        if (column.width > biggestColumnRef.width) {
+          biggestColumnRef.ref = column
+        }
+      }
+    }
+  }
+  const remainingDelta = maxWidth - totalWidthAchieved;
+  biggestColumnRef.ref.width += remainingDelta;
 }
 
 /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

For some inputs the function scaleColumns(colsByGroup: any, maxWidth: any, totalFlexGrow: any) in utils/math.ts returns a set of column with total width exceeding that of the maxWidth argument.

This seems to be the reason for a horizontal scrollbar on large screens where space is more than enough.

**What is the new behavior?**

After auto-caling the columns in flex mode, a correction is made based on the outstanding overflow/underflow by adding/removing the delta from the biggest column.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
