### PR TITLE
feat: support keyboard shortcuts for all rows selection

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -229,7 +229,9 @@ export class DataTableBodyRowComponent implements DoCheck {
       keyCode === Keys.left ||
       keyCode === Keys.right;
 
-    if (isAction && isTargetRow) {
+    const isCtrlA = event.key === 'a' && (event.ctrlKey || event.metaKey);
+
+    if ((isAction && isTargetRow) || isCtrlA) {
       event.preventDefault();
       event.stopPropagation();
 

--- a/projects/ngx-datatable/src/lib/components/body/selection.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/selection.component.ts
@@ -42,6 +42,9 @@ export class DataTableSelectionComponent {
     if (multi || chkbox || multiClick) {
       if (event.shiftKey) {
         selected = selectRowsBetween([], this.rows, index, this.prevIndex, this.getRowSelectedIdx.bind(this));
+      } else if ((event as KeyboardEvent).key === 'a' && (event.ctrlKey || event.metaKey)) {
+        // select all rows except dummy rows which are added for ghostloader in case of virtual scroll
+        selected = this.rows.filter(rowItem => !!rowItem);
       } else if (event.ctrlKey || event.metaKey || multiClick || chkbox) {
         selected = selectRows([...this.selected], row, this.getRowSelectedIdx.bind(this));
       } else {
@@ -79,6 +82,8 @@ export class DataTableSelectionComponent {
     } else if (type === 'keydown') {
       if ((event as KeyboardEvent).keyCode === Keys.return) {
         this.selectRow(event, index, row);
+      } else if ((event as KeyboardEvent).key === 'a' && (event.ctrlKey || event.metaKey)) {
+        this.selectRow(event, 0, this.rows[this.rows.length - 1]);
       } else {
         this.onKeyboardFocus(model);
       }


### PR DESCRIPTION
Allows user to select all rows with keyboard `meta+a` or `ctrl+a`. This only selects rows which are currently available to the datatable and will not select rows which get loaded from server in future by user actions like scrolling/paging

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently there is no effect when user press ctrl + A or meta + A on mac.

**What is the new behavior?**
When focus inside table on row and user presses ctrl+A or meta + A, all available rows will be selected and selection event will be emitted.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
