### PR TITLE
fix: page not emitted when columns are sorted

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -1163,6 +1163,13 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
     // Always go to first page when sorting to see the newly sorted data
     this.offset = 0;
     this.bodyComponent.updateOffsetY(this.offset);
+    // Emit the page object with updated offset value
+    this.page.emit({
+      count: this.count,
+      pageSize: this.pageSize,
+      limit: this.limit,
+      offset: this.offset
+    });
     this.sort.emit(event);
   }
 


### PR DESCRIPTION
Allows to keep external pagination components to be in sync with current page value.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here) 
external pagination component will not update the page number when user sort the columns

**What is the new behavior?**
external pagination component's page number stays in sync with the datatable offset value.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
