### PR TITLE
[b] Prefer unprefixed style attribute over prefixed one

### DIFF
--- a/projects/ngx-datatable/src/lib/utils/prefixes.ts
+++ b/projects/ngx-datatable/src/lib/utils/prefixes.ts
@@ -31,10 +31,10 @@ export function getVendorPrefixedName(property: string) {
   const name = camelCase(property);
 
   if (!cache[name]) {
-    if (prefix !== undefined && testStyle[prefix.css + property] !== undefined) {
-      cache[name] = prefix.css + property;
-    } else if (testStyle[property] !== undefined) {
+    if (testStyle[property] !== undefined) {
       cache[name] = property;
+    } else if (prefix !== undefined && testStyle[prefix.css + property] !== undefined) {
+      cache[name] = prefix.css + property;
     }
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

This is to fix an issue on Firefox 126 (released May 2024), which no longer support `-moz-transform` but `transform`. But when we get style attributes from an element, `-moz-transform` is still available, which makes our `testStyle` fails. So to resolve this issue, we want to use unprefixed attribute if available.

The issue happens if we use `virtualization`, screenshot below:
<img width="976" alt="image" src="https://github.com/siemens/ngx-datatable/assets/3904511/d24ae13f-d65b-4ae5-bc4c-0cb6891650a9">


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
