### PR TITLE
fix(row-grouping): sorting with grouped rows

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -47,7 +47,7 @@ import { ColumnChangesService } from '../services/column-changes.service';
 import { DimensionsHelper } from '../services/dimensions-helper.service';
 import { throttleable } from '../utils/throttle';
 import { adjustColumnWidths, forceFillColumnWidths } from '../utils/math';
-import { sortRows } from '../utils/sort';
+import { sortGroupedRows, sortRows } from '../utils/sort';
 
 @Component({
   selector: 'ngx-datatable',
@@ -1248,6 +1248,13 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
   }
 
   private sortInternalRows(): void {
-    this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts);
+    if (this.groupedRows && this.groupedRows.length) {
+      const sortOnGroupHeader = this.sorts?.find(sortColumns => sortColumns.prop === this._groupRowsBy);
+      this.groupedRows = this.groupArrayBy(this._rows, this._groupRowsBy);
+      this.groupedRows = sortGroupedRows(this.groupedRows, this._internalColumns, this.sorts, sortOnGroupHeader);
+      this._internalRows = [...this._internalRows];
+    } else {
+      this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts);
+    }
   }
 }

--- a/projects/ngx-datatable/src/lib/utils/sort.ts
+++ b/projects/ngx-datatable/src/lib/utils/sort.ts
@@ -119,3 +119,13 @@ export function sortRows(rows: any[], columns: any[], dirs: SortPropDir[]): any[
     return rowToIndexMap.get(rowA) < rowToIndexMap.get(rowB) ? -1 : 1;
   });
 }
+
+export function sortGroupedRows(groupedRows: any[], columns: any[], dirs: SortPropDir[], sortOnGroupHeader: SortPropDir): any[] {
+  if (sortOnGroupHeader) {
+    groupedRows = sortRows(groupedRows, columns, [{
+      dir: sortOnGroupHeader.dir,
+      prop: 'key'
+    }]);
+  }
+  return groupedRows.map(group => ({ ...group, value: sortRows(group.value, columns, dirs) }));
+}

--- a/src/app/basic/row-grouping.component.ts
+++ b/src/app/basic/row-grouping.component.ts
@@ -1,5 +1,4 @@
-import { Component, ViewChild, ViewEncapsulation } from '@angular/core';
-import { NgStyle } from '@angular/common';
+import { Component, ViewChild } from '@angular/core';
 import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
 
 @Component({
@@ -48,7 +47,7 @@ import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
         </ngx-datatable-group-header>
 
         <!-- Row Column Template -->
-        <ngx-datatable-column name="Exp. Pay." prop="" editable="true" frozenLeft="True">
+        <ngx-datatable-column name="Exp. Pay." prop="" editable="true" frozenLeft="True" [sortable]="false">
           <ng-template
             ngx-datatable-cell-template
             let-rowIndex="rowIndex"
@@ -259,8 +258,9 @@ export class RowGroupingComponent {
   }
 
   updateValue(event, cell, rowIndex) {
+    const index = rowIndex.split('-')[1];
     this.editing[rowIndex + '-' + cell] = false;
-    this.rows[rowIndex][cell] = event.target.value;
+    this.rows[index][cell] = event.target.value;
     this.rows = [...this.rows];
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Internal sorting doesn't work when row grouping feature is used with datatable.

**What is the new behavior?**
If the sort column is used as group then groups are sorted otherwise rows within each group is sorted within that group

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
