### PR TITLE
feat(rows): wrapper for pre applying directives

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,8 @@
   - Row Detail
     - [Inputs](api/detail/inputs.md)
     - [Outputs](api/detail/outputs.md)
+  - Row
+    - [Custom row wrapper](api/row/row-def.md)
 - Demos
   - [Online](http://siemens.github.io/ngx-datatable/)
   - [Source Code](https://github.com/siemens/ngx-datatable/tree/master/src/app)

--- a/docs/api/row/row-def.md
+++ b/docs/api/row/row-def.md
@@ -1,0 +1,20 @@
+# Custom row wrapper
+
+Use to pre-apply directives at row level.
+
+### `rowDef`
+
+Directive to be applied on `ng-template`.
+
+### `datatable-row-def`
+
+Component to be used as content of `ng-template`.
+Apply your custom row level directive/class on this component. Example:
+
+**Template**
+
+```html
+  <ng-template rowDef>
+    <datatable-row-def applyYourCustomDirectiveHereForRow />
+  </ng-template>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "~17.0.6",
+        "@angular/cdk": "~17.3.0",
         "@angular/common": "~17.0.6",
         "@angular/compiler": "~17.0.6",
         "@angular/core": "~17.0.6",
@@ -853,6 +854,22 @@
       },
       "peerDependencies": {
         "@angular/core": "17.0.6"
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "17.3.10",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.3.10.tgz",
+      "integrity": "sha512-b1qktT2c1TTTe5nTji/kFAVW92fULK0YhYAvJ+BjZTPKu2FniZNe8o4qqQ0pUuvtMu+ZQxp/QqFYoidIVCjScg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^17.0.0 || ^18.0.0",
+        "@angular/core": "^17.0.0 || ^18.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -8985,7 +9002,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -15945,6 +15962,18 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "devOptional": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parse5-html-rewriting-stream": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-html-rewriting-stream/-/parse5-html-rewriting-stream-7.0.0.tgz",
@@ -15959,18 +15988,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5-html-rewriting-stream/node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/parse5-sax-parser": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-sax-parser/-/parse5-sax-parser-7.0.0.tgz",
@@ -15978,18 +15995,6 @@
       "dev": true,
       "dependencies": {
         "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-sax-parser/node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
-      "dependencies": {
-        "entities": "^4.4.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -21346,6 +21351,15 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.0.6.tgz",
       "integrity": "sha512-fic61LjLHry79c5H9UGM8Ff311MJnf9an7EukLj2aLJ3J0uadL/H9de7dDp8PaIT10DX9g+aRTIKOmF3PmmXIQ==",
       "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@angular/cdk": {
+      "version": "17.3.10",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.3.10.tgz",
+      "integrity": "sha512-b1qktT2c1TTTe5nTji/kFAVW92fULK0YhYAvJ+BjZTPKu2FniZNe8o4qqQ0pUuvtMu+ZQxp/QqFYoidIVCjScg==",
+      "requires": {
+        "parse5": "^7.1.2",
         "tslib": "^2.3.0"
       }
     },
@@ -27191,7 +27205,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true
+      "devOptional": true
     },
     "env-paths": {
       "version": "2.2.1",
@@ -32316,6 +32330,15 @@
       "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
       "dev": true
     },
+    "parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "devOptional": true,
+      "requires": {
+        "entities": "^4.4.0"
+      }
+    },
     "parse5-html-rewriting-stream": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse5-html-rewriting-stream/-/parse5-html-rewriting-stream-7.0.0.tgz",
@@ -32325,17 +32348,6 @@
         "entities": "^4.3.0",
         "parse5": "^7.0.0",
         "parse5-sax-parser": "^7.0.0"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-          "dev": true,
-          "requires": {
-            "entities": "^4.4.0"
-          }
-        }
       }
     },
     "parse5-sax-parser": {
@@ -32345,17 +32357,6 @@
       "dev": true,
       "requires": {
         "parse5": "^7.0.0"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-          "dev": true,
-          "requires": {
-            "entities": "^4.4.0"
-          }
-        }
       }
     },
     "parseurl": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "~17.0.6",
+    "@angular/cdk": "~17.3.0",
     "@angular/common": "~17.0.6",
     "@angular/compiler": "~17.0.6",
     "@angular/core": "~17.0.6",

--- a/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
@@ -10,6 +10,11 @@ import {
   ViewContainerRef
 } from '@angular/core';
 
+/**
+ * This component is passed as ng-template and rendered by BodyComponent.
+ * BodyComponent uses rowDefInternal to first inject actual row template.
+ * This component will render that actual row template.
+ */
 @Component({
   selector: 'datatable-row-def',
   template: `<ng-container
@@ -43,7 +48,7 @@ export class DatatableRowDefDirective {
 export class DatatableRowDefInternalDirective implements OnInit {
   vc = inject(ViewContainerRef);
 
-  @Input() rowDefInternal!: RowDefContext;
+  @Input() rowDefInternal?: RowDefContext;
 
   ngOnInit(): void {
     this.vc.createEmbeddedView(

--- a/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
@@ -1,0 +1,75 @@
+import {
+  Component,
+  Directive,
+  inject,
+  InjectionToken,
+  Injector,
+  Input,
+  OnInit,
+  TemplateRef,
+  ViewContainerRef
+} from '@angular/core';
+
+@Component({
+  selector: 'datatable-row-def',
+  template: `<ng-container
+    *ngIf="rowDef.rowDefInternal.rowTemplate"
+    [ngTemplateOutlet]="rowDef.rowDefInternal.rowTemplate"
+    [ngTemplateOutletContext]="rowDef"
+  />`
+})
+export class DatatableRowDefComponent {
+  rowDef = inject(RowDefToken);
+}
+
+@Directive({
+  selector: '[rowDef]'
+})
+export class DatatableRowDefDirective {
+  static ngTemplateContextGuard(
+    _dir: DatatableRowDefDirective,
+    ctx: unknown
+  ): ctx is RowDefContext {
+    return true;
+  }
+}
+
+/**
+ * @internal To be used internally by ngx-datatable.
+ */
+@Directive({
+  selector: '[rowDefInternal]'
+})
+export class DatatableRowDefInternalDirective implements OnInit {
+  vc = inject(ViewContainerRef);
+
+  @Input() rowDefInternal!: RowDefContext;
+
+  ngOnInit(): void {
+    this.vc.createEmbeddedView(
+      this.rowDefInternal.template,
+      {
+        ...this.rowDefInternal
+      },
+      {
+        injector: Injector.create({
+          providers: [
+            {
+              provide: RowDefToken,
+              useValue: this
+            }
+          ]
+        })
+      }
+    );
+  }
+}
+const RowDefToken = new InjectionToken<DatatableRowDefInternalDirective>(
+  'RowDef'
+);
+type RowDefContext = {
+  template: TemplateRef<unknown>;
+  rowTemplate: TemplateRef<unknown>;
+  row: any;
+  index: number;
+};

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -198,7 +198,7 @@ import { DragEventData } from '../../types/drag-events.type';
   }
 })
 export class DataTableBodyComponent implements OnInit, OnDestroy {
-  @Input() rowDefTemplate!: TemplateRef<any>;
+  @Input() rowDefTemplate?: TemplateRef<any>;
   @Input() scrollbarV: boolean;
   @Input() scrollbarH: boolean;
   @Input() loadingIndicator: boolean;

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -8,6 +8,7 @@ import {
   OnDestroy,
   OnInit,
   Output,
+  TemplateRef,
   ViewChild
 } from '@angular/core';
 import { ScrollerComponent } from './scroller.component';
@@ -82,36 +83,51 @@ import { DragEventData } from '../../types/drag-events.type';
           [rowIndex]="getRowIndex(group && group[i])"
           (rowContextmenu)="rowContextmenu.emit($event)"
         >
-          <datatable-body-row
-            role="row"
-            *ngIf="!groupedRows; else groupedRowsTemplate"
-            tabindex="-1"
-            #rowElement
-            [disable$]="rowWrapper.disable$"
-            [isSelected]="selector.getRowSelected(group)"
-            [innerWidth]="innerWidth"
-            [offsetX]="offsetX"
-            [columns]="columns"
-            [rowHeight]="getRowHeight(group)"
-            [row]="group"
-            [rowIndex]="getRowIndex(group)"
-            [expanded]="getRowExpanded(group)"
-            [rowClass]="rowClass"
-            [displayCheck]="displayCheck"
-            [treeStatus]="group && group.treeStatus"
-            [ghostLoadingIndicator]="ghostLoadingIndicator"
-            [draggable]="rowDraggable"
-            [verticalScrollVisible]="verticalScrollVisible"
-            (treeAction)="onTreeAction(group)"
-            (activate)="selector.onActivate($event, indexes.first + i)"
-            (drop)="drop($event, group, rowElement)"
-            (dragover)="dragOver($event, group)"
-            (dragenter)="dragEnter($event, group, rowElement)"
-            (dragleave)="dragLeave($event, group, rowElement)"
-            (dragstart)="drag($event, group, rowElement)"
-            (dragend)="dragEnd($event, group)"
-          >
-          </datatable-body-row>
+          <ng-container *ngIf="rowDefTemplate else bodyRow">
+            <ng-container
+              *rowDefInternal="{
+                template: rowDefTemplate,
+                rowTemplate: bodyRow,
+                row: group,
+                index: i
+              }"
+            />
+          </ng-container>
+        
+          <ng-template #bodyRow>
+            <datatable-body-row
+              role="row"
+              *ngIf="!groupedRows; else groupedRowsTemplate"
+              tabindex="-1"
+              #rowElement
+              [disable$]="rowWrapper.disable$"
+              [isSelected]="selector.getRowSelected(group)"
+              [innerWidth]="innerWidth"
+              [offsetX]="offsetX"
+              [columns]="columns"
+              [rowHeight]="getRowHeight(group)"
+              [row]="group"
+              [rowIndex]="getRowIndex(group)"
+              [expanded]="getRowExpanded(group)"
+              [rowClass]="rowClass"
+              [displayCheck]="displayCheck"
+              [treeStatus]="group && group.treeStatus"
+              [ghostLoadingIndicator]="ghostLoadingIndicator"
+              [draggable]="rowDraggable"
+              [verticalScrollVisible]="verticalScrollVisible"
+              (treeAction)="onTreeAction(group)"
+              (activate)="selector.onActivate($event, indexes.first + i)"
+              (drop)="drop($event, group, rowElement)"
+              (dragover)="dragOver($event, group)"
+              (dragenter)="dragEnter($event, group, rowElement)"
+              (dragleave)="dragLeave($event, group, rowElement)"
+              (dragstart)="drag($event, group, rowElement)"
+              (dragend)="dragEnd($event, group)"
+            >
+            </datatable-body-row>
+
+          </ng-template>
+
           <ng-template #groupedRowsTemplate>
             <datatable-body-row
               role="row"
@@ -182,6 +198,7 @@ import { DragEventData } from '../../types/drag-events.type';
   }
 })
 export class DataTableBodyComponent implements OnInit, OnDestroy {
+  @Input() rowDefTemplate!: TemplateRef<any>;
   @Input() scrollbarV: boolean;
   @Input() scrollbarH: boolean;
   @Input() loadingIndicator: boolean;

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -71,6 +71,7 @@
       [disableRowCheck]="disableRowCheck"
       [rowDraggable]="rowDraggable"
       [rowDragEvents]="rowDragEvents"
+      [rowDefTemplate]="rowDefTemplate"
     >
       <ng-content select="[loading-indicator]" ngProjectAs="[loading-indicator]"></ng-content>
       <ng-content select="[empty-content]" ngProjectAs="[empty-content]"></ng-content>

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -21,6 +21,7 @@ import {
   Output,
   QueryList,
   SkipSelf,
+  TemplateRef,
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
@@ -48,6 +49,7 @@ import { DimensionsHelper } from '../services/dimensions-helper.service';
 import { throttleable } from '../utils/throttle';
 import { adjustColumnWidths, forceFillColumnWidths } from '../utils/math';
 import { sortGroupedRows, sortRows } from '../utils/sort';
+import { DatatableRowDefDirective } from './body/body-row-def.component';
 
 @Component({
   selector: 'ngx-datatable',
@@ -654,6 +656,9 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
 
   @ViewChild(DataTableBodyComponent, { read: ElementRef })
   private bodyElement: ElementRef<HTMLElement>;
+  @ContentChild(DatatableRowDefDirective, {
+    read: TemplateRef
+  }) rowDefTemplate!: TemplateRef<any>;
 
   /**
    * Returns if all rows are selected.

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -658,7 +658,7 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
   private bodyElement: ElementRef<HTMLElement>;
   @ContentChild(DatatableRowDefDirective, {
     read: TemplateRef
-  }) rowDefTemplate!: TemplateRef<any>;
+  }) rowDefTemplate?: TemplateRef<any>;
 
   /**
    * Returns if all rows are selected.

--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -91,8 +91,7 @@ import { DatatableRowDefComponent, DatatableRowDefDirective, DatatableRowDefInte
     DatatableGroupHeaderTemplateDirective,
     DisableRowDirective,
     DatatableRowDefComponent,
-    DatatableRowDefDirective,
-    DatatableRowDefInternalDirective
+    DatatableRowDefDirective
   ]
 })
 export class NgxDatatableModule {

--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -34,6 +34,7 @@ import { DatatableGroupHeaderTemplateDirective } from './components/body/body-gr
 import { DataTableSummaryRowComponent } from './components/body/summary/summary-row.component';
 import { DataTableGhostLoaderComponent } from './components/body/ghost-loader/ghost-loader.component';
 import { DisableRowDirective } from './directives/disable-row.directive';
+import { DatatableRowDefComponent, DatatableRowDefDirective, DatatableRowDefInternalDirective } from './components/body/body-row-def.component';
 
 @NgModule({
   imports: [CommonModule],
@@ -69,7 +70,10 @@ import { DisableRowDirective } from './directives/disable-row.directive';
     DatatableGroupHeaderTemplateDirective,
     DataTableSummaryRowComponent,
     DataTableGhostLoaderComponent,
-    DisableRowDirective
+    DisableRowDirective,
+    DatatableRowDefComponent,
+    DatatableRowDefDirective,
+    DatatableRowDefInternalDirective
   ],
   exports: [
     DatatableComponent,
@@ -85,7 +89,10 @@ import { DisableRowDirective } from './directives/disable-row.directive';
     DatatableFooterDirective,
     DataTablePagerComponent,
     DatatableGroupHeaderTemplateDirective,
-    DisableRowDirective
+    DisableRowDirective,
+    DatatableRowDefComponent,
+    DatatableRowDefDirective,
+    DatatableRowDefInternalDirective
   ]
 })
 export class NgxDatatableModule {

--- a/projects/ngx-datatable/src/lib/themes/material.scss
+++ b/projects/ngx-datatable/src/lib/themes/material.scss
@@ -276,6 +276,10 @@ $datatble-ghost-cell-animation-duration: 10s;
       border-top: solid 1px $datatable-group-header-border-top-color;
     }
 
+    datatable-row-def {
+      background-color: $ngx-datatable-background;
+    }
+
     .datatable-body-row {
       border-bottom: 1px solid $datatable-body-row-border-bottom-color;
 

--- a/projects/ngx-datatable/src/public-api.ts
+++ b/projects/ngx-datatable/src/public-api.ts
@@ -28,6 +28,7 @@ export * from './lib/components/columns/column-ghost-cell.directive';
 export * from './lib/components/columns/tree.directive';
 export * from './lib/components/row-detail/row-detail.directive';
 export * from './lib/components/row-detail/row-detail-template.directive';
+export * from './lib/components/body/body-row-def.component';
 
 // directives
 export * from './lib/directives/draggable.directive';

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -49,6 +49,9 @@
           <li>
             <a href="#empty" (click)="state = 'empty'">Empty Template</a>
           </li>
+          <li>
+            <a href="#drag-drop" (click)="state = 'drag-drop'">Drag Drop</a>
+          </li>
         </ul>
       </li>
       <li>
@@ -226,6 +229,7 @@
     <dynamic-height-demo *ngIf="state === 'dynamic'"></dynamic-height-demo>
     <footer-demo *ngIf="state === 'footer'"></footer-demo>
     <empty-demo *ngIf="state === 'empty'"></empty-demo>
+    <drag-drop-demo *ngIf="state === 'drag-drop'"></drag-drop-demo>
     <disabled-rows-demo *ngIf="state === 'disabled'"></disabled-rows-demo>
 
     <!-- Themes -->

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -77,12 +77,15 @@ import { SummaryRowInlineHtmlComponent } from './summary/summary-row-inline-html
 import { AppRoutingModule } from './app-routing.module';
 import { CommonModule } from '@angular/common';
 import { ScollingDynamicallyComponent } from './basic/scrolling-dynamically.component';
+import { DragDropComponent } from './drag-drop/drag-drop.component';
 
+import { DragDropModule } from '@angular/cdk/drag-drop';
 @NgModule({
   declarations: [
     AppComponent,
     BasicAutoComponent,
     BasicFixedComponent,
+    DragDropComponent,
     FullScreenComponent,
     FullScreenTreeComponent,
     InlineEditComponent,
@@ -140,6 +143,7 @@ import { ScollingDynamicallyComponent } from './basic/scrolling-dynamically.comp
     CommonModule,
     BrowserModule,
     AppRoutingModule,
+    DragDropModule,
     NgxDatatableModule.forRoot({
       messages: {
         emptyMessage: 'No data to display', // Message to show when array is presented, but contains no values

--- a/src/app/drag-drop/drag-drop.component.ts
+++ b/src/app/drag-drop/drag-drop.component.ts
@@ -1,0 +1,73 @@
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { Component } from '@angular/core';
+import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+
+@Component({
+  selector: 'drag-drop-demo',
+  template: `
+    <div>
+      <h3>
+        Drag Drop Using Angular CDK
+        <small>
+          <a
+            href="https://github.com/siemens/ngx-datatable/blob/master/src/app/drag-drop/drag-drop.component.ts"
+            target="_blank"
+          >
+            Source
+          </a>
+        </small>
+      </h3>
+      <ngx-datatable
+        class="material"
+        [rows]="rows"
+        [loadingIndicator]="loadingIndicator"
+        [columns]="columns"
+        [columnMode]="ColumnMode.force"
+        [headerHeight]="50"
+        [footerHeight]="50"
+        rowHeight="auto"
+        [reorderable]="reorderable"
+        (cdkDropListDropped)="drop($event)"
+        cdkDropList
+      >
+        <ng-template rowDef>
+          <datatable-row-def cdkDrag [cdkDragPreviewContainer]="'parent'"/>
+        </ng-template>
+      </ngx-datatable>
+    </div>
+  `
+})
+export class DragDropComponent {
+  rows = [];
+  loadingIndicator = true;
+  reorderable = true;
+
+  columns = [{ prop: 'name', sortable: false }, { name: 'Gender', sortable: false }, { name: 'Company', sortable: false }];
+
+  ColumnMode = ColumnMode;
+
+  constructor() {
+    this.fetch(data => {
+      this.rows = data;
+      setTimeout(() => {
+        this.loadingIndicator = false;
+      }, 1500);
+    });
+  }
+
+  fetch(cb) {
+    const req = new XMLHttpRequest();
+    req.open('GET', `assets/data/company.json`);
+
+    req.onload = () => {
+      cb(JSON.parse(req.response));
+    };
+
+    req.send();
+  }
+
+  drop(event: CdkDragDrop<any>) {
+    moveItemInArray(this.rows, event.previousIndex, event.currentIndex);
+    this.rows = [...this.rows];
+  }
+}


### PR DESCRIPTION
Introduced `DatatableRowDefComponent` which can be used by consumers to pre apply certain directives on each row.

Usage:

```html
<ngx-datatable>
  <ng-template rowDef>
    <datatable-row-def cdkDrag />
  </ng-template>
</ngx-datatable>
```

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
