### PR TITLE
fix(rows): expand collapse not working correctly

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -403,38 +403,33 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
    */
   ngOnInit(): void {
     if (this.rowDetail) {
-      this.listener = this.rowDetail.toggle.subscribe(({ type, value }: { type: string; value: any }) => {
-        if (type === 'row') {
-          this.toggleRowExpansion(value);
-        }
-        if (type === 'all') {
-          this.toggleAllRows(value);
-        }
-
-        // Refresh rows after toggle
-        // Fixes #883
-        this.updateIndexes();
-        this.updateRows();
-        this.cd.markForCheck();
-      });
+      this.listener = this.rowDetail.toggle.subscribe(({ type, value }: { type: string; value: any }) =>
+        this.toggleStateChange(type, value)
+      );
     }
 
     if (this.groupHeader) {
       this.listener = this.groupHeader.toggle.subscribe(({ type, value }: { type: string; value: any }) => {
-        if (type === 'group') {
-          this.toggleRowExpansion(value);
-        }
-        if (type === 'all') {
-          this.toggleAllRows(value);
-        }
-
-        // Refresh rows after toggle
-        // Fixes #883
-        this.updateIndexes();
-        this.updateRows();
-        this.cd.markForCheck();
+        // Remove default expansion state once user starts manual toggle.
+        this.groupExpansionDefault = false;
+        this.toggleStateChange(type, value);
       });
     }
+  }
+
+  private toggleStateChange(type: string, value: any) {
+    if (type === 'group' || type === 'row') {
+      this.toggleRowExpansion(value);
+    }
+    if (type === 'all') {
+      this.toggleAllRows(value);
+    }
+
+    // Refresh rows after toggle
+    // Fixes #883
+    this.updateIndexes();
+    this.updateRows();
+    this.cd.markForCheck();
   }
 
   /**
@@ -846,9 +841,9 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
     // Capture the row index of the first row that is visible on the viewport.
     const viewPortFirstRowIndex = this.getAdjustedViewPortIndex();
-
+    const rows = this.groupedRows ?? this.rows;
     if (expanded) {
-      for (const row of this.rows) {
+      for (const row of rows) {
         this.rowExpansions.push(row);
       }
     }
@@ -860,7 +855,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
 
     // Emit all rows that have been expanded.
     this.detailToggle.emit({
-      rows: this.rows,
+      rows: rows,
       currentIndex: viewPortFirstRowIndex
     });
   }


### PR DESCRIPTION
fixes the issue where `collapseAllGroups` and `expandAllGroups` methods don't work in case of grouped rows with `groupExpansionDefault` set to `true`.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
