### PR TITLE
fix(row-group): group header row height

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
@@ -17,7 +17,12 @@ import { BehaviorSubject } from 'rxjs';
   selector: 'datatable-row-wrapper',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div *ngIf="groupHeader && groupHeader.template" class="datatable-group-header" [ngStyle]="getGroupHeaderStyle()">
+    <div
+      *ngIf="groupHeader && groupHeader.template"
+      [style.height.px]="groupHeaderRowHeight"
+      class="datatable-group-header"
+      [ngStyle]="getGroupHeaderStyle()"
+    >
       <ng-template
         *ngIf="groupHeader && groupHeader.template"
         [ngTemplateOutlet]="groupHeader.template"
@@ -50,6 +55,7 @@ export class DataTableRowWrapperComponent implements DoCheck, OnInit {
   @Input() groupHeader: any;
   @Input() offsetX: number;
   @Input() detailRowHeight: any;
+  @Input() groupHeaderRowHeight: number;
   @Input() row: any;
   @Input() groupedRows: any;
   @Input() disableCheck: (row: any) => boolean;
@@ -133,7 +139,6 @@ export class DataTableRowWrapperComponent implements DoCheck, OnInit {
     styles.transform = 'translate3d(' + this.offsetX + 'px, 0px, 0px)';
     styles['backface-visibility'] = 'hidden';
     styles.width = this.innerWidth + 'px';
-
     return styles;
   }
 }

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -77,6 +77,7 @@ import { DragEventData } from '../../types/drag-events.type';
           [groupHeader]="groupHeader"
           [offsetX]="offsetX"
           [detailRowHeight]="getDetailRowHeight(group && group[i], i)"
+          [groupHeaderRowHeight]="getGroupHeaderRowHeight(group && group[i], i)"
           [row]="group"
           [disableCheck]="disableRowCheck"
           [expanded]="getRowExpanded(group)"
@@ -631,6 +632,14 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
       return 0;
     }
     const rowHeight = this.rowDetail.rowHeight;
+    return typeof rowHeight === 'function' ? rowHeight(row, index) : (rowHeight as number);
+  };
+  
+  getGroupHeaderRowHeight = (row?: any, index?: any): number => {
+    if (!this.groupHeader) {
+      return 0;
+    }
+    const rowHeight = this.groupHeader?.rowHeight === 0 ? this.rowHeight : this.groupHeader?.rowHeight;
     return typeof rowHeight === 'function' ? rowHeight(row, index) : (rowHeight as number);
   };
 

--- a/src/app/basic/row-grouping.component.ts
+++ b/src/app/basic/row-grouping.component.ts
@@ -34,9 +34,9 @@ import { SelectionType } from './../../../projects/ngx-datatable/src/lib/types/s
         [selectionType]="SelectionType.multiClick"
       >
         <!-- Group Header Template -->
-        <ngx-datatable-group-header [rowHeight]="50" #myGroupHeader (toggle)="onDetailToggle($event)">
+        <ngx-datatable-group-header [rowHeight]="34" #myGroupHeader (toggle)="onDetailToggle($event)">
           <ng-template let-group="group" let-expanded="expanded" ngx-datatable-group-header-template>
-            <div style="padding-left:5px;">
+            <div style="padding-left:5px;height: 100%; display:flex;align-items: center;">
               <a
                 href="#"
                 [class.datatable-icon-right]="!expanded"


### PR DESCRIPTION
fixes the issue where `rowHeight` on `ngx-datatable-group-header` doesn't work

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
