### PR TITLE
feat(sort): support to remove applied sort

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -19,6 +19,7 @@
       [allRowsSelected]="allRowsSelected"
       [selectionType]="selectionType"
       [verticalScrollVisible]="verticalScrollVisible"
+      [enableClearingSortState]="enableClearingSortState"
       (sort)="onColumnSort($event)"
       (resize)="onColumnResize($event)"
       (resizing)="onColumnResizing($event)"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -457,6 +457,13 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
   @Input() rowDraggable = false;
 
   /**
+   * A flag to controll behavior of sort states.
+   * By default sort on column toggles between ascending and descending without getting removed.
+   * Set true to clear sorting of column after performing ascending and descending sort on that column.
+   */
+  @Input() enableClearingSortState = false;
+
+  /**
    * Body was scrolled typically in a `scrollbarV:true` scenario.
    */
   @Output() scroll: EventEmitter<any> = new EventEmitter();
@@ -1262,13 +1269,17 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
   }
 
   private sortInternalRows(): void {
+    // if there are no sort criteria we reset the rows with original rows
+    if (!this.sorts || !this.sorts?.length) {
+      this._internalRows = this._rows;
+    }
     if (this.groupedRows && this.groupedRows.length) {
       const sortOnGroupHeader = this.sorts?.find(sortColumns => sortColumns.prop === this._groupRowsBy);
       this.groupedRows = this.groupArrayBy(this._rows, this._groupRowsBy);
       this.groupedRows = sortGroupedRows(this.groupedRows, this._internalColumns, this.sorts, sortOnGroupHeader);
       this._internalRows = [...this._internalRows];
     } else {
-      this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts);
+      this._internalRows = sortRows(this._rows, this._internalColumns, this.sorts);
     }
   }
 }

--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -54,6 +54,7 @@ export class DataTableHeaderCellComponent implements OnInit {
   @Input() isTarget: boolean;
   @Input() targetMarkerTemplate: any;
   @Input() targetMarkerContext: any;
+  @Input() enableClearingSortState = false;
 
   _allRowsSelected: boolean;
 
@@ -191,6 +192,10 @@ export class DataTableHeaderCellComponent implements OnInit {
 
   ngOnInit() {
     this.sortClass = this.calcSortClass(this.sortDir);
+    // If there is already a default sort then start the counter with 1.
+    if (this.sortDir) {
+      this.totalSortStatesApplied = 1;
+    }
   }
 
   calcSortDir(sorts: any[]): any {
@@ -200,11 +205,18 @@ export class DataTableHeaderCellComponent implements OnInit {
       if (sort) {return sort.dir;}
     }
   }
-
+  // Counter to reset sort once user sort asc and desc.
+  private totalSortStatesApplied = 0;
   onSort(): void {
     if (!this.column.sortable) {return;}
 
-    const newValue = nextSortDir(this.sortType, this.sortDir);
+    this.totalSortStatesApplied++;
+    let newValue = nextSortDir(this.sortType, this.sortDir);
+    // User has done both direction sort so we reset the next sort.
+    if (this.enableClearingSortState && this.totalSortStatesApplied === 3) {
+      newValue = undefined;
+      this.totalSortStatesApplied = 0;
+    }
     this.sort.emit({
       column: this.column,
       prevValue: this.sortDir,

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -62,6 +62,7 @@ import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
           [sortDescendingIcon]="sortDescendingIcon"
           [sortUnsetIcon]="sortUnsetIcon"
           [allRowsSelected]="allRowsSelected"
+          [enableClearingSortState]="enableClearingSortState"
           (sort)="onSort($event)"
           (select)="select.emit($event)"
           (columnContextmenu)="columnContextmenu.emit($event)"
@@ -82,6 +83,7 @@ export class DataTableHeaderComponent implements OnDestroy {
   @Input() scrollbarH: boolean;
   @Input() dealsWithGroup: boolean;
   @Input() targetMarkerTemplate: any;
+  @Input() enableClearingSortState = false;
 
   targetMarkerContext: any;
 

--- a/src/app/sorting/sorting-default.component.ts
+++ b/src/app/sorting/sorting-default.component.ts
@@ -24,6 +24,7 @@ import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
         [footerHeight]="50"
         [rowHeight]="50"
         [scrollbarV]="true"
+        [enableClearingSortState]="true"
         [sorts]="[{ prop: 'name', dir: 'desc' }]"
       >
         <ngx-datatable-column name="Company">


### PR DESCRIPTION
Introduced `enableClearingSortState` which allows to clear the sort on particular column after performing ascending and descending sort.

Similar to what angular material table provides:
https://material.angular.io/components/table/overview#table-sorting


**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
