### PR TITLE
fix(disabled-rows): recalculate only if row differs

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -850,7 +850,8 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
    * Lifecycle hook that is called when Angular dirty checks a directive.
    */
   ngDoCheck(): void {
-    if (this.rowDiffer.diff(this.rows) || this.disableRowCheck) {
+    const rowDiffers = this.rowDiffer.diff(this.rows);
+    if (rowDiffers || this.disableRowCheck) {
       if (!this.externalSorting) {
         this.sortInternalRows();
       } else {
@@ -864,10 +865,13 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
         optionalGetterForProp(this.treeToRelation)
       );
 
-      queueMicrotask(() => {
-        this.recalculate();
-        this.cd.markForCheck();
-      });
+      if (rowDiffers) {
+        queueMicrotask(() => {
+          this.recalculate();
+          this.cd.markForCheck();
+        });
+      }
+
       this.recalculatePages();
       this.cd.markForCheck();
     }


### PR DESCRIPTION
fixes the issue where `ngDoCheck` goes into infinte loop when `disableRowCheck` is provided.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
