### PR TITLE
refactor: visibility observer

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -1,4 +1,4 @@
-<div visibilityObserver (visible)="recalculate()">
+<div visibilityObserver [resizeThrottle]="resizeThrottle" [emitInitial]="emitInitial" (visible)="recalculate()">
   <div role="table">
     <datatable-header
       role="rowgroup"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -477,6 +477,16 @@ export class DatatableComponent<TRow = any> implements OnInit, DoCheck, AfterVie
   @Input() enableClearingSortState = false;
 
   /**
+   * Throttle time in ms. Will recalculate table this time after the resize.
+   */
+  @Input() resizeThrottle = 100;
+
+  /**
+   * Emits first visibility change immediately without waiting for resizeThrottle.
+   */
+  @Input() emitInitial = true;
+
+  /**
    * Body was scrolled typically in a `scrollbarV:true` scenario.
    */
   @Output() scroll: EventEmitter<ScrollEvent> = new EventEmitter();


### PR DESCRIPTION
use `ResizeObserver` api to emit visibility change. Also auto recalculate table when table resize by parent containers.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
