### PR TITLE
Disabled CSS transform in ngx-datatable to enable scroll event tracking

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.scss
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.scss
@@ -3,7 +3,6 @@
   overflow: hidden;
   justify-content: center;
   position: relative;
-  transform: translate3d(0, 0, 0);
 
   [hidden] {
     display: none !important;


### PR DESCRIPTION
The CSS transform property in ngx-datatable was preventing the detection and handling of scroll events within the table. This commit disables the CSS transform to ensure scroll events can be properly tracked and managed, enhancing the table's interactivity and responsiveness to user actions.

**What kind of change does this PR introduce?** (check one with "x")

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** When you scroll in the ngx-datatable, the scroll event is not detected or handled due to the CSS transform property being applied. This limits the ability to interact with the table through scrolling actions.

**What is the new behavior?** With the CSS transform property disabled in ngx-datatable, scroll events can now be properly tracked and managed. This enhancement allows for improved interactivity and responsiveness within the table, enabling actions based on scroll events.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No
- [X] I think No but i'm not really sure.

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: nothing more
