### PR TITLE
feat(table-scroll-header): sticky table header on window general scroll

### DIFF
--- a/docs/api/column/modes.md
+++ b/docs/api/column/modes.md
@@ -10,7 +10,7 @@ Columns are distributed given the width's defined in the column options.
 ## Flex
 
 Flex mode distributes the width's grow factor relative to other columns.
-It works the same as the [flex-grow API](http =//www.w3.org/TR/css3-flexbox/) in CSS.
+It works the same as the [flex-grow API](https://www.w3.org/TR/css3-flexbox-1/) in CSS.
 Basically it takes any available extra width and distribute it proportionally
 according to each column's `flexGrow` value.
 

--- a/docs/api/table/directives.md
+++ b/docs/api/table/directives.md
@@ -1,0 +1,13 @@
+# Table directives
+
+## `stickyHeader`
+
+The `stickyHeader` directive is designed to make a header element sticky at the top of the page as the user scrolls down. This directive ensures that the header remains visible at the top of the viewport, enhancing the user experience by keeping important navigational controls or information in view.
+
+> **WARNING:** However, it's important to note that for the sticky behavior to work correctly, none of the element's parent containers should have CSS properties like transform, filter, perspective, or height: 100% applied to them.
+
+To apply this directive, simply add the stickyHeader attribute to the `ngx-datatable` HTML tag in your HTML template:
+```html
+<ngx-datatable stickyHeader ...>your ngx-datatable content</ngx-datatable>
+```
+This example makes the header of the ngx-datatable sticky at the top of the page as you scroll along your table. However, once the entirety of the content has been scrolled past, the header will no longer be sticky and will scroll away.

--- a/projects/ngx-datatable/src/lib/directives/sticky-header.directive.spec.ts
+++ b/projects/ngx-datatable/src/lib/directives/sticky-header.directive.spec.ts
@@ -5,7 +5,7 @@ import { StickyHeaderDirective } from './sticky-header.directive';
 
 @Component({
   selector: 'test-fixture-component',
-  template: ` <div sticky-header></div> `
+  template: ` <div stickyHeader></div> `
 })
 class TestFixtureComponent {}
 

--- a/projects/ngx-datatable/src/lib/directives/sticky-header.directive.spec.ts
+++ b/projects/ngx-datatable/src/lib/directives/sticky-header.directive.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { StickyHeaderDirective } from './sticky-header.directive';
+
+@Component({
+  selector: 'test-fixture-component',
+  template: ` <div sticky-header></div> `
+})
+class TestFixtureComponent {}
+
+describe('StickyHeaderDirective', () => {
+  let fixture: ComponentFixture<TestFixtureComponent>;
+  let component: TestFixtureComponent;
+  let element;
+
+  // provide our implementations or mocks to the dependency injector
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [StickyHeaderDirective, TestFixtureComponent]
+    });
+  });
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.compileComponents().then(() => {
+        fixture = TestBed.createComponent(TestFixtureComponent);
+        component = fixture.componentInstance;
+        element = fixture.nativeElement;
+      });
+    })
+  );
+
+  describe('fixture', () => {
+    let directive: StickyHeaderDirective;
+
+    beforeEach(() => {
+      directive = fixture.debugElement.query(By.directive(StickyHeaderDirective)).injector.get(StickyHeaderDirective);
+    });
+
+    it('should have a component instance', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should have LongPressDirective directive', () => {
+      expect(directive).toBeTruthy();
+    });
+
+    it('should have isLongPress set to false', () => {
+      expect(directive._isFixed).toBeFalsy();
+    });
+  });
+});

--- a/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
@@ -21,8 +21,6 @@ export class StickyHeaderDirective implements OnInit {
     const datatableHeader = this.ngxDatatable?.element?.querySelector('.datatable-header') as HTMLElement;
     const datatableHeaderBoundingClientRect = datatableHeader.getBoundingClientRect();
     const datatableBoundingClientRect = this.ngxDatatable?.element?.getBoundingClientRect();
-    console.log('datatableHeader bounding client rect', datatableHeaderBoundingClientRect);
-    console.log('datatable bounding client rect', this.ngxDatatable.element.getBoundingClientRect());
     const datatableYTopInViewport = this._isFixed
       ? datatableBoundingClientRect.top - datatableHeaderBoundingClientRect.height
       : datatableHeaderBoundingClientRect.top;

--- a/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
@@ -7,6 +7,7 @@ import { DatatableComponent } from '@siemens/ngx-datatable';
 })
 export class StickyHeaderDirective implements OnInit {
   private _isFixed = false;
+  private _shouldBeFixed = false;
 
   constructor(@Host() @Optional() private ngxDatatable: DatatableComponent) {}
 
@@ -23,12 +24,19 @@ export class StickyHeaderDirective implements OnInit {
     const tableRect = this.ngxDatatable?.element?.getBoundingClientRect();
 
     const shouldFixHeader = tableRect.top <= 0 && tableRect.bottom - headerRect.height > 0;
-    if (shouldFixHeader && !this.isFixed) {
+    if (shouldFixHeader && !this._isFixed) {
       this.applyFixedStyles(header);
-      this.isFixed = true;
-    } else if (!shouldFixHeader && this.isFixed) {
-      this.resetStyles(header);
-      this.isFixed = false;
+      if (this._shouldBeFixed) {
+        this.ngxDatatable.element.style.paddingTop = `${headerRect.height}px`;
+        this._isFixed = true;
+      }
+      this._shouldBeFixed = true;
+    } else if (!shouldFixHeader && this._isFixed) {
+      if (!this._shouldBeFixed) {
+        this.resetStyles(header);
+        this._isFixed = false;
+      }
+      this._shouldBeFixed = false;
     }
   }
 
@@ -37,14 +45,13 @@ export class StickyHeaderDirective implements OnInit {
     header.style.top = '0';
     header.style.zIndex = '1000';
     header.style.backgroundColor = 'white';
-    this.ngxDatatable.element.style.marginTop = `${header.getBoundingClientRect().height}px`;
   }
 
   private resetStyles(header: HTMLElement) {
-    header.style.position = null;
-    header.style.top = null;
-    header.style.zIndex = null;
-    header.style.backgroundColor = null;
-    this.ngxDatatable.element.style.marginTop = null;
+    header.style.position = '';
+    header.style.top = '';
+    header.style.zIndex = '';
+    header.style.backgroundColor = '';
+    this.ngxDatatable.element.style.paddingTop = '';
   }
 }

--- a/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
@@ -1,0 +1,50 @@
+import { Directive, Host, HostListener, OnInit, Optional } from '@angular/core';
+import { DatatableComponent } from '@siemens/ngx-datatable';
+
+@Directive({
+  selector: '[sticky-header]',
+  standalone: true,
+})
+export class StickyHeaderDirective implements OnInit {
+  private _isFixed = false;
+
+  constructor(@Host() @Optional() private ngxDatatable: DatatableComponent) {}
+
+  ngOnInit() {
+    if (!this.ngxDatatable) {
+      throw new Error('StickyHeaderDirective must be used with ngx-datatable');
+    }
+  }
+
+  @HostListener('window:scroll', ['$event'])
+  onWindowScroll() {
+    const datatableHeader = this.ngxDatatable?.element?.querySelector('.datatable-header') as HTMLElement;
+    const datatableHeaderBoundingClientRect = datatableHeader.getBoundingClientRect();
+    const datatableBoundingClientRect = this.ngxDatatable?.element?.getBoundingClientRect();
+    console.log('datatableHeader bounding client rect', datatableHeaderBoundingClientRect);
+    console.log('datatable bounding client rect', this.ngxDatatable.element.getBoundingClientRect());
+    const datatableYTopInViewport = this._isFixed
+      ? datatableBoundingClientRect.top - datatableHeaderBoundingClientRect.height
+      : datatableHeaderBoundingClientRect.top;
+
+    // 2 * datatableHeaderBoundingClientRect?.height is used to account for the height of the potential sticky header
+    // and the height of the header that is now unfixed (so the table was "pushed" by the top by the header that is now unfixed)
+    const datatableYBottomInViewport = datatableBoundingClientRect.bottom - datatableHeaderBoundingClientRect?.height;
+
+    if (datatableYTopInViewport <= 0 && datatableYBottomInViewport > 0) {
+      datatableHeader.style.position = 'fixed';
+      datatableHeader.style.top = '0';
+      datatableHeader.style.zIndex = '1000';
+      datatableHeader.style.backgroundColor = 'white';
+      this.ngxDatatable.element.style.marginTop = `${datatableHeaderBoundingClientRect?.height}px`;
+      this._isFixed = true;
+    } else {
+      datatableHeader.style.position = null;
+      datatableHeader.style.top = null;
+      datatableHeader.style.zIndex = null;
+      datatableHeader.style.backgroundColor = null;
+      this.ngxDatatable.element.style.marginTop = null;
+      this._isFixed = false;
+    }
+  }
+}

--- a/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
@@ -25,8 +25,8 @@ export class StickyHeaderDirective implements OnInit {
 
     const shouldFixHeader = tableRect.top <= 0 && tableRect.bottom - headerRect.height > 0;
     if (shouldFixHeader && !this._isFixed) {
-      this.applyFixedStyles(header);
       if (this._shouldBeFixed) {
+        this.applyFixedStyles(header);
         this.ngxDatatable.element.style.paddingTop = `${headerRect.height}px`;
         this._isFixed = true;
       }

--- a/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
@@ -16,33 +16,35 @@ export class StickyHeaderDirective implements OnInit {
     }
   }
 
-  @HostListener('window:scroll', ['$event'])
+    @HostListener('window:scroll', ['$event'])
   onWindowScroll() {
-    const datatableHeader = this.ngxDatatable?.element?.querySelector('.datatable-header') as HTMLElement;
-    const datatableHeaderBoundingClientRect = datatableHeader.getBoundingClientRect();
-    const datatableBoundingClientRect = this.ngxDatatable?.element?.getBoundingClientRect();
-    const datatableYTopInViewport = this._isFixed
-      ? datatableBoundingClientRect.top - datatableHeaderBoundingClientRect.height
-      : datatableHeaderBoundingClientRect.top;
+    const header = this.ngxDatatable?.element?.querySelector('.datatable-header') as HTMLElement;
+    const headerRect = header.getBoundingClientRect();
+    const tableRect = this.ngxDatatable?.element?.getBoundingClientRect();
 
-    // 2 * datatableHeaderBoundingClientRect?.height is used to account for the height of the potential sticky header
-    // and the height of the header that is now unfixed (so the table was "pushed" by the top by the header that is now unfixed)
-    const datatableYBottomInViewport = datatableBoundingClientRect.bottom - datatableHeaderBoundingClientRect?.height;
-
-    if (datatableYTopInViewport <= 0 && datatableYBottomInViewport > 0) {
-      datatableHeader.style.position = 'fixed';
-      datatableHeader.style.top = '0';
-      datatableHeader.style.zIndex = '1000';
-      datatableHeader.style.backgroundColor = 'white';
-      this.ngxDatatable.element.style.marginTop = `${datatableHeaderBoundingClientRect?.height}px`;
-      this._isFixed = true;
-    } else {
-      datatableHeader.style.position = null;
-      datatableHeader.style.top = null;
-      datatableHeader.style.zIndex = null;
-      datatableHeader.style.backgroundColor = null;
-      this.ngxDatatable.element.style.marginTop = null;
-      this._isFixed = false;
+    const shouldFixHeader = tableRect.top <= 0 && tableRect.bottom - headerRect.height > 0;
+    if (shouldFixHeader && !this.isFixed) {
+      this.applyFixedStyles(header);
+      this.isFixed = true;
+    } else if (!shouldFixHeader && this.isFixed) {
+      this.resetStyles(header);
+      this.isFixed = false;
     }
+  }
+
+  private applyFixedStyles(header: HTMLElement) {
+    header.style.position = 'fixed';
+    header.style.top = '0';
+    header.style.zIndex = '1000';
+    header.style.backgroundColor = 'white';
+    this.ngxDatatable.element.style.marginTop = `${header.getBoundingClientRect().height}px`;
+  }
+
+  private resetStyles(header: HTMLElement) {
+    header.style.position = null;
+    header.style.top = null;
+    header.style.zIndex = null;
+    header.style.backgroundColor = null;
+    this.ngxDatatable.element.style.marginTop = null;
   }
 }

--- a/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
@@ -18,7 +18,7 @@ export class StickyHeaderDirective implements OnInit {
 
     @HostListener('window:scroll', ['$event'])
   onWindowScroll() {
-    const header = this.ngxDatatable?.element?.querySelector('.datatable-header') as HTMLElement;
+    const header: HTMLElement = this.ngxDatatable?.element?.querySelector('.datatable-header');
     const headerRect = header.getBoundingClientRect();
     const tableRect = this.ngxDatatable?.element?.getBoundingClientRect();
 

--- a/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/sticky-header.directive.ts
@@ -2,7 +2,7 @@ import { Directive, Host, HostListener, OnInit, Optional } from '@angular/core';
 import { DatatableComponent } from '@siemens/ngx-datatable';
 
 @Directive({
-  selector: '[sticky-header]',
+  selector: '[stickyHeader]',
   standalone: true,
 })
 export class StickyHeaderDirective implements OnInit {

--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -9,6 +9,7 @@ import { DraggableDirective } from './directives/draggable.directive';
 import { ResizeableDirective } from './directives/resizeable.directive';
 import { OrderableDirective } from './directives/orderable.directive';
 import { LongPressDirective } from './directives/long-press.directive';
+import { LongPressDirective } from './directives/sticky-header.directive';
 import { ScrollerComponent } from './components/body/scroller.component';
 import { DatatableComponent } from './components/datatable.component';
 import { DataTableColumnDirective } from './components/columns/column.directive';
@@ -46,6 +47,7 @@ import { DatatableRowDefComponent, DatatableRowDefDirective, DatatableRowDefInte
     ResizeableDirective,
     OrderableDirective,
     LongPressDirective,
+    StickyHeaderDirective,
     ScrollerComponent,
     DatatableComponent,
     DataTableColumnDirective,
@@ -87,6 +89,7 @@ import { DatatableRowDefComponent, DatatableRowDefDirective, DatatableRowDefInte
     DataTableColumnCellTreeToggle,
     DataTableFooterTemplateDirective,
     DatatableFooterDirective,
+    StickyHeaderDirective,
     DataTablePagerComponent,
     DatatableGroupHeaderTemplateDirective,
     DisableRowDirective,

--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -9,7 +9,7 @@ import { DraggableDirective } from './directives/draggable.directive';
 import { ResizeableDirective } from './directives/resizeable.directive';
 import { OrderableDirective } from './directives/orderable.directive';
 import { LongPressDirective } from './directives/long-press.directive';
-import { LongPressDirective } from './directives/sticky-header.directive';
+import { StickyHeaderDirective } from './directives/sticky-header.directive';
 import { ScrollerComponent } from './components/body/scroller.component';
 import { DatatableComponent } from './components/datatable.component';
 import { DataTableColumnDirective } from './components/columns/column.directive';


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the new behavior?** This MR brings you the ability to have a sticky datatable header when scrolling long tables in your browser adding only one directive to the root ngx-datatable HTML tag.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
