### PR TITLE
fix: tree grouping breaks if rows are assigned statically

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -1277,6 +1277,14 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
     // if there are no sort criteria we reset the rows with original rows
     if (!this.sorts || !this.sorts?.length) {
       this._internalRows = this._rows;
+      // if there is any tree relation then re-group rows accordingly
+      if (this.treeFromRelation && this.treeToRelation) {
+        this._internalRows = groupRowsByParents(
+          this._internalRows,
+          optionalGetterForProp(this.treeFromRelation),
+          optionalGetterForProp(this.treeToRelation)
+        );
+      }
     }
     if (this.groupedRows && this.groupedRows.length) {
       const sortOnGroupHeader = this.sorts?.find(sortColumns => sortColumns.prop === this._groupRowsBy);


### PR DESCRIPTION
Fixes the issue where  tree grouping breaks if rows are directly set on ngx-datatable without doing any async calls.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
