### PR TITLE
feat(table-sticky-header): sticky table header on scroll

### DIFF
--- a/docs/api/column/modes.md
+++ b/docs/api/column/modes.md
@@ -10,7 +10,7 @@ Columns are distributed given the width's defined in the column options.
 ## Flex
 
 Flex mode distributes the width's grow factor relative to other columns.
-It works the same as the [flex-grow API](http =//www.w3.org/TR/css3-flexbox/) in CSS.
+It works the same as the [flex-grow API](https://www.w3.org/TR/css3-flexbox-1/) in CSS.
 Basically it takes any available extra width and distribute it proportionally
 according to each column's `flexGrow` value.
 

--- a/docs/introduction/themes.md
+++ b/docs/introduction/themes.md
@@ -20,7 +20,7 @@ You can just add above to your `scss` file and then specify the class of your ng
 - `ngx-datatable`: Master Table class
 
   - `fixed-header`: The header is fixed on the table
-  - `sticky-header`: The header is sticky during the scroll along the table.
+  - `sticky-header`: The header is sticky during the scroll along the table. ⚠️ Do not apply `overflow: hidden;` or `overflow-{x,y}: hidden;` properties to parent elements.
 
 - `datatable-header`: Header row class
 

--- a/docs/introduction/themes.md
+++ b/docs/introduction/themes.md
@@ -20,6 +20,7 @@ You can just add above to your `scss` file and then specify the class of your ng
 - `ngx-datatable`: Master Table class
 
   - `fixed-header`: The header is fixed on the table
+  - `sticky-header`: The header is sticky during the scroll along the table.
 
 - `datatable-header`: Header row class
 

--- a/projects/ngx-datatable/src/lib/components/datatable.component.scss
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.scss
@@ -60,6 +60,20 @@
   }
 
   /**
+   * Sticky header style
+   */
+  &.sticky-header {
+    overflow: unset !important;
+  
+    .datatable-header {
+      position: sticky;
+      top: 0;
+      z-index: 999;
+      background-color: white;
+    }
+  }
+
+  /**
    * Fixed row height adjustments
    */
   &.fixed-row {

--- a/projects/ngx-datatable/src/lib/themes/_rows.scss
+++ b/projects/ngx-datatable/src/lib/themes/_rows.scss
@@ -20,3 +20,14 @@ $disable-row-text-color: #83888E !default;
     }
   }
 }
+
+.ngx-datatable-sticky {
+  overflow: unset !important;
+
+  .datatable-header {
+    position: sticky;
+    top: 0;
+    z-index: 999;
+    background-color: white;
+  }
+}

--- a/projects/ngx-datatable/src/lib/themes/_rows.scss
+++ b/projects/ngx-datatable/src/lib/themes/_rows.scss
@@ -20,14 +20,3 @@ $disable-row-text-color: #83888E !default;
     }
   }
 }
-
-.ngx-datatable-sticky {
-  overflow: unset !important;
-
-  .datatable-header {
-    position: sticky;
-    top: 0;
-    z-index: 999;
-    background-color: white;
-  }
-}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the new behavior?** This MR brings you the ability to have a sticky datatable header when scrolling long tables in your browser adding only one CSS class to add to the root ngx-datatable HTML tag.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

**Other information**: N/A