### PR TITLE
fix: `datatable-scroller` width should update on recalculate

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -269,8 +269,7 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
   @Input() set columns(val: any[]) {
     if (val !== this._columns) {
       this._columns = val;
-      const colsByPin = columnsByPin(val);
-      this.columnGroupWidths = columnGroupWidths(colsByPin, val);
+      this.updateColumnGroupWidths();
     }
   }
 
@@ -1011,5 +1010,10 @@ export class DataTableBodyComponent implements OnInit, OnDestroy {
     });
     this._draggedRow = undefined;
     this._draggedRowElement = undefined;
+  }
+
+  updateColumnGroupWidths() {
+    const colsByPin = columnsByPin(this._columns);
+    this.columnGroupWidths = columnGroupWidths(colsByPin, this._columns);
   }
 }

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -940,6 +940,11 @@ export class DatatableComponent implements OnInit, DoCheck, AfterViewInit, After
       adjustColumnWidths(columns, width);
     }
 
+    if (this.bodyComponent) {
+      this.bodyComponent.updateColumnGroupWidths();
+      this.bodyComponent.cd.markForCheck();
+    }
+
     return columns;
   }
 


### PR DESCRIPTION
Steps to reproduce:

- Go to https://swimlane.github.io/ngx-datatable/#virtual-scroll
- Now decrease browser width
- Now open inspector and check the width of `datatable-scroller` element

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
`datatable-scroller` width doesn't update to match actual column total widths

**What is the new behavior?**
`datatable-scroller` width  will update to match actual column total widths whenever table resize/recalculate.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
