### PR TITLE
refactor: remove unnecessary getter/setters on columnTemplates

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -628,17 +628,7 @@ export class DatatableComponent<TRow = any> implements OnInit, DoCheck, AfterVie
    * if described in your markup.
    */
   @ContentChildren(DataTableColumnDirective)
-  set columnTemplates(val: QueryList<DataTableColumnDirective>) {
-    this._columnTemplates = val;
-    this.translateColumns(val);
-  }
-
-  /**
-   * Returns the column templates.
-   */
-  get columnTemplates(): QueryList<DataTableColumnDirective> {
-    return this._columnTemplates;
-  }
+    columnTemplates!: QueryList<DataTableColumnDirective>;
 
   /**
    * Row Detail templates gathered from the ContentChild
@@ -711,7 +701,6 @@ export class DatatableComponent<TRow = any> implements OnInit, DoCheck, AfterVie
   _internalRows: TRow[];
   _internalColumns: TableColumn[];
   _columns: TableColumn[];
-  _columnTemplates: QueryList<DataTableColumnDirective>;
   _subscriptions: Subscription[] = [];
   _ghostLoadingIndicator = false;
   protected verticalScrollVisible = false;
@@ -789,7 +778,10 @@ export class DatatableComponent<TRow = any> implements OnInit, DoCheck, AfterVie
    * content has been fully initialized.
    */
   ngAfterContentInit() {
-    this.columnTemplates.changes.subscribe(v => this.translateColumns(v));
+    if (this.columnTemplates.length) {
+      this.translateColumns(this.columnTemplates);
+    }
+    this._subscriptions.push(this.columnTemplates.changes.subscribe(v => this.translateColumns(v)));
     this.listenForColumnInputChanges();
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
value setter is defined on `@ContentChildren` to perform computation

**What is the new behavior?**
invoke computation in `ngAfterContentInit` instead of setter.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
