### PR TITLE
refactor: use signals to render internal rows

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -115,7 +115,7 @@ describe('DataTableBodyComponent', () => {
 
   describe('Summary row', () => {
     it('should not return custom styles for a bottom summary row if a scrollbar mode is off', () => {
-      const styles = component.getBottomSummaryRowStyles();
+      const styles = component.bottomSummaryRowsStyles();
       expect(styles).toBeFalsy();
     });
 
@@ -124,7 +124,7 @@ describe('DataTableBodyComponent', () => {
       component.scrollbarV = true;
       component.virtualization = true;
       component.rows = [{ num: 1 }, { num: 2 }, { num: 3 }, { num: 4 }];
-      const styles = component.getBottomSummaryRowStyles();
+      const styles = component.bottomSummaryRowsStyles();
       expect(styles).toBeDefined();
     });
   });


### PR DESCRIPTION
This has following changes:

- Switched to use signal for `temp` iterator which was used for rendering the rows on view also renamed `temp` to `rowsToRender`.
- `getRowsStyles` and `bottomSummaryRowsStyles` converted to `computed` signals to avoid calling them unnecessarily. This should lead to some performance boost.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
