### PR TITLE
fix: resetting table with empty array

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -99,9 +99,11 @@ export class DatatableComponent<TRow = any>
    */
   @Input() set rows(val: TRow[] | null | undefined) {
     this._rows = val;
-    // This will ensure that datatable detects changes on doing like this rows = [...rows];
-    this.rowDiffer.diff([]);
     if (val) {
+      // This will ensure that datatable detects changes on doing like this rows = [...rows];
+      if (val.length) {
+        this.rowDiffer.diff([]);
+      }
       this._internalRows = [...val];
     }
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
This one is regression of https://github.com/siemens/ngx-datatable/pull/91

Steps to reproduce:
- load table with some rows
- on some button click do rows = [] 
- console throws errors


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
