### PR TITLE
fix: calculate column widths only when table is visible

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -898,11 +898,10 @@ export class DatatableComponent<TRow = any>
     forceIdx: number = -1,
     allowBleed: boolean = this.scrollbarH
   ): TableColumn[] | undefined {
-    if (!columns) {
+    let width = this._innerWidth;
+    if (!columns || !width) {
       return undefined;
     }
-
-    let width = this._innerWidth;
     const bodyElement = this.bodyElement?.nativeElement;
     this.verticalScrollVisible = bodyElement?.scrollHeight > bodyElement?.clientHeight;
     if (this.scrollbarV && !this.scrollbarVDynamic) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
This issue occurs mainly when table is hidden using `display:none`

Column widths are calculated on load even when table is not visible.
Even though recalculation is again triggered when table visibility change it leads to wrong width calculations as it calculates based on pervious widths of columns.


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
