### PR TITLE
refactor: use signals for indexes

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -65,7 +65,7 @@ describe('DataTableBodyComponent', () => {
       component.rowCount = 20;
       const expectedIndexes = { first: 10, last: 20 };
       component.updateIndexes();
-      expect(component.indexes).toEqual(expectedIndexes);
+      expect(component.indexes()).toEqual(expectedIndexes);
     });
 
     it('should have correct indexes for normal paging with rows < pageSize', () => {
@@ -76,7 +76,7 @@ describe('DataTableBodyComponent', () => {
       component.rowCount = 9;
       const expectedIndexes = { first: 5, last: 9 };
       component.updateIndexes();
-      expect(component.indexes).toEqual(expectedIndexes);
+      expect(component.indexes()).toEqual(expectedIndexes);
     });
 
     it('should have correct indexes for external paging with rows > pageSize', () => {
@@ -98,7 +98,7 @@ describe('DataTableBodyComponent', () => {
       component.rowCount = 20;
       const expectedIndexes = { first: 0, last: 10 };
       component.updateIndexes();
-      expect(component.indexes).toEqual(expectedIndexes);
+      expect(component.indexes()).toEqual(expectedIndexes);
     });
 
     it('should have correct indexes for external paging with rows < pageSize', () => {
@@ -109,7 +109,7 @@ describe('DataTableBodyComponent', () => {
       component.rowCount = 9;
       const expectedIndexes = { first: 0, last: 5 };
       component.updateIndexes();
-      expect(component.indexes).toEqual(expectedIndexes);
+      expect(component.indexes()).toEqual(expectedIndexes);
     });
   });
 

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -675,7 +675,7 @@ export class DatatableComponent<TRow = any>
 
     if (this.bodyComponent && this.selectAllRowsOnPage) {
       const indexes = this.bodyComponent.indexes;
-      const rowsOnPage = indexes.last - indexes.first;
+      const rowsOnPage = indexes().last - indexes().first;
       allRowsSelected = this.selected.length === rowsOnPage;
     }
 
@@ -1209,8 +1209,8 @@ export class DatatableComponent<TRow = any>
   onHeaderSelect(): void {
     if (this.bodyComponent && this.selectAllRowsOnPage) {
       // before we splice, chk if we currently have all selected
-      const first = this.bodyComponent.indexes.first;
-      const last = this.bodyComponent.indexes.last;
+      const first = this.bodyComponent.indexes().first;
+      const last = this.bodyComponent.indexes().last;
       const allSelected = this.selected.length === last - first;
 
       // remove all existing either way


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
indexes are now signals which allows to make `rowsToRender` as `computed` depending on changes in `indexes`;
this allows to remove manual calls to `updateRows` from everywhere and ensures to be called when indexes are changed.
on a side effect it also fixes manually removing dummy ghost rows.

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
