### PR TITLE
fix: hide rows when ghostLoading with no virtualization

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -91,6 +91,9 @@ import {
           @for (group of rowsToRender(); track rowTrackingFn(i, group); let i = $index) {
             <datatable-row-wrapper
               #rowWrapper
+              [attr.hidden]="
+                ghostLoadingIndicator && (!rowCount || !virtualization || !scrollbarV) ? true : null
+              "
               [groupedRows]="groupedRows"
               [innerWidth]="innerWidth"
               [ngStyle]="rowsStyles()[i]"

--- a/src/app/paging/paging-scrolling-novirtualization.component.ts
+++ b/src/app/paging/paging-scrolling-novirtualization.component.ts
@@ -34,6 +34,7 @@ import { Employee } from '../data.model';
         [count]="page.totalElements"
         [offset]="page.pageNumber"
         [limit]="page.size"
+        [ghostLoadingIndicator]="isLoading > 0"
         (page)="setPage($event)"
       >
       </ngx-datatable>
@@ -50,6 +51,7 @@ export class PagingScrollingNoVirtualizationComponent implements OnInit {
   rows: Employee[] = [];
 
   ColumnMode = ColumnMode;
+  isLoading = 0;
 
   constructor(private serverResultsService: MockServerResultsService) {}
 
@@ -63,7 +65,9 @@ export class PagingScrollingNoVirtualizationComponent implements OnInit {
    */
   setPage(pageInfo) {
     this.page.pageNumber = pageInfo.offset;
+    this.isLoading++;
     this.serverResultsService.getResults(this.page).subscribe(pagedData => {
+      this.isLoading--;
       this.page = pagedData.page;
       this.rows = pagedData.data;
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

1. Configure a basic `ngx-datatable` with some arbitrary data as well as a text input 
2. Define a boolean representing loading (initially false) and bind it to the `ghostLoadingIndicator` of the datatable
3. On input / search set the loading boolean to true (and optionally to false after a while)
4. Observe the behaviour of the datatable: existing rows are still visible while ghost cells are being displayed.


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
