### PR TITLE
fix: partial values for messages and cssClasses

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -338,7 +338,7 @@ export class DatatableComponent<TRow = any>
   /**
    * Css class overrides
    */
-  @Input() cssClasses: INgxDatatableConfig['cssClasses'] = {
+  @Input() cssClasses: Partial<INgxDatatableConfig['cssClasses']> = {
     sortAscending: 'datatable-icon-up',
     sortDescending: 'datatable-icon-down',
     sortUnset: 'datatable-icon-sort-unset',
@@ -355,7 +355,7 @@ export class DatatableComponent<TRow = any>
    * totalMessage     [default] = 'total'
    * selectedMessage  [default] = 'selected'
    */
-  @Input() messages: INgxDatatableConfig['messages'] = {
+  @Input() messages: Partial<INgxDatatableConfig['messages']> = {
     // Message to show when array is presented
     // but contains no values
     emptyMessage: 'No data to display',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
Before introducing strict types we allowed overriding messages and cssClasses partially.

currently applications needs to provide all default values even if they intend to override only one specific.


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
