### PR TITLE
fix: horizontal scroll

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -19,6 +19,7 @@ import {
   OnInit,
   Output,
   QueryList,
+  signal,
   TemplateRef,
   ViewChild,
   ViewEncapsulation
@@ -702,6 +703,11 @@ export class DatatableComponent<TRow = any>
   _ghostLoadingIndicator = false;
   _defaultColumnWidth?: number;
   protected verticalScrollVisible = false;
+  // In case horizontal scroll is enabled
+  // the column widths are initially calculated without vertical scroll offset
+  // this makes horizontal scroll to appear on load even if columns can fit in view
+  // this will be set to true once rows are available and rendered on UI
+  private _rowInitDone = signal(false);
 
   constructor() {
     // apply global settings from Module.forRoot
@@ -855,6 +861,7 @@ export class DatatableComponent<TRow = any>
       }
       if (rowDiffers) {
         queueMicrotask(() => {
+          this._rowInitDone.set(true);
           this.recalculate();
           this.cd.markForCheck();
         });
@@ -906,32 +913,32 @@ export class DatatableComponent<TRow = any>
     }
     const bodyElement = this.bodyElement?.nativeElement;
     this.verticalScrollVisible = bodyElement?.scrollHeight > bodyElement?.clientHeight;
-    if (this.scrollbarV && !this.scrollbarVDynamic) {
-      width = width - (this.verticalScrollVisible ? this.scrollbarHelper.width : 0);
-    } else if (this.scrollbarVDynamic) {
-      const scrollerHeight = this.bodyComponent?.scroller?.element.offsetHeight;
-      if (scrollerHeight && this.bodyHeight < scrollerHeight) {
-        width = width - (this.verticalScrollVisible ? this.scrollbarHelper.width : 0);
-      }
-
-      if (this.headerComponent && this.headerComponent.innerWidth !== width) {
-        this.headerComponent.innerWidth = width;
-      }
-      if (this.bodyComponent && this.bodyComponent.innerWidth !== width) {
-        this.bodyComponent.innerWidth = width;
-        this.bodyComponent.cd.markForCheck();
-      }
+    if (this.scrollbarV || this.scrollbarVDynamic) {
+      width =
+        width -
+        (this.verticalScrollVisible || !this._rowInitDone() ? this.scrollbarHelper.width : 0);
     }
 
     if (this.columnMode === ColumnMode.force) {
-      forceFillColumnWidths(columns, width, forceIdx, allowBleed, this._defaultColumnWidth);
+      forceFillColumnWidths(
+        columns,
+        width,
+        forceIdx,
+        allowBleed,
+        this._defaultColumnWidth,
+        this.scrollbarHelper.width
+      );
     } else if (this.columnMode === ColumnMode.flex) {
       adjustColumnWidths(columns, width);
     }
 
-    if (this.bodyComponent) {
-      this.bodyComponent.updateColumnGroupWidths();
+    if (this.bodyComponent && this.bodyComponent.columnGroupWidths.total !== width) {
+      this.bodyComponent.columns = [...this._internalColumns];
       this.bodyComponent.cd.markForCheck();
+    }
+
+    if (this.headerComponent && this.headerComponent._columnGroupWidths.total !== width) {
+      this.headerComponent.columns = [...this._internalColumns];
     }
 
     return columns;

--- a/projects/ngx-datatable/src/lib/utils/math.ts
+++ b/projects/ngx-datatable/src/lib/utils/math.ts
@@ -126,7 +126,8 @@ export function forceFillColumnWidths(
   expectedWidth: number,
   startIdx: number,
   allowBleed: boolean,
-  defaultColWidth: number = 150
+  defaultColWidth: number = 150,
+  verticalScrollWidth = 0
 ) {
   const columnsToResize = allColumns
     .slice(startIdx + 1, allColumns.length)
@@ -142,6 +143,7 @@ export function forceFillColumnWidths(
   let exceedsWindow = false;
   let contentWidth = getContentWidth(allColumns, defaultColWidth);
   let remainingWidth = expectedWidth - contentWidth;
+  const initialRemainingWidth = remainingWidth;
   const columnsProcessed: any[] = [];
   const remainingWidthLimit = 1; // when to stop
 
@@ -151,7 +153,8 @@ export function forceFillColumnWidths(
     exceedsWindow = contentWidth >= expectedWidth;
 
     for (const column of columnsToResize) {
-      if (exceedsWindow && allowBleed) {
+      // don't bleed if the initialRemainingWidth is same as verticalScrollWidth
+      if (exceedsWindow && allowBleed && initialRemainingWidth !== -1 * verticalScrollWidth) {
         column.width = column.$$oldWidth || column.width || defaultColWidth;
       } else {
         const newSize = (column.width || defaultColWidth) + additionWidthPerColumn;


### PR DESCRIPTION
horizontal scroll shouldn't appear on load if there is enough space available to render columns.

steps to reproduce:
1. go to example https://github.com/siemens/ngx-datatable/blob/master/src/app/basic/scrolling.component.ts 
2. keep only first 2 columns (Name and Gender) and remove rest of the columns
3. observe that horizontal scroll is still present even though 2 columns are possible to fit in view port.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
