### PR TITLE
refactor: use signals for rowHeightCache

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -74,7 +74,7 @@ import {
         <datatable-scroller
           [scrollbarV]="scrollbarV"
           [scrollbarH]="scrollbarH"
-          [scrollHeight]="scrollHeight"
+          [scrollHeight]="scrollHeight()"
           [scrollWidth]="columnGroupWidths?.total"
           (scroll)="onBodyScroll($event)"
         >
@@ -235,7 +235,7 @@ import {
         <datatable-scroller
           [scrollbarV]="scrollbarV"
           [scrollbarH]="scrollbarH"
-          [scrollHeight]="scrollHeight"
+          [scrollHeight]="scrollHeight()"
           [style.width]="scrollbarH ? columnGroupWidths?.total + 'px' : '100%'"
           (scroll)="onBodyScroll($event)"
         >
@@ -401,18 +401,18 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
    * based on the row heights cache for virtual scroll and virtualization. Other scenarios
    * calculate scroll height automatically (as height will be undefined).
    */
-  get scrollHeight(): number | undefined {
-    if (this.scrollbarV && this.virtualization && this.rowCount) {
-      return this.rowHeightsCache.query(this.rowCount - 1);
+  scrollHeight = computed(() => {
+    if (this.rowHeightsCache() && this.scrollbarV && this.virtualization && this.rowCount) {
+      return this.rowHeightsCache().query(this.rowCount - 1);
     }
     // avoid TS7030: Not all code paths return a value.
     return undefined;
-  }
+  });
 
-  rowHeightsCache: RowHeightCache = new RowHeightCache();
   rowsToRender = computed(() => {
     return this.updateRows();
   });
+  rowHeightsCache = signal(new RowHeightCache());
   offsetY = 0;
   indexes = signal<{ first: number; last: number }>({ first: 0, last: 0 });
   columnGroupWidths: ColumnGroupWidth;
@@ -506,7 +506,7 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
     if (this.scrollbarV && this.virtualization && offset) {
       // First get the row Index that we need to move to.
       const rowIndex = this.pageSize * offset;
-      offset = this.rowHeightsCache.query(rowIndex - 1);
+      offset = this.rowHeightsCache().query(rowIndex - 1);
     } else if (this.scrollbarV && !this.virtualization) {
       offset = 0;
     }
@@ -737,7 +737,7 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
         // const pos = idx * rowHeight;
         // The position of this row would be the sum of all row heights
         // until the previous row position.
-        const pos = this.rowHeightsCache.query(idx - 1);
+        const pos = this.rowHeightsCache().query(idx - 1);
 
         Object.assign(styles, translateXY(0, pos));
       }
@@ -760,7 +760,7 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
       return null;
     }
 
-    const pos = this.rowHeightsCache.query(this.rows.length - 1);
+    const pos = this.rowHeightsCache().query(this.rows.length - 1);
     return {
       ...translateXY(0, pos),
       position: 'absolute'
@@ -787,8 +787,8 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
         // scrollY position would be at.  The last index would be the one
         // that shows up inside the view port the last.
         const height = parseInt(this._bodyHeight, 10);
-        first = this.rowHeightsCache.getRowIndex(this.offsetY);
-        last = this.rowHeightsCache.getRowIndex(height + this.offsetY) + 1;
+        first = this.rowHeightsCache().getRowIndex(this.offsetY);
+        last = this.rowHeightsCache().getRowIndex(height + this.offsetY) + 1;
       } else {
         // If virtual rows are not needed
         // We render all in one go
@@ -819,7 +819,7 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
     // clear the previous row height cache if already present.
     // this is useful during sorts, filters where the state of the
     // rows array is changed.
-    this.rowHeightsCache.clearCache();
+    this.rowHeightsCache().clearCache();
 
     // Initialize the tree only if there are rows inside the tree.
     if (this.rows && this.rows.length) {
@@ -832,7 +832,7 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
         }
       }
 
-      this.rowHeightsCache.initCache({
+      this.rowHeightsCache().initCache({
         rows: this.rows,
         rowHeight: this.rowHeight,
         detailRowHeight: this.getDetailRowHeight,
@@ -841,6 +841,7 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
         rowIndexes: this.rowIndexes,
         rowExpansions
       });
+      this.rowHeightsCache.set(Object.create(this.rowHeightsCache()));
     }
   }
 
@@ -854,7 +855,7 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
     const viewPortFirstRowIndex = this.indexes().first;
 
     if (this.scrollbarV && this.virtualization) {
-      const offsetScroll = this.rowHeightsCache.query(viewPortFirstRowIndex - 1);
+      const offsetScroll = this.rowHeightsCache().query(viewPortFirstRowIndex - 1);
       return offsetScroll <= this.offsetY ? viewPortFirstRowIndex - 1 : viewPortFirstRowIndex;
     }
 
@@ -878,7 +879,7 @@ export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = a
       const detailRowHeight = this.getDetailRowHeight(row) * (expanded ? -1 : 1);
       // const idx = this.rowIndexes.get(row) || 0;
       const idx = this.getRowIndex(row);
-      this.rowHeightsCache.update(idx, detailRowHeight);
+      this.rowHeightsCache().update(idx, detailRowHeight);
     }
 
     // Update the toggled row and update thive nevere heights in the cache.


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

use rowHeightCache as signal which then can be used to compute scrollHeight
and removes multiple getter calls to calculate `scrollHeight`.

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
