### PR TITLE
fix: apply even/odd classes correctly when rows are grouped

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -25,7 +25,7 @@ import {
 } from '../../types/public.types';
 import { DataTableGhostLoaderComponent } from './ghost-loader/ghost-loader.component';
 import { NgTemplateOutlet } from '@angular/common';
-import { TableColumnInternal } from '../../types/internal.types';
+import { RowIndex, TableColumnInternal } from '../../types/internal.types';
 
 @Component({
   selector: 'datatable-body-cell',
@@ -151,14 +151,15 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
     return this._expanded;
   }
 
-  @Input() set rowIndex(val: number) {
+  @Input() set rowIndex(val: RowIndex) {
     this._rowIndex = val;
-    this.cellContext.rowIndex = val;
+    this.cellContext.rowIndex = val?.index;
+    this.cellContext.rowInGroupIndex = val?.indexInGroup;
     this.checkValueUpdates();
     this.cd.markForCheck();
   }
 
-  get rowIndex(): number {
+  get rowIndex(): RowIndex {
     return this._rowIndex;
   }
 
@@ -302,7 +303,7 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
   private _row: TRow;
   private _group: TRow[];
   private _rowHeight: number;
-  private _rowIndex: number;
+  private _rowIndex: RowIndex;
   private _expanded: boolean;
   private _element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
   private _treeStatus: TreeStatus;
@@ -318,7 +319,8 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
       column: this.column,
       rowHeight: this.rowHeight,
       isSelected: this.isSelected,
-      rowIndex: this.rowIndex,
+      rowIndex: this.rowIndex?.index,
+      rowInGroupIndex: this.rowIndex?.indexInGroup,
       treeStatus: this.treeStatus,
       disabled: this._disabled,
       onTreeAction: () => this.onTreeAction()

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.spec.ts
@@ -1,0 +1,61 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { DataTableBodyRowComponent } from './body-row.component';
+import { Component } from '@angular/core';
+import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
+import { TableColumn } from '../../types/table-column.type';
+import { By } from '@angular/platform-browser';
+import { RowIndex } from '../../types/internal.types';
+import { toInternalColumn } from '../../utils/column-helper';
+
+describe('DataTableBodyRowComponent', () => {
+  @Component({
+    template: ` <datatable-body-row [rowIndex]="rowIndex" [row]="row" [columns]="columns" /> `,
+    imports: [DataTableBodyRowComponent],
+    standalone: true
+  })
+  class TestHostComponent {
+    rowIndex: RowIndex = { index: 0 };
+    row: any = { prop: 'value' };
+    columns: TableColumn[] = toInternalColumn([{ prop: 'prop' }]);
+  }
+
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+
+  // provide our implementations or mocks to the dependency injector
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [ScrollbarHelper]
+    });
+  });
+
+  beforeEach(waitForAsync(() => {
+    TestBed.compileComponents().then(() => {
+      fixture = TestBed.createComponent(TestHostComponent);
+      component = fixture.componentInstance;
+    });
+  }));
+
+  it('should apply odd/event without groups', () => {
+    component.rowIndex = { index: 0 };
+    fixture.detectChanges();
+    const element = fixture.debugElement.query(By.directive(DataTableBodyRowComponent))
+      .nativeElement as HTMLElement;
+    expect(element.classList).toContain('datatable-row-even');
+    component.rowIndex = { index: 3 };
+    fixture.detectChanges();
+    expect(element.classList).toContain('datatable-row-odd');
+  });
+
+  it('should apply event odd/even if row is grouped', () => {
+    component.rowIndex = { index: 1, indexInGroup: 0 };
+    fixture.detectChanges();
+    const element = fixture.debugElement.query(By.directive(DataTableBodyRowComponent))
+      .nativeElement as HTMLElement;
+    expect(element.classList).toContain('datatable-row-even');
+    component.rowIndex = { index: 666, indexInGroup: 3 };
+    fixture.detectChanges();
+    expect(element.classList).toContain('datatable-row-odd');
+  });
+});

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -19,7 +19,12 @@ import {
 import { columnGroupWidths, columnsByPin, columnsByPinArr } from '../../utils/column';
 import { Keys } from '../../utils/keys';
 import { ActivateEvent, RowOrGroup, TreeStatus } from '../../types/public.types';
-import { ColumnGroupWidth, PinnedColumns, TableColumnInternal } from '../../types/internal.types';
+import {
+  ColumnGroupWidth,
+  PinnedColumns,
+  RowIndex,
+  TableColumnInternal
+} from '../../types/internal.types';
 import { DataTableBodyCellComponent } from './body-cell.component';
 
 @Component({
@@ -89,7 +94,7 @@ export class DataTableBodyRowComponent<TRow = any> implements DoCheck, OnChanges
   @Input() row: TRow;
   @Input() group: TRow[];
   @Input() isSelected: boolean;
-  @Input() rowIndex: number;
+  @Input() rowIndex: RowIndex | undefined;
   @Input() displayCheck?: (row: TRow, column: TableColumnInternal, value?: any) => boolean;
   @Input() treeStatus?: TreeStatus = 'collapsed';
   @Input() ghostLoadingIndicator = false;
@@ -103,10 +108,10 @@ export class DataTableBodyRowComponent<TRow = any> implements DoCheck, OnChanges
     if (this.isSelected) {
       cls += ' active';
     }
-    if (this.rowIndex % 2 !== 0) {
+    if (this.innerRowIndex % 2 !== 0) {
       cls += ' datatable-row-odd';
     }
-    if (this.rowIndex % 2 === 0) {
+    if (this.innerRowIndex % 2 === 0) {
       cls += ' datatable-row-even';
     }
     if (this.disabled) {
@@ -216,5 +221,10 @@ export class DataTableBodyRowComponent<TRow = any> implements DoCheck, OnChanges
 
   onTreeAction() {
     this.treeAction.emit();
+  }
+
+  /** Returns the row index, or if in a group, the index within a group. */
+  private get innerRowIndex(): number {
+    return this.rowIndex?.indexInGroup ?? this.rowIndex?.index ?? 0;
   }
 }

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
@@ -29,7 +29,7 @@ function noopSumFunc(cells: any[]): void {
         [columns]="_internalColumns"
         [rowHeight]="rowHeight"
         [row]="summaryRow"
-        [rowIndex]="-1"
+        [rowIndex]="{ index: -1 }"
       >
       </datatable-body-row>
     }

--- a/projects/ngx-datatable/src/lib/types/internal.types.ts
+++ b/projects/ngx-datatable/src/lib/types/internal.types.ts
@@ -76,3 +76,11 @@ export interface TableColumnGroup {
   center: TableColumnInternal[];
   right: TableColumnInternal[];
 }
+
+/** Represents the index of a row. */
+export interface RowIndex {
+  /** Index of the row. If the row is inside a group, it will hold the index the group. */
+  index: number;
+  /** Index of a row inside a group. Only present if the row is inside a group. */
+  indexInGroup?: number;
+}

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -68,6 +68,7 @@ export interface CellContext<TRow = any> {
   rowHeight: number;
   isSelected: boolean;
   rowIndex: number;
+  rowInGroupIndex?: number;
   treeStatus: TreeStatus;
   disabled: boolean;
   onTreeAction: () => void;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When using groups, all rows are marked as `odd`.

**What is the new behavior?**

When using groups, all rows are marked as `even` / `odd` toggling in their group. So, the first element in a group will always be `even`.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No (except for the correct typing, but since this is not released, we don't need a notice here.

If this PR contains a breaking change, please describe the impact and migration path for existing applications: 

Previously `CellContext.rowIndex` was a `string` if the row was inside a group. Now `CellContext.rowIndex` is always a number, either containing the index of the row or if the row is inside a group, the index of the group.
To access the index value of a row within a group, use the new `CellContext.rowInGroupIndex`.

**Other information**:
