### PR TITLE
fix: add missing space before headerClass (#138)

### DIFF
--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -136,7 +136,7 @@ export class DataTableHeaderCellComponent implements OnInit {
         });
 
         if (typeof res === 'string') {
-          cls += res;
+          cls += ' ' + res;
         } else if (typeof res === 'object') {
           const keys = Object.keys(res);
           for (const k of keys) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

#138 

**What is the new behavior?**

This PR adds the missing space, as described in #138 

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

If you are very, very strict, this is a breaking change for the few people, that used a string returning function for `headerClass` and that did not realize, that their class is not getting applied.

**Other information**:
