### PR TITLE
ci: split e2e into separate job

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -14,58 +14,34 @@ jobs:
         with:
           node-version: lts/iron
 
+        # We cannot use built-in LFS functionality due to the missing support of custom LFS endpoints.
+        # See: https://github.com/actions/checkout/issues/365
       - name: Pull Repository with LFS
         run: git lfs pull
 
       - name: Install
-        uses: bahmutov/npm-install@v1
+        run: npm ci
 
       - name: Build and package library
-        run: |
-          npm run package --if-present
-        env:
-          CI: true
+        run: npm run package
 
       - name: Format
-        run: |
-          npm run format:check --if-present
-        env:
-          CI: true
+        run: npm run format:check
 
       - name: Build
-        run: |
-          npm run build --if-present
-        env:
-          CI: true
+        run: npm run build
 
-      - name: Test
-        run: |
-          npm run ci --if-present
-        env:
-          CI: true
-
-      - name: E2E
-        uses: addnab/docker-run-action@v3
-        with:
-          image: mcr.microsoft.com/playwright:v1.46.0-jammy
-          options: --ipc=host -v ${{ github.workspace }}:/workspace -w /workspace
-          run: |
-            npm run e2e --if-present
-        env:
-          CI: true
-
-      - name: Upload E2E Results
-        if: always()
+      - name: Archive build
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-results
-          path: playwright/results
+          name: build
+          path: dist/ngx-datatable
+
+      - name: Test
+        run: npm run ci
 
       - name: Build Docs
-        run: |
-          npm run build-docs --if-present
-        env:
-          CI: true
+        run: npm run build-docs
 
       - name: Deploy Docs
         uses: JamesIves/github-pages-deploy-action@4.1.5
@@ -73,3 +49,39 @@ jobs:
           branch: gh-pages
           folder: dist/ngx-datatable
         if: ${{ github.ref == 'refs/heads/master' }}
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    container: mcr.microsoft.com/playwright:v1.46.0-jammy
+    steps:
+      # The LFS situation is even worse here. As we are in another container, we need to install LFS manually.
+      - name: Install LFS
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+          apt install git-lfs
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Pull Repository with LFS
+        run: git lfs pull
+
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: dist/ngx-datatable
+
+      - name: Install
+        run: npm ci
+
+      - name: E2E
+        run: npm run e2e
+
+      - name: Upload E2E Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results
+          path: playwright/results

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -58,18 +58,11 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: isCI
     ? [
+        ['github'],
         [
           'html',
           {
-            open: 'on-failure',
             outputFolder: './playwright/results/preview'
-          }
-        ],
-        [
-          'junit',
-          {
-            outputFile: `./playwright/results/reports/report-e2e.xml`,
-            includeProjectInTestName: true
           }
         ],
         [
@@ -87,15 +80,6 @@ export default defineConfig({
           {
             open: isContainer ? 'never' : 'on-failure',
             outputFolder: './playwright/results/preview'
-          }
-        ],
-        [
-          'junit',
-          {
-            outputFile: `./playwright/results/reports/report-${
-              isA11y && isVrt ? 'e2e' : isA11y ? 'a11y' : 'vrt'
-            }.xml`,
-            includeProjectInTestName: true
           }
         ],
         [


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

CI runs html report server if e2e fails and creates an a11y report that is not used.

**What is the new behavior?**

CI uses github reporter and do not run an http server or generates an unused unit report.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
