### PR TITLE
refactor: only export symbols that are meant to be exported

### DIFF
--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -2,7 +2,6 @@ import { ModuleWithProviders, NgModule } from '@angular/core';
 import { DataTableFooterTemplateDirective } from './components/footer/footer-template.directive';
 import { DatatableComponent } from './components/datatable.component';
 import { DataTableColumnDirective } from './components/columns/column.directive';
-import { DataTablePagerComponent } from './components/footer/pager.component';
 import { DatatableRowDetailDirective } from './components/row-detail/row-detail.directive';
 import { DatatableGroupHeaderDirective } from './components/body/body-group-header.directive';
 import { DatatableRowDetailTemplateDirective } from './components/row-detail/row-detail-template.directive';
@@ -23,7 +22,6 @@ import {
     DataTableFooterTemplateDirective,
     DatatableComponent,
     DataTableColumnDirective,
-    DataTablePagerComponent,
     DatatableRowDetailDirective,
     DatatableGroupHeaderDirective,
     DatatableRowDetailTemplateDirective,
@@ -49,7 +47,6 @@ import {
     DataTableColumnCellTreeToggle,
     DataTableFooterTemplateDirective,
     DatatableFooterDirective,
-    DataTablePagerComponent,
     DatatableGroupHeaderTemplateDirective,
     DisableRowDirective,
     DatatableRowDefComponent,

--- a/projects/ngx-datatable/src/public-api.ts
+++ b/projects/ngx-datatable/src/public-api.ts
@@ -5,20 +5,8 @@
 // components
 export * from './lib/ngx-datatable.module';
 export * from './lib/components/datatable.component';
-export * from './lib/components/header/header.component';
-export * from './lib/components/header/header-cell.component';
-export * from './lib/components/body/body.component';
-export * from './lib/components/body/body-cell.component';
-export * from './lib/components/body/body-row.component';
-export * from './lib/components/body/progress-bar.component';
-export * from './lib/components/body/scroller.component';
-export * from './lib/components/body/body-row-wrapper.component';
-export * from './lib/components/body/selection.component';
 export * from './lib/components/body/body-group-header.directive';
 export * from './lib/components/body/body-group-header-template.directive';
-export * from './lib/components/body/summary/summary-row.component';
-export * from './lib/components/footer/footer.component';
-export * from './lib/components/footer/pager.component';
 export * from './lib/components/footer/footer.directive';
 export * from './lib/components/footer/footer-template.directive';
 export * from './lib/components/columns/column.directive';
@@ -31,31 +19,8 @@ export * from './lib/components/row-detail/row-detail-template.directive';
 export * from './lib/components/body/body-row-def.component';
 
 // directives
-export * from './lib/directives/draggable.directive';
-export * from './lib/directives/long-press.directive';
-export * from './lib/directives/orderable.directive';
-export * from './lib/directives/resizeable.directive';
-export * from './lib/directives/visibility.directive';
 export * from './lib/directives/disable-row.directive';
-
-// services
-export * from './lib/services/scrollbar-helper.service';
-export * from './lib/services/column-changes.service';
 
 // types
 export * from './lib/types/public.types';
 export * from './lib/types/table-column.type';
-
-// utils
-export * from './lib/utils/id';
-export * from './lib/utils/column';
-export * from './lib/utils/column-prop-getters';
-export * from './lib/utils/camel-case';
-export * from './lib/utils/keys';
-export * from './lib/utils/math';
-export * from './lib/utils/selection';
-export * from './lib/utils/throttle';
-export * from './lib/utils/sort';
-export * from './lib/utils/row-height-cache';
-export * from './lib/utils/column-helper';
-export * from './lib/utils/tree';


### PR DESCRIPTION
BREAKING CHANGE: Removed several symbols from the public API that were intended to be internal.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Exports everything.

**What is the new behavior?**

Only export symbols that are meant to be used outside.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
