### PR TITLE
fix: allow partial overrides of CSS classes

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -353,15 +353,7 @@ export class DatatableComponent<TRow = any>
   /**
    * Css class overrides
    */
-  @Input() cssClasses: Partial<INgxDatatableConfig['cssClasses']> = {
-    sortAscending: 'datatable-icon-up',
-    sortDescending: 'datatable-icon-down',
-    sortUnset: 'datatable-icon-sort-unset',
-    pagerLeftArrow: 'datatable-icon-left',
-    pagerRightArrow: 'datatable-icon-right',
-    pagerPrevious: 'datatable-icon-prev',
-    pagerNext: 'datatable-icon-skip'
-  };
+  @Input() cssClasses: Partial<INgxDatatableConfig['cssClasses']> = {};
 
   /**
    * Message overrides for localization

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
@@ -57,10 +57,10 @@ export class DataTableFooterComponent {
   @Input() rowCount: number;
   @Input() pageSize: number;
   @Input() offset: number;
-  @Input() pagerLeftArrowIcon: string;
-  @Input() pagerRightArrowIcon: string;
-  @Input() pagerPreviousIcon: string;
-  @Input() pagerNextIcon: string;
+  @Input() pagerLeftArrowIcon?: string;
+  @Input() pagerRightArrowIcon?: string;
+  @Input() pagerPreviousIcon?: string;
+  @Input() pagerNextIcon?: string;
   @Input() totalMessage: string;
   @Input() footerTemplate: DatatableFooterDirective;
 

--- a/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
@@ -8,12 +8,12 @@ import { Page } from '../../types/internal.types';
     <ul class="pager">
       <li [class.disabled]="!canPrevious()">
         <a role="button" aria-label="go to first page" (click)="selectPage(1)">
-          <i class="{{ pagerPreviousIcon }}"></i>
+          <i class="{{ pagerPreviousIcon ?? 'datatable-icon-prev' }}"></i>
         </a>
       </li>
       <li [class.disabled]="!canPrevious()">
         <a role="button" aria-label="go to previous page" (click)="prevPage()">
-          <i class="{{ pagerLeftArrowIcon }}"></i>
+          <i class="{{ pagerLeftArrowIcon ?? 'datatable-icon-left' }}"></i>
         </a>
       </li>
       @for (pg of pages; track pg.number) {
@@ -29,12 +29,12 @@ import { Page } from '../../types/internal.types';
       }
       <li [class.disabled]="!canNext()">
         <a role="button" aria-label="go to next page" (click)="nextPage()">
-          <i class="{{ pagerRightArrowIcon }}"></i>
+          <i class="{{ pagerRightArrowIcon ?? 'datatable-icon-right' }}"></i>
         </a>
       </li>
       <li [class.disabled]="!canNext()">
         <a role="button" aria-label="go to last page" (click)="selectPage(totalPages)">
-          <i class="{{ pagerNextIcon }}"></i>
+          <i class="{{ pagerNextIcon ?? 'datatable-icon-skip' }}"></i>
         </a>
       </li>
     </ul>
@@ -46,10 +46,10 @@ import { Page } from '../../types/internal.types';
   standalone: true
 })
 export class DataTablePagerComponent {
-  @Input() pagerLeftArrowIcon: string;
-  @Input() pagerRightArrowIcon: string;
-  @Input() pagerPreviousIcon: string;
-  @Input() pagerNextIcon: string;
+  @Input() pagerLeftArrowIcon?: string;
+  @Input() pagerRightArrowIcon?: string;
+  @Input() pagerPreviousIcon?: string;
+  @Input() pagerNextIcon?: string;
 
   @Input()
   set size(val: number) {

--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -66,9 +66,9 @@ export class DataTableHeaderCellComponent implements OnInit {
   private cd = inject(ChangeDetectorRef);
 
   @Input() sortType: SortType;
-  @Input() sortAscendingIcon: string;
-  @Input() sortDescendingIcon: string;
-  @Input() sortUnsetIcon: string;
+  @Input() sortAscendingIcon?: string;
+  @Input() sortDescendingIcon?: string;
+  @Input() sortUnsetIcon?: string;
 
   @Input() isTarget: boolean;
   @Input() targetMarkerTemplate: TemplateRef<any>;
@@ -256,11 +256,11 @@ export class DataTableHeaderCellComponent implements OnInit {
       return;
     }
     if (sortDir === SortDirection.asc) {
-      return `sort-btn sort-asc ${this.sortAscendingIcon}`;
+      return `sort-btn sort-asc ${this.sortAscendingIcon ?? 'datatable-icon-up'}`;
     } else if (sortDir === SortDirection.desc) {
-      return `sort-btn sort-desc ${this.sortDescendingIcon}`;
+      return `sort-btn sort-desc ${this.sortDescendingIcon ?? 'datatable-icon-down'}`;
     } else {
-      return `sort-btn ${this.sortUnsetIcon}`;
+      return `sort-btn ${this.sortUnsetIcon ?? 'datatable-icon-sort-unset'}`;
     }
   }
 }

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -108,9 +108,9 @@ export class DataTableHeaderComponent implements OnDestroy, OnChanges {
   private cd = inject(ChangeDetectorRef);
   private scrollbarHelper = inject(ScrollbarHelper);
 
-  @Input() sortAscendingIcon: string;
-  @Input() sortDescendingIcon: string;
-  @Input() sortUnsetIcon: string;
+  @Input() sortAscendingIcon?: string;
+  @Input() sortDescendingIcon?: string;
+  @Input() sortUnsetIcon?: string;
   @Input() scrollbarH: boolean;
   @Input() dealsWithGroup: boolean;
   @Input() targetMarkerTemplate: TemplateRef<unknown>;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Although the type says diffrently one always needed to set every CSS class.

**What is the new behavior?**

Now one can only override partial CSS classes and the other defaults will be kept.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This is part of a larger refactoring to enable strictNullChecks