### PR TITLE
refactor: use interface for row properties that may be set by the dat…

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -22,6 +22,7 @@ import { BehaviorSubject } from 'rxjs';
 import {
   ActivateEvent,
   CellContext,
+  Row,
   RowOrGroup,
   SortDirection,
   SortPropDir,
@@ -99,9 +100,7 @@ import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
   standalone: true,
   imports: [NgTemplateOutlet, DataTableGhostLoaderComponent, AsyncPipe]
 })
-export class DataTableBodyCellComponent<TRow extends { level?: number } = any>
-  implements DoCheck, OnDestroy
-{
+export class DataTableBodyCellComponent<TRow extends Row = any> implements DoCheck, OnDestroy {
   private cd = inject(ChangeDetectorRef);
 
   @Input() displayCheck: (row: RowOrGroup<TRow>, column: TableColumn, value: any) => boolean;

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -28,10 +28,10 @@ import {
   ActivateEvent,
   DragEventData,
   Group,
+  Row,
   RowOrGroup,
   ScrollEvent,
-  SelectionType,
-  TreeStatus
+  SelectionType
 } from '../../types/public.types';
 import { DraggableDirective } from '../../directives/draggable.directive';
 import { DatatableRowDefInternalDirective } from './body-row-def.component';
@@ -261,9 +261,7 @@ import { DataTableGhostLoaderComponent } from './ghost-loader/ghost-loader.compo
     DraggableDirective
   ]
 })
-export class DataTableBodyComponent<TRow extends { treeStatus?: TreeStatus } = any>
-  implements OnInit, OnDestroy
-{
+export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, OnDestroy {
   cd = inject(ChangeDetectorRef);
 
   @Input() rowDefTemplate?: TemplateRef<any>;

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -56,6 +56,7 @@ import {
   PageEvent,
   PagerPageEvent,
   ReorderEvent,
+  Row,
   RowOrGroup,
   ScrollEvent,
   SelectionType,
@@ -96,7 +97,7 @@ import { ProgressBarComponent } from './body/progress-bar.component';
     ProgressBarComponent
   ]
 })
-export class DatatableComponent<TRow = any>
+export class DatatableComponent<TRow extends Row = any>
   implements OnInit, DoCheck, AfterViewInit, AfterContentInit, OnDestroy
 {
   private scrollbarHelper = inject(ScrollbarHelper);

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -109,6 +109,16 @@ export interface RowDetailContext<TRow = any> {
   disableRow$?: Observable<boolean>;
 }
 
+/**
+ * Consumer provided rows should extend this interface
+ * to get access to implicit row properties which are set by the datatable if required.
+ */
+export interface Row {
+  [key: TableColumnProp]: any;
+  treeStatus?: TreeStatus;
+  level?: number;
+}
+
 export interface ReorderEvent {
   column: TableColumn;
   prevValue: number;


### PR DESCRIPTION
…atable

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Some components add properties to the row type if they need it.
This is causing conflicts when passing rows between components if stricter compiler checks are enabled.

**What is the new behavior?**

There is a common interface for those extra row types. So that we can use it everywhere if needed.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
This is part of a larger refactoring to enable strictNullChecks