### PR TITLE
refactor: always use type event

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -321,7 +321,7 @@ export class DataTableBodyCellComponent<TRow extends { level?: number } = any>
 
   constructor() {
     this.cellContext = {
-      onCheckboxChangeFn: (event: MouseEvent | KeyboardEvent) => this.onCheckboxChange(event),
+      onCheckboxChangeFn: (event: Event) => this.onCheckboxChange(event),
       activateFn: (event: ActivateEvent<TRow>) => this.activate.emit(event),
       row: this.row,
       group: this.group,
@@ -441,7 +441,7 @@ export class DataTableBodyCellComponent<TRow extends { level?: number } = any>
     }
   }
 
-  onCheckboxChange(event: MouseEvent | KeyboardEvent): void {
+  onCheckboxChange(event: Event): void {
     this.activate.emit({
       type: 'checkbox',
       event,

--- a/projects/ngx-datatable/src/lib/components/body/selection.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/selection.component.ts
@@ -18,12 +18,12 @@ export class DataTableSelectionComponent<TRow = any> {
   @Input() selectCheck: (value: TRow, index: number, array: TRow[]) => boolean;
   @Input() disableCheck: (row: TRow) => boolean;
 
-  @Output() activate: EventEmitter<ActivateEvent<TRow>> = new EventEmitter();
-  @Output() select: EventEmitter<{ selected: TRow[] }> = new EventEmitter();
+  @Output() activate = new EventEmitter<ActivateEvent<TRow>>();
+  @Output() select = new EventEmitter<{ selected: TRow[] }>();
 
   prevIndex: number;
 
-  selectRow(event: KeyboardEvent | MouseEvent, index: number, row: TRow): void {
+  selectRow(event: Event, index: number, row: TRow): void {
     if (!this.selectEnabled) {
       return;
     }
@@ -33,13 +33,22 @@ export class DataTableSelectionComponent<TRow = any> {
     const multiClick = this.selectionType === SelectionType.multiClick;
     let selected: TRow[] = [];
 
+    // TODO: this code needs cleanup. Casting it to KeyboardEvent is not correct as it could also be other types.
     if (multi || chkbox || multiClick) {
-      if (event.shiftKey) {
+      if ((event as KeyboardEvent).shiftKey) {
         selected = selectRowsBetween([], this.rows, index, this.prevIndex);
-      } else if ((event as KeyboardEvent).key === 'a' && (event.ctrlKey || event.metaKey)) {
+      } else if (
+        (event as KeyboardEvent).key === 'a' &&
+        ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey)
+      ) {
         // select all rows except dummy rows which are added for ghostloader in case of virtual scroll
         selected = this.rows.filter(rowItem => !!rowItem);
-      } else if (event.ctrlKey || event.metaKey || multiClick || chkbox) {
+      } else if (
+        (event as KeyboardEvent).ctrlKey ||
+        (event as KeyboardEvent).metaKey ||
+        multiClick ||
+        chkbox
+      ) {
         selected = selectRows([...this.selected], row, this.getRowSelectedIdx.bind(this));
       } else {
         selected = selectRows([], row, this.getRowSelectedIdx.bind(this));
@@ -77,7 +86,10 @@ export class DataTableSelectionComponent<TRow = any> {
     } else if (type === 'keydown') {
       if ((event as KeyboardEvent).key === Keys.return) {
         this.selectRow(event, index, row);
-      } else if ((event as KeyboardEvent).key === 'a' && (event.ctrlKey || event.metaKey)) {
+      } else if (
+        (event as KeyboardEvent).key === 'a' &&
+        ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey)
+      ) {
         this.selectRow(event, 0, this.rows[this.rows.length - 1]);
       } else {
         this.onKeyboardFocus(model);

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -36,7 +36,7 @@ export type TreeStatus = 'collapsed' | 'expanded' | 'loading' | 'disabled';
 
 export interface ActivateEvent<TRow> {
   type: 'checkbox' | 'click' | 'dblclick' | 'keydown' | 'mouseenter';
-  event: MouseEvent | KeyboardEvent;
+  event: Event;
   row: TRow;
   group?: TRow[];
   rowHeight?: number;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

We sometimes declare an event around our `ActivationEvent` as `MouseEvent | KeyboardEvent` which is wrong in that case 
as a row may also gets activated by a checkbox change which Emits a normal `Event`.

**What is the new behavior?**

Just declare everything as `Event` and add necessary type casts.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Public API is affected, but only the a new type which is not typed in the latest release anyway. So refactoring scope is correct here.