### PR TITLE
fix: allow ctrl-a inside inputs

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -185,7 +185,15 @@ export class DataTableBodyRowComponent<TRow = any> implements DoCheck, OnChanges
       key === Keys.left ||
       key === Keys.right;
 
-    const isCtrlA = event.key === 'a' && (event.ctrlKey || event.metaKey);
+    const isCtrlA =
+      event.key === 'a' &&
+      (event.ctrlKey || event.metaKey) &&
+      (!event.target ||
+        !(event.target instanceof HTMLElement) ||
+        ((!event.target.closest('input') ||
+          event.target.closest('input[type=checkbox]') ||
+          event.target.closest('input[type=radio]')) &&
+          !event.target.closest('textarea')));
 
     if ((isAction && isTargetRow) || isCtrlA) {
       event.preventDefault();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

If an input is inside a custom template, ctrl/cmd + a doesn't work (because of the row selection logic)

**What is the new behavior?**

Excludes if the event occurs inside of an input/textarea (except checkbox and radio)

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
