### PR TITLE
fix: only run disabled check on rows

### DIFF
--- a/playwright/e2e/row-disabled.spec.ts
+++ b/playwright/e2e/row-disabled.spec.ts
@@ -1,0 +1,14 @@
+import { test } from '../support/test-helpers';
+
+test('disabled rows', async ({ si, page }) => {
+  await si.visitExample('disabled');
+  await page
+    .getByRole('row', { name: 'Merritt Booker' })
+    .getByRole('button', { name: 'Disable row' })
+    .click();
+  await si.runVisualAndA11yTests(undefined, [
+    { id: 'color-contrast', enabled: false },
+    { id: 'label', enabled: false },
+    { id: 'select-name', enabled: false }
+  ]);
+});

--- a/playwright/snapshots/e2e/row-disabled.spec.ts-snapshots/disabled-chromium-linux.png
+++ b/playwright/snapshots/e2e/row-disabled.spec.ts-snapshots/disabled-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da4606a7a5aa0d295588c2955d881d989c0aa0c316af9078d91648e38867f1ca
+size 73082

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -18,9 +18,7 @@ import {
 
 import { columnGroupWidths, columnsByPin, columnsByPinArr } from '../../utils/column';
 import { Keys } from '../../utils/keys';
-import { BehaviorSubject } from 'rxjs';
 import { ActivateEvent, RowOrGroup, TreeStatus } from '../../types/public.types';
-import { AsyncPipe } from '@angular/common';
 import { TableColumn } from '../../types/table-column.type';
 import { ColumnGroupWidth, PinnedColumns } from '../../types/internal.types';
 import { DataTableBodyCellComponent } from './body-cell.component';
@@ -33,7 +31,7 @@ import { DataTableBodyCellComponent } from './body-cell.component';
       <div
         class="datatable-row-{{ colGroup.type }} datatable-row-group"
         [style.width.px]="_columnGroupWidths[colGroup.type]"
-        [class.row-disabled]="disable$ ? (disable$ | async) : false"
+        [class.row-disabled]="disabled"
       >
         @for (column of colGroup.columns; track column.$$id; let ii = $index) {
           <datatable-body-cell
@@ -47,7 +45,7 @@ import { DataTableBodyCellComponent } from './body-cell.component';
             [column]="column"
             [rowHeight]="rowHeight"
             [displayCheck]="displayCheck"
-            [disable$]="disable$"
+            [disabled]="disabled"
             [treeStatus]="treeStatus"
             [ghostLoadingIndicator]="ghostLoadingIndicator"
             (activate)="onActivate($event, ii)"
@@ -59,7 +57,7 @@ import { DataTableBodyCellComponent } from './body-cell.component';
     }
   `,
   standalone: true,
-  imports: [DataTableBodyCellComponent, AsyncPipe]
+  imports: [DataTableBodyCellComponent]
 })
 export class DataTableBodyRowComponent<TRow = any> implements DoCheck, OnChanges {
   private cd = inject(ChangeDetectorRef);
@@ -98,7 +96,7 @@ export class DataTableBodyRowComponent<TRow = any> implements DoCheck, OnChanges
   @Input() ghostLoadingIndicator = false;
   @Input() verticalScrollVisible = false;
 
-  @Input() disable$: BehaviorSubject<boolean>;
+  @Input() disabled: boolean;
 
   @HostBinding('class')
   get cssClass() {
@@ -112,7 +110,7 @@ export class DataTableBodyRowComponent<TRow = any> implements DoCheck, OnChanges
     if (this.rowIndex % 2 === 0) {
       cls += ' datatable-row-even';
     }
-    if (this.disable$ && this.disable$.value) {
+    if (this.disabled) {
       cls += ' row-disabled';
     }
 

--- a/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -1,13 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { DataTableBodyComponent } from './body.component';
 import { DataTableBodyRowComponent } from './body-row.component';
-import { DataTableRowWrapperComponent } from './body-row-wrapper.component';
-import { DataTableBodyCellComponent } from './body-cell.component';
-import { DataTableSelectionComponent } from './selection.component';
-import { DataTableSummaryRowComponent } from './summary/summary-row.component';
-import { ProgressBarComponent } from './progress-bar.component';
-import { ScrollerComponent } from './scroller.component';
 import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
+import { By } from '@angular/platform-browser';
+import { DatatableComponentToken } from '../../utils/table-token';
 
 describe('DataTableBodyComponent', () => {
   let fixture: ComponentFixture<DataTableBodyComponent>;
@@ -16,17 +12,8 @@ describe('DataTableBodyComponent', () => {
   // provide our implementations or mocks to the dependency injector
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        DataTableBodyComponent,
-        DataTableBodyRowComponent,
-        DataTableRowWrapperComponent,
-        DataTableBodyCellComponent,
-        DataTableSelectionComponent,
-        DataTableSummaryRowComponent,
-        ProgressBarComponent,
-        ScrollerComponent
-      ],
-      providers: [ScrollbarHelper]
+      imports: [DataTableBodyComponent],
+      providers: [ScrollbarHelper, { provide: DatatableComponentToken, useValue: {} }]
     });
   });
 
@@ -108,6 +95,57 @@ describe('DataTableBodyComponent', () => {
       const expectedIndexes = { first: 0, last: 5 };
       component.updateIndexes();
       expect(component.indexes()).toEqual(expectedIndexes);
+    });
+  });
+
+  describe('with disableCheck', () => {
+    beforeEach(() => {
+      component.columns = [{ name: 'value', $$id: 'id', $$valueGetter: obj => obj.value }];
+      component.disableRowCheck = (row: any) => row.disabled;
+    });
+
+    it('should disable rows', () => {
+      component.rows = [
+        { value: '1', disabled: false },
+        { value: '2', disabled: true }
+      ];
+      component.rowCount = 2;
+      component.pageSize = 2;
+      component.offset = 0;
+      component.updateIndexes();
+      fixture.detectChanges();
+      let rows = fixture.debugElement.queryAll(By.directive(DataTableBodyRowComponent));
+      expect(rows[0].classes['row-disabled']).toBeFalsy();
+      expect(rows[1].classes['row-disabled']).toBeTrue();
+      component.rows = [
+        { value: '1', disabled: true },
+        { value: '2', disabled: false }
+      ];
+      fixture.detectChanges();
+      rows = fixture.debugElement.queryAll(By.directive(DataTableBodyRowComponent));
+      expect(rows[0].classes['row-disabled']).toBeTrue();
+      expect(rows[1].classes['row-disabled']).toBeFalsy();
+    });
+
+    it('should disable grouped rows', () => {
+      component.groupedRows = [
+        {
+          key: 'g1',
+          value: [
+            { value: '1', disabled: false },
+            { value: '2', disabled: true }
+          ]
+        }
+      ];
+      component.rows = ['dummy'];
+      component.rowCount = 2;
+      component.pageSize = 2;
+      component.offset = 0;
+      component.updateIndexes();
+      fixture.detectChanges();
+      const rows = fixture.debugElement.queryAll(By.directive(DataTableBodyRowComponent));
+      expect(rows[0].classes['row-disabled']).toBeFalsy();
+      expect(rows[1].classes['row-disabled']).toBeTrue();
     });
   });
 

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -90,8 +90,8 @@ import { DataTableGhostLoaderComponent } from './ghost-loader/ghost-loader.compo
             </datatable-summary-row>
           }
           @for (group of rowsToRender(); track rowTrackingFn(i, group); let i = $index) {
+            @let disabled = isRow(group) && disableRowCheck && disableRowCheck(group);
             <datatable-row-wrapper
-              #rowWrapper
               [attr.hidden]="
                 ghostLoadingIndicator && (!rowCount || !virtualization || !scrollbarV) ? true : null
               "
@@ -104,7 +104,7 @@ import { DataTableGhostLoaderComponent } from './ghost-loader/ghost-loader.compo
               [detailRowHeight]="getDetailRowHeight(group && group[i], i)"
               [groupHeaderRowHeight]="getGroupHeaderRowHeight(group && group[i], i)"
               [row]="group"
-              [disableCheck]="disableRowCheck"
+              [disabled]="disabled"
               [expanded]="getRowExpanded(group)"
               [rowIndex]="getRowIndex(group && group[i])"
               [selected]="selected"
@@ -125,7 +125,7 @@ import { DataTableGhostLoaderComponent } from './ghost-loader/ghost-loader.compo
                     role="row"
                     tabindex="-1"
                     #rowElement
-                    [disable$]="rowWrapper.disable$"
+                    [disabled]="disabled"
                     [isSelected]="selector.getRowSelected(group)"
                     [innerWidth]="innerWidth"
                     [columns]="columns"
@@ -158,7 +158,7 @@ import { DataTableGhostLoaderComponent } from './ghost-loader/ghost-loader.compo
                     role="row"
                     tabindex="-1"
                     #rowElement
-                    [disable$]="rowWrapper.disable$"
+                    [disabled]="disabled"
                     [isSelected]="selector.getRowSelected(group)"
                     [innerWidth]="innerWidth"
                     [columns]="columns"
@@ -188,9 +188,10 @@ import { DataTableGhostLoaderComponent } from './ghost-loader/ghost-loader.compo
               @if (isGroup(group)) {
                 <!-- The row typecast is due to angular compiler acting weird. It is obvious that it is of type TRow, but the compiler does not understand. -->
                 @for (row of group.value; track rowTrackingFn(i, row); let i = $index) {
+                  @let rowInGroupDisabled = disableRowCheck && disableRowCheck(row);
                   <datatable-body-row
                     role="row"
-                    [disable$]="rowWrapper.disable$"
+                    [disabled]="rowInGroupDisabled"
                     tabindex="-1"
                     #rowElement
                     [isSelected]="selector.getRowSelected(row)"

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -1,5 +1,4 @@
 import { TableColumn, TableColumnProp } from './table-column.type';
-import { BehaviorSubject, Observable } from 'rxjs';
 
 export interface SortPropDir {
   dir: SortDirection | 'desc' | 'asc';
@@ -73,7 +72,7 @@ export interface CellContext<TRow = any> {
   isSelected: boolean;
   rowIndex: number;
   treeStatus: TreeStatus;
-  disable$: BehaviorSubject<boolean>;
+  disabled: boolean;
   onTreeAction: () => void;
   expanded?: boolean;
 }
@@ -106,7 +105,7 @@ export interface RowDetailContext<TRow = any> {
   row: TRow;
   expanded: boolean;
   rowIndex: number;
-  disableRow$?: Observable<boolean>;
+  disabled: boolean;
 }
 
 /**

--- a/src/app/basic/disabled-rows.component.ts
+++ b/src/app/basic/disabled-rows.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { ColumnMode, SelectionType } from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
-import { BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'disabled-rows-demo',
@@ -34,7 +33,7 @@ import { BehaviorSubject } from 'rxjs';
               let-value="value"
               let-rowIndex="rowIndex"
               let-row="row"
-              let-disable$="disable$"
+              let-disabled="disabled"
               ngx-datatable-cell-template
             >
               {{ value }}
@@ -45,14 +44,14 @@ import { BehaviorSubject } from 'rxjs';
               let-value="value"
               let-rowIndex="rowIndex"
               let-row="row"
-              let-disable$="disable$"
+              let-disabled="disabled"
               ngx-datatable-cell-template
             >
               <select
                 [style.height]="'auto'"
                 [value]="value"
-                (change)="updateValue($event, 'gender', rowIndex, disable$)"
-                [disabled]="disable$ ? (disable$ | async) : false"
+                (change)="updateValue($event, 'gender', rowIndex)"
+                [disabled]="disabled"
                 [style.margin]="0"
               >
                 <option value="male">Male</option>
@@ -63,15 +62,15 @@ import { BehaviorSubject } from 'rxjs';
           <ngx-datatable-column name="Age">
             <ng-template
               let-row="row"
-              let-disable$="disable$"
+              let-disabled="disabled"
               let-rowIndex="rowIndex"
               let-value="value"
               ngx-datatable-cell-template
             >
-              <div [disabled]="disable$ | async" disable-row>
-                <input (blur)="updateValue($event, 'age', rowIndex, disable$)" [value]="value" />
+              <div [disabled]="disabled" disable-row>
+                <input (blur)="updateValue($event, 'age', rowIndex)" [value]="value" />
                 <br />
-                <button (click)="disableRow(rowIndex, disable$)">Disable row</button>
+                <button (click)="disableRow(rowIndex)">Disable row</button>
               </div>
             </ng-template>
           </ngx-datatable-column>
@@ -107,20 +106,19 @@ export class DisabledRowsComponent {
     return !(!row.isDisabled && row.age < 40);
   }
 
-  disableRow(rowIndex: number, disableRow$: BehaviorSubject<boolean>) {
+  disableRow(rowIndex: number) {
     this.rows[rowIndex].isDisabled = true;
     this.rows = [...this.rows];
-    disableRow$.next(true);
   }
 
-  updateValue(event, cell, rowIndex: number, disableRow$: BehaviorSubject<boolean>) {
+  updateValue(event, cell, rowIndex: number) {
     this.rows[rowIndex][cell] = event.target.value;
     this.rows = [...this.rows];
-    if (disableRow$ && cell === 'age' && this.rows[rowIndex][cell] > 40) {
-      disableRow$.next(true);
+    if (cell === 'age' && this.rows[rowIndex][cell] > 40) {
+      this.rows[rowIndex].isDisabled = true;
     }
-    if (disableRow$ && cell === 'gender' && this.rows[rowIndex][cell] === 'male') {
-      disableRow$.next(true);
+    if (cell === 'gender' && this.rows[rowIndex][cell] === 'male') {
+      this.rows[rowIndex].isDisabled = true;
     }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Previously, `disableRowCheck` was called on groups instead of rows inside a group.
But we  documented that this check is called on rows.
This was leading to the problem, that it was only possible to disable entire groups instead of single rows
within in a group.

Beside this, we had an observable in some template contexts, which is a very uncommon approach.

**What is the new behavior?**

`disableRowCheck` is only called on rows even if the rows are grouped.

The template context now only provide a normal boolean property instead of a subject.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

1. The row detail context (`RowDetailContext`) no longer contains `disableRow$?: Observable<boolean>`.
    Use the new `disabled: boolean` value instead.
2. The cell context (`CellContext`) no longer contains `disableRow$?: Observable<boolean>`.
    Use the new `disabled: boolean` value instead.
3. `disableRowCheck` will only be called with actual rows.
    Although documented otherwise, in the case of groups, the `disableRowCheck`
    was only called for groups instead of each row inside that group.
    This allows disabling single rows inside a group and not only entire groups.

    To update the disabled state of a row just update the row itself instead of using the previous `disableRow$` subject.
**Other information**:
