### PR TITLE
fix: add missing type to comparator

### DIFF
--- a/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
@@ -30,7 +30,13 @@ export class DataTableColumnDirective<TRow> implements TableColumn, OnChanges {
   @Input({ transform: booleanAttribute }) frozenRight: boolean;
   @Input({ transform: numberAttribute }) flexGrow: number;
   @Input({ transform: booleanAttribute }) resizeable: boolean;
-  @Input() comparator: any;
+  @Input() comparator: (
+    valueA: any,
+    valueB: any,
+    rowA: TRow,
+    rowB: TRow,
+    sortDir: 'desc' | 'asc'
+  ) => number;
   @Input() pipe: PipeTransform;
   @Input({ transform: booleanAttribute }) sortable: boolean;
   @Input({ transform: booleanAttribute }) draggable: boolean;

--- a/projects/ngx-datatable/src/lib/types/table-column.type.ts
+++ b/projects/ngx-datatable/src/lib/types/table-column.type.ts
@@ -74,7 +74,13 @@ export interface TableColumn<TRow = any> {
   /**
    * Custom sort comparator
    */
-  comparator?: any;
+  comparator?: (
+    valueA: any,
+    valueB: any,
+    rowA: TRow,
+    rowB: TRow,
+    sortDir: 'desc' | 'asc'
+  ) => number;
 
   /**
    * Custom pipe transforms


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Comparator function is typed as any.

**What is the new behavior?**

Comparator function is type as expected. See sort.ts for usage.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No, but broken types will now be unrevealed.

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
