### PR TITLE
refactor: add dedicated type for `SelectEvent`

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -31,6 +31,7 @@ import {
   Row,
   RowOrGroup,
   ScrollEvent,
+  SelectEvent,
   SelectionType
 } from '../../types/public.types';
 import { DraggableDirective } from '../../directives/draggable.directive';
@@ -389,7 +390,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   @Output() scroll = new EventEmitter<ScrollEvent>();
   @Output() page = new EventEmitter<number>();
   @Output() activate = new EventEmitter<ActivateEvent<TRow>>();
-  @Output() select = new EventEmitter<{ selected: TRow[] }>();
+  @Output() select = new EventEmitter<SelectEvent<TRow>>();
   @Output() detailToggle = new EventEmitter<any>();
   @Output() rowContextmenu = new EventEmitter<{ event: MouseEvent; row: RowOrGroup<TRow> }>(false);
   @Output() treeAction = new EventEmitter<{ row: TRow }>();

--- a/projects/ngx-datatable/src/lib/components/body/selection.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/selection.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { selectRows, selectRowsBetween } from '../../utils/selection';
 import { Keys } from '../../utils/keys';
-import { ActivateEvent, SelectionType } from '../../types/public.types';
+import { ActivateEvent, SelectEvent, SelectionType } from '../../types/public.types';
 
 @Component({
   selector: 'datatable-selection',
@@ -19,7 +19,7 @@ export class DataTableSelectionComponent<TRow = any> {
   @Input() disableCheck: (row: TRow) => boolean;
 
   @Output() activate = new EventEmitter<ActivateEvent<TRow>>();
-  @Output() select = new EventEmitter<{ selected: TRow[] }>();
+  @Output() select = new EventEmitter<SelectEvent<TRow>>();
 
   prevIndex: number;
 

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -59,6 +59,7 @@ import {
   Row,
   RowOrGroup,
   ScrollEvent,
+  SelectEvent,
   SelectionType,
   SortEvent,
   SortPropDir,
@@ -482,7 +483,7 @@ export class DatatableComponent<TRow extends Row = any>
   /**
    * A cell or row was selected.
    */
-  @Output() select = new EventEmitter<{ selected: TRow[] }>();
+  @Output() select = new EventEmitter<SelectEvent<TRow>>();
 
   /**
    * Column sort was invoked.
@@ -1257,7 +1258,7 @@ export class DatatableComponent<TRow extends Row = any>
   /**
    * A row was selected from body
    */
-  onBodySelect(event: { selected: TRow[] }): void {
+  onBodySelect(event: SelectEvent<TRow>): void {
     this.select.emit(event);
   }
 

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -166,6 +166,10 @@ export enum SelectionType {
   checkbox = 'checkbox'
 }
 
+export interface SelectEvent<TRow> {
+  selected: TRow[];
+}
+
 export type DragEventType =
   | 'drag'
   | 'dragend'

--- a/src/app/selection/selection-cell.component.ts
+++ b/src/app/selection/selection-cell.component.ts
@@ -1,5 +1,10 @@
 import { Component } from '@angular/core';
-import { ColumnMode, SelectionType, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  SelectEvent,
+  SelectionType,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -59,7 +64,7 @@ export class CellSelectionComponent {
     req.send();
   }
 
-  onSelect(event) {
+  onSelect(event: SelectEvent<Employee>) {
     console.log('Event: select', event, this.selected);
   }
 

--- a/src/app/selection/selection-chkbox-template.component.ts
+++ b/src/app/selection/selection-chkbox-template.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ColumnMode, SelectionType } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, SelectEvent, SelectionType } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -108,7 +108,7 @@ export class CustomCheckboxSelectionComponent {
     req.send();
   }
 
-  onSelect({ selected }) {
+  onSelect({ selected }: SelectEvent<Employee>) {
     console.log('Select Event', selected, this.selected);
 
     this.selected.splice(0, this.selected.length);

--- a/src/app/selection/selection-chkbox.component.ts
+++ b/src/app/selection/selection-chkbox.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ColumnMode, SelectionType } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, SelectEvent, SelectionType } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -97,7 +97,7 @@ export class CheckboxSelectionComponent {
     req.send();
   }
 
-  onSelect({ selected }) {
+  onSelect({ selected }: SelectEvent<Employee>) {
     console.log('Select Event', selected, this.selected);
 
     this.selected.splice(0, this.selected.length);

--- a/src/app/selection/selection-disabled.component.ts
+++ b/src/app/selection/selection-disabled.component.ts
@@ -1,5 +1,10 @@
 import { Component } from '@angular/core';
-import { ColumnMode, SelectionType, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  SelectEvent,
+  SelectionType,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -79,7 +84,7 @@ export class MultiDisableSelectionComponent {
     req.send();
   }
 
-  onSelect({ selected }) {
+  onSelect({ selected }: SelectEvent<Employee>) {
     console.log('Select Event', selected, this.selected);
 
     this.selected.splice(0, this.selected.length);

--- a/src/app/selection/selection-multi-click-chkbox.component.ts
+++ b/src/app/selection/selection-multi-click-chkbox.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ColumnMode, SelectionType } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, SelectEvent, SelectionType } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -98,7 +98,7 @@ export class MultiClickCheckboxSelectionComponent {
     req.send();
   }
 
-  onSelect({ selected }) {
+  onSelect({ selected }: SelectEvent<Employee>) {
     console.log('Select Event', selected, this.selected);
 
     this.selected.splice(0, this.selected.length);

--- a/src/app/selection/selection-multi-click.component.ts
+++ b/src/app/selection/selection-multi-click.component.ts
@@ -1,5 +1,10 @@
 import { Component } from '@angular/core';
-import { ColumnMode, SelectionType, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  SelectEvent,
+  SelectionType,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -82,7 +87,7 @@ export class MultiClickSelectionComponent {
     req.send();
   }
 
-  onSelect({ selected }) {
+  onSelect({ selected }: SelectEvent<Employee>) {
     console.log('Select Event', selected, this.selected);
 
     this.selected.splice(0, this.selected.length);

--- a/src/app/selection/selection-multi.component.ts
+++ b/src/app/selection/selection-multi.component.ts
@@ -1,5 +1,10 @@
 import { Component } from '@angular/core';
-import { ColumnMode, SelectionType, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  SelectEvent,
+  SelectionType,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -85,7 +90,7 @@ export class MultiSelectionComponent {
     req.send();
   }
 
-  onSelect({ selected }) {
+  onSelect({ selected }: SelectEvent<Employee>) {
     console.log('Select Event', selected, this.selected);
 
     this.selected.splice(0, this.selected.length);

--- a/src/app/selection/selection-single.component.ts
+++ b/src/app/selection/selection-single.component.ts
@@ -1,5 +1,10 @@
 import { Component } from '@angular/core';
-import { ColumnMode, SelectionType, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  SelectEvent,
+  SelectionType,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -86,7 +91,7 @@ export class SingleSelectionComponent {
     req.send();
   }
 
-  onSelect({ selected }) {
+  onSelect({ selected }: SelectEvent<Employee>) {
     console.log('Select Event', selected, this.selected);
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The `select` event does not have its own reusable type.

**What is the new behavior?**

The `select` event has its own reusable type which can be used in code when creating handler.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
