### PR TITLE
feat: add type for details toggle event

### DIFF
--- a/projects/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
@@ -1,6 +1,6 @@
 import { ContentChild, Directive, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
 import { DatatableRowDetailTemplateDirective } from './row-detail-template.directive';
-import { RowDetailContext } from '../../types/public.types';
+import { DetailToggleEvents, RowDetailContext } from '../../types/public.types';
 
 @Directive({
   selector: 'ngx-datatable-row-detail',
@@ -26,7 +26,7 @@ export class DatatableRowDetailDirective<TRow = any> {
   /**
    * Row detail row visbility was toggled.
    */
-  @Output() toggle = new EventEmitter<any>();
+  @Output() toggle = new EventEmitter<DetailToggleEvents<TRow>>();
 
   /**
    * Toggle the expansion of the row

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -158,6 +158,18 @@ export interface AllGroupsToggleEvent {
 
 export type GroupToggleEvents<TRow> = GroupToggleEvent<TRow> | AllGroupsToggleEvent;
 
+export interface DetailToggleEvent<TRow> {
+  type: 'row';
+  value: TRow;
+}
+
+export interface AllDetailToggleEvent {
+  type: 'all';
+  value: boolean;
+}
+
+export type DetailToggleEvents<TRow> = DetailToggleEvent<TRow> | AllDetailToggleEvent;
+
 export enum SelectionType {
   single = 'single',
   multi = 'multi',

--- a/src/app/basic/responsive.component.ts
+++ b/src/app/basic/responsive.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject, ViewChild, ViewEncapsulation } from '@angular/core';
-import { ColumnMode, DatatableComponent, PageEvent } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DatatableComponent,
+  DetailToggleEvents,
+  PageEvent
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -145,7 +150,7 @@ export class ResponsiveComponent {
     this.table.rowDetail.toggleExpandRow(row);
   }
 
-  onDetailToggle(event) {
+  onDetailToggle(event: DetailToggleEvents<FullEmployee>) {
     console.log('Detail Toggled', event);
   }
 }

--- a/src/app/basic/row-detail.component.ts
+++ b/src/app/basic/row-detail.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject, ViewChild, ViewEncapsulation } from '@angular/core';
-import { ColumnMode, DatatableComponent, PageEvent } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DatatableComponent,
+  DetailToggleEvents,
+  PageEvent
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -119,7 +124,7 @@ export class RowDetailsComponent {
     this.table.rowDetail.toggleExpandRow(row);
   }
 
-  onDetailToggle(event) {
+  onDetailToggle(event: DetailToggleEvents<FullEmployee>) {
     console.log('Detail Toggled', event);
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The details event has an anonymous type which is hard to use as it does not express the relation between the `type` field and the value.

**What is the new behavior?**

The new type can be reused in event listener and is a discriminated union so auto TS type calculation works.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
