### PR TITLE
refactor: adjust the type of rowClass as it is never called with groups

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -86,7 +86,7 @@ export class DataTableBodyRowComponent<TRow = any> implements DoCheck, OnChanges
   }
 
   @Input() expanded: boolean;
-  @Input() rowClass?: (row: RowOrGroup<TRow>) => string | Record<string, boolean>;
+  @Input() rowClass?: (row: TRow) => string | Record<string, boolean>;
   @Input() row: TRow;
   @Input() group: TRow[];
   @Input() isSelected: boolean;

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -282,7 +282,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   @Input() selectCheck: (value: TRow, index: number, array: TRow[]) => boolean;
   @Input() displayCheck: (row: TRow, column: TableColumn, value?: any) => boolean;
   @Input() trackByProp: string;
-  @Input() rowClass: (row: RowOrGroup<TRow>) => string | Record<string, boolean>;
+  @Input() rowClass: (row: TRow) => string | Record<string, boolean>;
   @Input() groupedRows: Group<TRow>[];
   @Input() groupExpansionDefault: boolean;
   @Input() innerWidth: number;

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -376,7 +376,7 @@ export class DatatableComponent<TRow extends Row = any>
    * - a string: `"class-1 class-2`
    * - a Record<string, boolean>: `{ 'class-1': true, 'class-2': false }`
    */
-  @Input() rowClass: (row: Group<TRow> | TRow) => string | Record<string, boolean>;
+  @Input() rowClass: (row: TRow) => string | Record<string, boolean>;
 
   /**
    * A boolean/function you can use to check whether you want


### PR DESCRIPTION
This is a refactoring as we never released typing yet.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

According to our current signature rowClass is also called with groups, but it never is.

**What is the new behavior?**

Changed the signature so rowClass is also by type never called with groups.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This MR is labeled as `refactor` since we did not release this type.