### PR TITLE
Ci/codeclimate coverage report

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,6 +46,14 @@ jobs:
           name: coverage
           path: coverage/ngx-datatable-lib
 
+      - name: Publish coverage results
+        uses: paambaati/codeclimate-action@v9.0.0
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        with:
+          coverageLocations: ${{github.workspace}}/coverage/ngx-datatable-lib/lcov.info:lcov
+        if: env.CC_TEST_REPORTER_ID
+
       - name: Build Docs
         run: npm run build-docs
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The coverage report is only visible within the CI logs after manually downloading the artifacts. The coverage badge in the main readme is broken.

**What is the new behavior?**

The coverage can also be seen on CodeClimate on a file-by-file basis, including historical changes. The coverage badge starts working.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The integration is done according to CodeClimates docs (see https://docs.codeclimate.com/docs/github-actions-test-coverage), particularly the plugin example for the upload-only use-case (see https://github.com/paambaati/codeclimate-action?tab=readme-ov-file#example-with-only-upload). The required secret is also already injected (see https://github.com/siemens/ngx-datatable/settings/secrets/actions).

There would be quite a few other services around, but considering that the code quality integration already works, we already have their badge and a [`.codeclimate.yml`](https://github.com/siemens/ngx-datatable/blob/master/.codeclimate.yml) in the repo, it's the easiest solution for simple code coverage.
