### PR TITLE
refactor: always use the same event type for reorder columns

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -1140,7 +1140,8 @@ export class DatatableComponent<TRow extends Row = any>
   /**
    * The header triggered a column re-order event.
    */
-  onColumnReorder({ column, newValue, prevValue }: ReorderEvent): void {
+  onColumnReorder(event: ReorderEvent): void {
+    const { column, newValue, prevValue } = event;
     const cols = this._internalColumns.map(c => ({ ...c }));
 
     if (this.swapColumns) {
@@ -1165,11 +1166,7 @@ export class DatatableComponent<TRow extends Row = any>
 
     this._internalColumns = cols;
 
-    this.reorder.emit({
-      column,
-      newValue,
-      prevValue
-    });
+    this.reorder.emit(event);
   }
 
   /**

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -26,11 +26,7 @@ import {
 import { NgStyle } from '@angular/common';
 import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
 import { TableColumn } from '../../types/table-column.type';
-import {
-  OrderableReorderEvent,
-  PinnedColumns,
-  TargetChangedEvent
-} from '../../types/internal.types';
+import { PinnedColumns, TargetChangedEvent } from '../../types/internal.types';
 import { DraggableDirective } from '../../directives/draggable.directive';
 import { LongPressDirective } from '../../directives/long-press.directive';
 import { ResizeableDirective } from '../../directives/resizeable.directive';
@@ -267,15 +263,11 @@ export class DataTableHeaderComponent implements OnDestroy, OnChanges {
     };
   }
 
-  onColumnReordered({ prevIndex, newIndex, model }: OrderableReorderEvent): void {
-    const column = this.getColumn(newIndex);
+  onColumnReordered(event: ReorderEvent): void {
+    const column = this.getColumn(event.newValue);
     column.isTarget = false;
     column.targetMarkerContext = undefined;
-    this.reorder.emit({
-      column: model,
-      prevValue: prevIndex,
-      newValue: newIndex
-    });
+    this.reorder.emit(event);
   }
 
   onTargetChanged({ prevIndex, newIndex, initialIndex }: TargetChangedEvent): void {

--- a/projects/ngx-datatable/src/lib/directives/orderable.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/orderable.directive.ts
@@ -14,11 +14,8 @@ import {
 import { DraggableDirective } from './draggable.directive';
 import { DOCUMENT } from '@angular/common';
 import { TableColumn } from '../types/table-column.type';
-import {
-  DraggableDragEvent,
-  OrderableReorderEvent,
-  TargetChangedEvent
-} from '../types/internal.types';
+import { DraggableDragEvent, TargetChangedEvent } from '../types/internal.types';
+import { ReorderEvent } from '../types/public.types';
 
 interface OrderPosition {
   left: number;
@@ -34,7 +31,7 @@ interface OrderPosition {
 export class OrderableDirective implements AfterContentInit, OnDestroy {
   private document = inject(DOCUMENT);
 
-  @Output() reorder = new EventEmitter<OrderableReorderEvent>();
+  @Output() reorder = new EventEmitter<ReorderEvent>();
   @Output() targetChanged = new EventEmitter<TargetChangedEvent>();
 
   @ContentChildren(DraggableDirective, { descendants: true })
@@ -131,9 +128,9 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
     const target = this.isTarget(model, event);
     if (target) {
       this.reorder.emit({
-        prevIndex: prevPos.index,
-        newIndex: target.i,
-        model
+        prevValue: prevPos.index,
+        newValue: target.i,
+        column: model
       });
     }
 

--- a/projects/ngx-datatable/src/lib/types/internal.types.ts
+++ b/projects/ngx-datatable/src/lib/types/internal.types.ts
@@ -14,12 +14,6 @@ export interface ColumnGroupWidth {
   total: number;
 }
 
-export interface OrderableReorderEvent {
-  prevIndex: number;
-  newIndex: number;
-  model: TableColumn;
-}
-
 export interface TargetChangedEvent {
   newIndex?: number;
   prevIndex: number;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

We previously had two event types for reordering, that had a completely different naming.

**What is the new behavior?**

Those events are now consolidated into one following the existing naming pattern of the public API.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
