### PR TITLE
refactor: remove limit from page event

### DIFF
--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -125,7 +125,8 @@ export interface ReorderEvent {
 export interface PageEvent {
   count: number;
   pageSize: number;
-  limit: number;
+  /** @deprecated Use {@link pageSize} instead. */
+  limit: number | undefined;
   offset: number;
 }
 

--- a/src/app/paging/paging-virtual.component.ts
+++ b/src/app/paging/paging-virtual.component.ts
@@ -1,15 +1,8 @@
 import { Component } from '@angular/core';
 import { MockServerResultsService } from './mock-server-results-service';
 import { Page } from './model/page';
-import { ColumnMode, DatatableComponent } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, PageEvent } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
-
-interface PageInfo {
-  offset: number;
-  pageSize: number;
-  limit: number;
-  count: number;
-}
 
 @Component({
   selector: 'virtual-paging-demo',
@@ -71,7 +64,7 @@ export class VirtualPagingComponent {
     this.pageNumber = 0;
   }
 
-  setPage(pageInfo: PageInfo) {
+  setPage(pageInfo: PageEvent) {
     // Current page number is determined by last call to setPage
     // This is the page the UI is currently displaying
     // The current page is based on the UI pagesize and scroll position


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

We currently emit the `limit` value in the page change event.

**What is the new behavior?**

We no longer emit the `limit` value.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Applications should use `pageSize` as this contains the actual used `pageSize`.
If they for some reason need the `limit`,  then they need to use the value they provided, as we never modify the `limit` value.

**Other information**:

