### PR TITLE
docs: migrate examples to standalone

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -75,15 +75,22 @@ import { SummaryRowCustomTemplateComponent } from './summary/summary-row-custom-
 import { SummaryRowServerPagingComponent } from './summary/summary-row-server-paging.component';
 import { SummaryRowInlineHtmlComponent } from './summary/summary-row-inline-html.component';
 import { AppRoutingModule } from './app-routing.module';
-import { CommonModule } from '@angular/common';
 import { ScrollingDynamicallyComponent } from './basic/scrolling-dynamically.component';
 import { DragDropComponent } from './drag-drop/drag-drop.component';
-
-import { DragDropModule } from '@angular/cdk/drag-drop';
 import { provideHttpClient } from '@angular/common/http';
+
 @NgModule({
-  declarations: [
-    AppComponent,
+  declarations: [AppComponent],
+  imports: [
+    BrowserModule,
+    AppRoutingModule,
+    NgxDatatableModule.forRoot({
+      messages: {
+        emptyMessage: 'No data to display', // Message to show when array is presented, but contains no values
+        totalMessage: 'total', // Footer total message
+        selectedMessage: 'selected' // Footer selected message
+      }
+    }),
     BasicAutoComponent,
     BasicFixedComponent,
     DragDropComponent,
@@ -139,19 +146,6 @@ import { provideHttpClient } from '@angular/common/http';
     SummaryRowServerPagingComponent,
     SummaryRowInlineHtmlComponent,
     DisabledRowsComponent
-  ],
-  imports: [
-    CommonModule,
-    BrowserModule,
-    AppRoutingModule,
-    DragDropModule,
-    NgxDatatableModule.forRoot({
-      messages: {
-        emptyMessage: 'No data to display', // Message to show when array is presented, but contains no values
-        totalMessage: 'total', // Footer total message
-        selectedMessage: 'selected' // Footer selected message
-      }
-    })
   ],
   providers: [provideHttpClient()],
   bootstrap: [AppComponent]

--- a/src/app/basic/basic-auto.component.ts
+++ b/src/app/basic/basic-auto.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -31,7 +31,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class BasicAutoComponent {
   rows: Employee[] = [];

--- a/src/app/basic/basic-fixed.component.ts
+++ b/src/app/basic/basic-fixed.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -29,7 +29,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class BasicFixedComponent {
   rows: Employee[] = [];

--- a/src/app/basic/bootstrap.component.ts
+++ b/src/app/basic/bootstrap.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -34,7 +34,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class BootstrapThemeComponent {
   rows: Employee[] = [];

--- a/src/app/basic/contextmenu.component.ts
+++ b/src/app/basic/contextmenu.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, ContextMenuEvent, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  ContextMenuEvent,
+  DatatableComponent,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -52,7 +57,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class ContextMenuDemoComponent {
   rows: Employee[] = [];

--- a/src/app/basic/css.component.ts
+++ b/src/app/basic/css.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -36,7 +41,9 @@ import { DataService } from '../data.service';
         <ngx-datatable-column name="Age"></ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class RowCssComponent {
   rows: FullEmployee[] = [];

--- a/src/app/basic/dark-theme.component.ts
+++ b/src/app/basic/dark-theme.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -33,7 +33,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class DarkThemeComponent {
   rows: Employee[] = [];

--- a/src/app/basic/disabled-rows.component.ts
+++ b/src/app/basic/disabled-rows.component.ts
@@ -1,5 +1,12 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, SelectionType } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DatatableComponent,
+  DisableRowDirective,
+  SelectionType
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -78,7 +85,14 @@ import { DataService } from '../data.service';
         </ngx-datatable>
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [
+    DatatableComponent,
+    DataTableColumnDirective,
+    DataTableColumnCellDirective,
+    DisableRowDirective
+  ]
 })
 export class DisabledRowsComponent {
   rows: (FullEmployee & { isDisabled?: boolean })[] = [];

--- a/src/app/basic/dynamic-height.component.ts
+++ b/src/app/basic/dynamic-height.component.ts
@@ -1,5 +1,9 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -32,7 +36,9 @@ import { DataService } from '../data.service';
         <ngx-datatable-column name="Row Height" prop="height"></ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class DynamicHeightComponent {
   rows: (FullEmployee & { height: number })[] = [];

--- a/src/app/basic/empty.component.ts
+++ b/src/app/basic/empty.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 
 @Component({
   selector: 'empty-demo',
@@ -29,7 +29,9 @@ import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
         >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class BasicEmptyComponent {
   columns: TableColumn[] = [

--- a/src/app/basic/filter.component.ts
+++ b/src/app/basic/filter.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, ViewChild } from '@angular/core';
-import { DatatableComponent } from '../../../projects/ngx-datatable/src/lib/components/datatable.component';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -38,7 +37,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class FilterComponent {
   rows: Employee[] = [];

--- a/src/app/basic/footer.component.ts
+++ b/src/app/basic/footer.component.ts
@@ -1,5 +1,11 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DatatableComponent,
+  DatatableFooterDirective,
+  DataTableFooterTemplateDirective,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -48,7 +54,9 @@ import { DataService } from '../data.service';
         </ngx-datatable-footer>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DatatableFooterDirective, DataTableFooterTemplateDirective]
 })
 export class FooterDemoComponent {
   rows: Employee[] = [];

--- a/src/app/basic/fullscreen.component.ts
+++ b/src/app/basic/fullscreen.component.ts
@@ -1,5 +1,9 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -41,7 +45,9 @@ import { DataService } from '../data.service';
         ></ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class FullScreenComponent {
   rows: FullEmployee[] = [];

--- a/src/app/basic/inline.component.ts
+++ b/src/app/basic/inline.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -75,7 +80,9 @@ import { DataService } from '../data.service';
         </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective]
 })
 export class InlineEditComponent {
   editing: Record<string, boolean> = {};

--- a/src/app/basic/live.component.ts
+++ b/src/app/basic/live.component.ts
@@ -1,5 +1,9 @@
 import { Component, inject, ViewChild } from '@angular/core';
-import { ColumnMode, DatatableComponent } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -40,7 +44,9 @@ import { DataService } from '../data.service';
         <ngx-datatable-column name="Company"></ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class LiveDataComponent {
   @ViewChild('mydatatable') mydatatable: DatatableComponent<Employee & { updated: string }>;

--- a/src/app/basic/multiple.component.ts
+++ b/src/app/basic/multiple.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 
 @Component({
   selector: 'multiple-tables-demo',
@@ -37,7 +37,9 @@ import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class MultipleTablesComponent {
   columns1: TableColumn[] = [{ prop: 'name' }, { name: 'Gender' }, { name: 'Company' }];

--- a/src/app/basic/responsive.component.ts
+++ b/src/app/basic/responsive.component.ts
@@ -1,7 +1,12 @@
 import { Component, inject, ViewChild, ViewEncapsulation } from '@angular/core';
 import {
   ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DataTableColumnHeaderDirective,
   DatatableComponent,
+  DatatableRowDetailDirective,
+  DatatableRowDetailTemplateDirective,
   DetailToggleEvents,
   PageEvent
 } from 'projects/ngx-datatable/src/public-api';
@@ -119,7 +124,16 @@ import { DataService } from '../data.service';
     </div>
   `,
   // eslint-disable-next-line @angular-eslint/use-component-view-encapsulation
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  imports: [
+    DatatableComponent,
+    DatatableRowDetailDirective,
+    DatatableRowDetailTemplateDirective,
+    DataTableColumnDirective,
+    DataTableColumnCellDirective,
+    DataTableColumnHeaderDirective
+  ]
 })
 export class ResponsiveComponent {
   @ViewChild('myTable') table: DatatableComponent<FullEmployee>;

--- a/src/app/basic/row-detail.component.ts
+++ b/src/app/basic/row-detail.component.ts
@@ -1,7 +1,11 @@
 import { Component, inject, ViewChild, ViewEncapsulation } from '@angular/core';
 import {
   ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
   DatatableComponent,
+  DatatableRowDetailDirective,
+  DatatableRowDetailTemplateDirective,
   DetailToggleEvents,
   PageEvent
 } from 'projects/ngx-datatable/src/public-api';
@@ -93,7 +97,15 @@ import { DataService } from '../data.service';
     </div>
   `,
   // eslint-disable-next-line @angular-eslint/use-component-view-encapsulation
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  standalone: true,
+  imports: [
+    DatatableComponent,
+    DatatableRowDetailDirective,
+    DatatableRowDetailTemplateDirective,
+    DataTableColumnDirective,
+    DataTableColumnCellDirective
+  ]
 })
 export class RowDetailsComponent {
   @ViewChild('myTable') table: DatatableComponent<FullEmployee>;

--- a/src/app/basic/row-grouping.component.ts
+++ b/src/app/basic/row-grouping.component.ts
@@ -2,7 +2,11 @@ import { Component, inject, ViewChild } from '@angular/core';
 import { GroupedEmployee } from '../data.model';
 import {
   ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
   DatatableComponent,
+  DatatableGroupHeaderDirective,
+  DatatableGroupHeaderTemplateDirective,
   Group,
   GroupToggleEvents,
   SelectionType
@@ -149,7 +153,15 @@ import { DataService } from '../data.service';
         </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [
+    DatatableComponent,
+    DatatableGroupHeaderDirective,
+    DatatableGroupHeaderTemplateDirective,
+    DataTableColumnDirective,
+    DataTableColumnCellDirective
+  ]
 })
 export class RowGroupingComponent {
   @ViewChild('myTable') table: DatatableComponent<GroupedEmployee>;

--- a/src/app/basic/rx.component.ts
+++ b/src/app/basic/rx.component.ts
@@ -1,8 +1,9 @@
 import { Component, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
+import { AsyncPipe } from '@angular/common';
 
 @Component({
   selector: 'rx-demo',
@@ -30,7 +31,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, AsyncPipe]
 })
 export class RxDemoComponent {
   rows: Observable<Employee[]>;

--- a/src/app/basic/scrolling-dynamically.component.ts
+++ b/src/app/basic/scrolling-dynamically.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -78,7 +83,9 @@ import { DataService } from '../data.service';
         </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective]
 })
 export class ScrollingDynamicallyComponent {
   editing: Record<string, boolean> = {};

--- a/src/app/basic/scrolling.component.ts
+++ b/src/app/basic/scrolling.component.ts
@@ -1,6 +1,10 @@
 import { Component, inject } from '@angular/core';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
+import {
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 
 @Component({
   selector: 'horz-vert-scrolling-demo',
@@ -38,7 +42,9 @@ import { DataService } from '../data.service';
         ></ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class HorzVertScrollingComponent {
   rows: FullEmployee[] = [];

--- a/src/app/basic/tabs.component.ts
+++ b/src/app/basic/tabs.component.ts
@@ -1,5 +1,9 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -67,7 +71,9 @@ import { DataService } from '../data.service';
         }
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class TabsDemoComponent {
   rows: FullEmployee[] = [];

--- a/src/app/basic/virtual.component.ts
+++ b/src/app/basic/virtual.component.ts
@@ -1,5 +1,11 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, PageEvent } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DatatableComponent,
+  PageEvent
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -41,7 +47,9 @@ import { DataService } from '../data.service';
         <ngx-datatable-column name="Row Height" prop="height" [width]="80"> </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective]
 })
 export class VirtualScrollComponent {
   rows: (FullEmployee & { height: number })[];

--- a/src/app/columns/column-flex.component.ts
+++ b/src/app/columns/column-flex.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -43,7 +48,9 @@ import { DataService } from '../data.service';
         </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective]
 })
 export class ColumnFlexComponent {
   rows: Employee[] = [];

--- a/src/app/columns/column-force.component.ts
+++ b/src/app/columns/column-force.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -43,7 +48,9 @@ import { DataService } from '../data.service';
         </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective]
 })
 export class ColumnForceComponent {
   rows: Employee[] = [];

--- a/src/app/columns/column-reorder.component.ts
+++ b/src/app/columns/column-reorder.component.ts
@@ -1,7 +1,8 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
+import { NgClass } from '@angular/common';
 
 @Component({
   selector: 'column-reorder-demo',
@@ -55,7 +56,9 @@ import { DataService } from '../data.service';
         </div>
       </ng-template>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, NgClass]
 })
 export class ColumnReorderComponent {
   rows: Employee[] = [];

--- a/src/app/columns/column-standard.component.ts
+++ b/src/app/columns/column-standard.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -43,7 +48,9 @@ import { DataService } from '../data.service';
         </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective]
 })
 export class ColumnStandardComponent {
   rows: Employee[] = [];

--- a/src/app/columns/column-toggle.component.ts
+++ b/src/app/columns/column-toggle.component.ts
@@ -1,5 +1,10 @@
 import { Component } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -48,7 +53,9 @@ import { Employee } from '../data.model';
         </ul>
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class ColumnToggleComponent {
   rows: Employee[] = [

--- a/src/app/columns/pinning.component.ts
+++ b/src/app/columns/pinning.component.ts
@@ -1,5 +1,9 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -36,7 +40,9 @@ import { DataService } from '../data.service';
         </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class ColumnPinningComponent {
   rows: FullEmployee[] = [];

--- a/src/app/drag-drop/drag-drop.component.ts
+++ b/src/app/drag-drop/drag-drop.component.ts
@@ -1,6 +1,11 @@
-import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { CdkDrag, CdkDragDrop, CdkDropList, moveItemInArray } from '@angular/cdk/drag-drop';
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DatatableComponent,
+  DatatableRowDefComponent,
+  DatatableRowDefDirective
+} from 'projects/ngx-datatable/src/public-api';
 import { DataService } from '../data.service';
 import { Employee } from '../data.model';
 
@@ -37,7 +42,15 @@ import { Employee } from '../data.model';
         </ng-template>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [
+    DatatableComponent,
+    CdkDropList,
+    DatatableRowDefDirective,
+    DatatableRowDefComponent,
+    CdkDrag
+  ]
 })
 export class DragDropComponent {
   rows: Employee[] = [];

--- a/src/app/paging/paging-client.component.ts
+++ b/src/app/paging/paging-client.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -30,7 +30,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class ClientPagingComponent {
   rows: Employee[] = [];

--- a/src/app/paging/paging-scrolling-novirtualization.component.ts
+++ b/src/app/paging/paging-scrolling-novirtualization.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { MockServerResultsService } from './mock-server-results-service';
 import { Page } from './model/page';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -39,7 +39,9 @@ import { Employee } from '../data.model';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class PagingScrollingNoVirtualizationComponent implements OnInit {
   page: Page = {

--- a/src/app/paging/paging-server.component.ts
+++ b/src/app/paging/paging-server.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { MockServerResultsService } from './mock-server-results-service';
 import { Page } from './model/page';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -36,7 +36,9 @@ import { Employee } from '../data.model';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class ServerPagingComponent implements OnInit {
   page: Page = {

--- a/src/app/paging/paging-virtual.component.ts
+++ b/src/app/paging/paging-virtual.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { MockServerResultsService } from './mock-server-results-service';
 import { Page } from './model/page';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 interface PageInfo {
@@ -52,7 +52,9 @@ interface PageInfo {
       </ngx-datatable>
     </div>
   `,
-  styleUrls: ['./paging-virtual.component.scss']
+  styleUrls: ['./paging-virtual.component.scss'],
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class VirtualPagingComponent {
   totalElements: number;

--- a/src/app/paging/scrolling-server.component.ts
+++ b/src/app/paging/scrolling-server.component.ts
@@ -3,7 +3,7 @@ import { Observable, of } from 'rxjs';
 import { delay, map } from 'rxjs/operators';
 
 import data from 'src/assets/data/company.json';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 const companyData = data as any[];
@@ -55,7 +55,9 @@ export class MockServerResultsService {
       ></ngx-datatable>
     </div>
   `,
-  styleUrls: ['./scrolling-server.component.css']
+  styleUrls: ['./scrolling-server.component.css'],
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class ServerScrollingComponent implements OnInit {
   readonly headerHeight = 50;

--- a/src/app/selection/selection-cell.component.ts
+++ b/src/app/selection/selection-cell.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   ColumnMode,
+  DatatableComponent,
   SelectEvent,
   SelectionType,
   TableColumn
@@ -39,7 +40,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class CellSelectionComponent {
   rows: Employee[] = [];

--- a/src/app/selection/selection-chkbox-template.component.ts
+++ b/src/app/selection/selection-chkbox-template.component.ts
@@ -2,6 +2,10 @@ import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DataTableColumnHeaderDirective,
+  DatatableComponent,
   SelectEvent,
   SelectionType
 } from 'projects/ngx-datatable/src/public-api';
@@ -88,7 +92,14 @@ import { DataService } from '../data.service';
         </ul>
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [
+    DatatableComponent,
+    DataTableColumnDirective,
+    DataTableColumnHeaderDirective,
+    DataTableColumnCellDirective
+  ]
 })
 export class CustomCheckboxSelectionComponent {
   rows: Employee[] = [];

--- a/src/app/selection/selection-chkbox.component.ts
+++ b/src/app/selection/selection-chkbox.component.ts
@@ -2,6 +2,8 @@ import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent,
   SelectEvent,
   SelectionType
 } from 'projects/ngx-datatable/src/public-api';
@@ -77,7 +79,9 @@ import { DataService } from '../data.service';
         </ul>
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class CheckboxSelectionComponent {
   rows: Employee[] = [];

--- a/src/app/selection/selection-disabled.component.ts
+++ b/src/app/selection/selection-disabled.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   ColumnMode,
+  DatatableComponent,
   SelectEvent,
   SelectionType,
   TableColumn
@@ -57,7 +58,9 @@ import { DataService } from '../data.service';
         </ul>
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class MultiDisableSelectionComponent {
   rows: Employee[] = [];

--- a/src/app/selection/selection-multi-click-chkbox.component.ts
+++ b/src/app/selection/selection-multi-click-chkbox.component.ts
@@ -2,6 +2,8 @@ import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent,
   SelectEvent,
   SelectionType
 } from 'projects/ngx-datatable/src/public-api';
@@ -78,7 +80,9 @@ import { DataService } from '../data.service';
         </ul>
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class MultiClickCheckboxSelectionComponent {
   rows: Employee[] = [];

--- a/src/app/selection/selection-multi-click.component.ts
+++ b/src/app/selection/selection-multi-click.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   ColumnMode,
+  DatatableComponent,
   SelectEvent,
   SelectionType,
   TableColumn
@@ -60,7 +61,9 @@ import { DataService } from '../data.service';
         </ul>
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class MultiClickSelectionComponent {
   rows: Employee[] = [];

--- a/src/app/selection/selection-multi.component.ts
+++ b/src/app/selection/selection-multi.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   ColumnMode,
+  DatatableComponent,
   SelectEvent,
   SelectionType,
   TableColumn
@@ -63,7 +64,9 @@ import { DataService } from '../data.service';
         </ul>
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class MultiSelectionComponent {
   rows: Employee[] = [];

--- a/src/app/selection/selection-single.component.ts
+++ b/src/app/selection/selection-single.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   ColumnMode,
+  DatatableComponent,
   SelectEvent,
   SelectionType,
   TableColumn
@@ -63,7 +64,9 @@ import { DataService } from '../data.service';
         </ul>
       </div>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class SingleSelectionComponent {
   rows: Employee[] = [];

--- a/src/app/sorting/sorting-client.component.ts
+++ b/src/app/sorting/sorting-client.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, SortType, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DatatableComponent,
+  SortType,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -31,7 +36,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class ClientSortingComponent {
   rows: Employee[] = [];

--- a/src/app/sorting/sorting-comparator.component.ts
+++ b/src/app/sorting/sorting-comparator.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -29,7 +29,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class SortingComparatorComponent {
   rows: Employee[] = [];

--- a/src/app/sorting/sorting-default.component.ts
+++ b/src/app/sorting/sorting-default.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject, OnInit } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -44,7 +49,9 @@ import { DataService } from '../data.service';
         <ngx-datatable-column name="Gender"> </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective]
 })
 export class DefaultSortingComponent implements OnInit {
   rows: Employee[] = [];

--- a/src/app/sorting/sorting-server.component.ts
+++ b/src/app/sorting/sorting-server.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, SortEvent, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DatatableComponent,
+  SortEvent,
+  TableColumn
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -32,7 +37,9 @@ import { DataService } from '../data.service';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class ServerSortingComponent {
   loading = false;

--- a/src/app/summary/summary-row-custom-template.component.ts
+++ b/src/app/summary/summary-row-custom-template.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit, TemplateRef, ViewChild } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -39,7 +39,9 @@ import { DataService } from '../data.service';
       </ng-template>
     </div>
   `,
-  styleUrls: ['./summary-row-custom-template.component.scss']
+  styleUrls: ['./summary-row-custom-template.component.scss'],
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class SummaryRowCustomTemplateComponent implements OnInit {
   rows: Employee[] = [];

--- a/src/app/summary/summary-row-inline-html.component.ts
+++ b/src/app/summary/summary-row-inline-html.component.ts
@@ -1,5 +1,9 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -44,7 +48,9 @@ import { DataService } from '../data.service';
         </div>
       </ng-template>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective]
 })
 export class SummaryRowInlineHtmlComponent {
   rows: Employee[] = [];

--- a/src/app/summary/summary-row-server-paging.component.ts
+++ b/src/app/summary/summary-row-server-paging.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { MockServerResultsService } from '../paging/mock-server-results-service';
 import { Page } from '../paging/model/page';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 
 @Component({
@@ -37,7 +37,9 @@ import { Employee } from '../data.model';
       >
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class SummaryRowServerPagingComponent implements OnInit {
   page: Page = {

--- a/src/app/summary/summary-row-simple.component.ts
+++ b/src/app/summary/summary-row-simple.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -49,7 +49,9 @@ import { DataService } from '../data.service';
       </ngx-datatable>
     </div>
   `,
-  styleUrls: ['./summary-row-simple.component.scss']
+  styleUrls: ['./summary-row-simple.component.scss'],
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class SummaryRowSimpleComponent {
   rows: Employee[] = [];

--- a/src/app/templates/template-dom.component.ts
+++ b/src/app/templates/template-dom.component.ts
@@ -1,5 +1,11 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DataTableColumnHeaderDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -52,7 +58,14 @@ import { DataService } from '../data.service';
         </ngx-datatable-column>
       </ngx-datatable>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [
+    DatatableComponent,
+    DataTableColumnDirective,
+    DataTableColumnHeaderDirective,
+    DataTableColumnCellDirective
+  ]
 })
 export class InlineTemplatesComponent {
   rows: Employee[] = [];

--- a/src/app/templates/template-obj.component.ts
+++ b/src/app/templates/template-obj.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit, TemplateRef, ViewChild } from '@angular/core';
-import { ColumnMode, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { ColumnMode, DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -42,7 +42,9 @@ import { DataService } from '../data.service';
         }
       </ng-template>
     </div>
-  `
+  `,
+  standalone: true,
+  imports: [DatatableComponent]
 })
 export class TemplateRefTemplatesComponent implements OnInit {
   @ViewChild('editTmpl', { static: true }) editTmpl: TemplateRef<any>;

--- a/src/app/tree/client-tree.component.ts
+++ b/src/app/tree/client-tree.component.ts
@@ -1,5 +1,10 @@
 import { Component, inject } from '@angular/core';
-import { ColumnMode } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellDirective,
+  DataTableColumnDirective,
+  DatatableComponent
+} from 'projects/ngx-datatable/src/public-api';
 import { TreeEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -47,7 +52,9 @@ import { DataService } from '../data.service';
       </ngx-datatable>
     </div>
   `,
-  styles: ['.icon {height: 10px; width: 10px; }', '.disabled {opacity: 0.5; }']
+  styles: ['.icon {height: 10px; width: 10px; }', '.disabled {opacity: 0.5; }'],
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective]
 })
 export class ClientTreeComponent {
   rows: TreeEmployee[] = [];

--- a/src/app/tree/fullscreen.component.ts
+++ b/src/app/tree/fullscreen.component.ts
@@ -1,5 +1,11 @@
 import { ChangeDetectorRef, Component } from '@angular/core';
-import { ColumnMode, TreeStatus } from 'projects/ngx-datatable/src/public-api';
+import {
+  ColumnMode,
+  DataTableColumnCellTreeToggle,
+  DataTableColumnDirective,
+  DatatableComponent,
+  TreeStatus
+} from 'projects/ngx-datatable/src/public-api';
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
@@ -67,7 +73,9 @@ import { DataService } from '../data.service';
       </ngx-datatable>
     </div>
   `,
-  styles: ['.icon {height: 10px; width: 10px; }', '.disabled {opacity: 0.5; }']
+  styles: ['.icon {height: 10px; width: 10px; }', '.disabled {opacity: 0.5; }'],
+  standalone: true,
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellTreeToggle]
 })
 export class FullScreenTreeComponent {
   rows: (FullEmployee & { treeStatus: TreeStatus; parentId?: string })[] = [];


### PR DESCRIPTION
Running the angular migration script on the examples

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: docs

**What is the current behavior?** (You can also link to an open issue here)

Examples are not using Angular's standalone component mode.

**What is the new behavior?**

Examples are using Angular's standalone component mode.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Not really needed, but the Jetbrain language server was somehow broken without Angular's standalone component mode. So I did this. This was automatically migrated.
