### PR TITLE
refactor: make column resize handling typesafe

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -1095,22 +1095,12 @@ export class DatatableComponent<TRow extends Row = any>
       return;
     }
 
-    let idx: number;
-    const cols = this._internalColumns.map((c, i) => {
-      c = { ...c };
-
-      if (c.$$id === column.$$id) {
-        idx = i;
-        c.width = newValue;
-
-        // set this so we can force the column
-        // width distribution to be to this value
-        c.$$oldWidth = newValue;
-      }
-
-      return c;
-    });
-
+    const idx = this._internalColumns.indexOf(column);
+    const cols = this._internalColumns.map(col => ({ ...col }));
+    cols[idx].width = newValue;
+    // set this so we can force the column
+    // width distribution to be to this value
+    cols[idx].$$oldWidth = newValue;
     this.recalculateColumns(cols, idx);
     this._internalColumns = cols;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The column resize handler is written in a weird way as `Array.map` has a side effect.

**What is the new behavior?**

The column resize handler is written less weird and is strict `null` compatible.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Add one point we should figure out why columns are cloned, but this is up for later.