### PR TITLE
Ci/GitHub action update

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -63,13 +63,6 @@ jobs:
       - name: Build Docs
         run: npm run build-docs
 
-      - name: Deploy Docs
-        uses: JamesIves/github-pages-deploy-action@4.1.5
-        with:
-          branch: gh-pages
-          folder: dist/ngx-datatable
-        if: ${{ github.ref == 'refs/heads/master' }}
-
   e2e:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Archive coverage results
         uses: actions/upload-artifact@v4
+        if: success() || failure()
         with:
           name: coverage
           path: coverage/ngx-datatable-lib
@@ -95,6 +96,7 @@ jobs:
         run: npm run e2e
 
       - name: Upload E2E Results
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-results

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,6 +1,11 @@
 name: Build, Test, and Deploy
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

- In case of a test failure (e.g. E2E image mismatch), the test report wouldn't be saved.
- Only PRs were built, we don't know if the default branch/releases ever worked and also have no default coverage value (e.g. coverage badge broken).
- `Deploy Docs` was a no-op since the task never ran. As discussed offline, we already update the docs during releases, which is easier to understand for our end users.

**What is the new behavior?**

- Test reports always get uploaded, even if the test fails.
- Besides PR builds, we now also build changes on the default branch.
- The no-op task `Deploy Docs` is no longer part of the pipeline, hence all tasks actually run at some point.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

See the individual commit messages.
