### PR TITLE
fix: bind empty message string as plain text to avoid xss

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -79,11 +79,9 @@
       </ng-content>
       <ng-content select="[empty-content]" ngProjectAs="[empty-content]">
         <div role="row">
-          <div
-            role="cell"
-            class="empty-row"
-            [innerHTML]="messages.emptyMessage ?? 'No data to display'"
-          ></div>
+          <div role="cell" class="empty-row">
+            {{ messages.emptyMessage ?? 'No data to display' }}
+          </div>
         </div>
       </ng-content>
     </datatable-body>


### PR DESCRIPTION
BREAKING CHANGE: `emptyMessage` no longer allow passing html to prevent XSS attacks. use slot based content projection `empty-content` for displaying html rich empty content message.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
