### PR TITLE
refactor: move some shared styles to respective components

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.scss
@@ -6,3 +6,8 @@
 .datatable-row-detail {
   overflow-y: hidden;
 }
+
+.datatable-group-header {
+  left: 0;
+  position: sticky;
+}

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.scss
@@ -1,3 +1,5 @@
+@use '../shared';
+
 :host {
   outline: none;
 
@@ -9,3 +11,5 @@
     display: flex;
   }
 }
+
+@include shared.pinned-columns();

--- a/projects/ngx-datatable/src/lib/components/datatable.component.scss
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.scss
@@ -53,22 +53,6 @@
     }
   }
 
-  .datatable-row-left,
-  .datatable-row-right,
-  .datatable-group-header {
-    z-index: 9;
-    position: sticky !important;
-  }
-
-  .datatable-row-left,
-  .datatable-group-header {
-    left: 0;
-  }
-
-  .datatable-row-right {
-    right: 0;
-  }
-
   .datatable-row-center,
   .datatable-row-group {
     position: relative;

--- a/projects/ngx-datatable/src/lib/components/header/header.component.scss
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.scss
@@ -1,3 +1,5 @@
+@use '../shared';
+
 :host {
   display: block;
   overflow: hidden;
@@ -11,3 +13,5 @@
     white-space: nowrap;
   }
 }
+
+@include shared.pinned-columns();

--- a/projects/ngx-datatable/src/lib/components/shared.scss
+++ b/projects/ngx-datatable/src/lib/components/shared.scss
@@ -1,0 +1,15 @@
+@mixin pinned-columns() {
+  .datatable-row-left,
+  .datatable-row-right {
+    position: sticky;
+    z-index: 9;
+  }
+
+  .datatable-row-left {
+    left: 0;
+  }
+
+  .datatable-row-right {
+    right: 0;
+  }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Various styles are located on root component level.

**What is the new behavior?**

Styles are now located on the component level using a shared mixin.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

I guess in the long run, we should consider having some shared styles that have to be imported into the global style sheet of the application to avoid duplication at runtime. With the mixin we at least do not have the code duplicated.
