### PR TITLE
refactor: move display related styles to respective components

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.scss
@@ -1,15 +1,17 @@
 @use '../shared';
 
 :host {
+  display: flex;
   outline: none;
 
   :host-context(ngx-datatable.fixed-row) & {
     white-space: nowrap;
   }
+}
 
-  > div {
-    display: flex;
-  }
+.datatable-row-group {
+  display: flex;
+  position: relative;
 }
 
 @include shared.pinned-columns();

--- a/projects/ngx-datatable/src/lib/components/datatable.component.scss
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.scss
@@ -31,16 +31,6 @@
     }
   }
 
-  /**
-   * Shared Styles
-   */
-  .datatable-body-row,
-  .datatable-row-center,
-  .datatable-header-inner {
-    display: flex;
-    flex-flow: row;
-  }
-
   .datatable-body-cell,
   .datatable-header-cell {
     overflow-x: hidden;
@@ -51,10 +41,5 @@
     &:focus {
       outline: none;
     }
-  }
-
-  .datatable-row-center,
-  .datatable-row-group {
-    position: relative;
   }
 }

--- a/projects/ngx-datatable/src/lib/components/header/header.component.scss
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.scss
@@ -6,8 +6,7 @@
 }
 
 .datatable-header-inner {
-  align-items: stretch;
-  -webkit-align-items: stretch;
+  display: flex;
 
   :host-context(ngx-datatable.fixed-header) & {
     white-space: nowrap;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Styles around display are on the root component. Additionally, `align-items: center` and `flex-flow: row` are the defaults so setting those value is unnecessary.

**What is the new behavior?**

Styles in the respective component and useless assignments are dropped.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

`.datatable-row-center` is always a `.datatable-row-group` so styles could be simplified. Same applies for  `> div` selector in the  body-row-component.