### PR TITLE
refactor: remove explicit standalone flags

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-group-header-template.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-group-header-template.directive.ts
@@ -2,8 +2,7 @@ import { Directive } from '@angular/core';
 import { GroupContext } from '../../types/public.types';
 
 @Directive({
-  selector: '[ngx-datatable-group-header-template]',
-  standalone: true
+  selector: '[ngx-datatable-group-header-template]'
 })
 export class DatatableGroupHeaderTemplateDirective {
   static ngTemplateContextGuard(

--- a/projects/ngx-datatable/src/lib/components/body/body-group-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-group-header.directive.ts
@@ -3,8 +3,7 @@ import { DatatableGroupHeaderTemplateDirective } from './body-group-header-templ
 import { Group, GroupContext, GroupToggleEvents } from '../../types/public.types';
 
 @Directive({
-  selector: 'ngx-datatable-group-header',
-  standalone: true
+  selector: 'ngx-datatable-group-header'
 })
 export class DatatableGroupHeaderDirective<TRow = any> {
   /**

--- a/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
@@ -36,8 +36,7 @@ export class DatatableRowDefComponent {
 }
 
 @Directive({
-  selector: '[rowDef]',
-  standalone: true
+  selector: '[rowDef]'
 })
 export class DatatableRowDefDirective {
   static ngTemplateContextGuard(
@@ -52,8 +51,7 @@ export class DatatableRowDefDirective {
  * @internal To be used internally by ngx-datatable.
  */
 @Directive({
-  selector: '[rowDefInternal]',
-  standalone: true
+  selector: '[rowDefInternal]'
 })
 export class DatatableRowDefInternalDirective implements OnInit {
   vc = inject(ViewContainerRef);

--- a/projects/ngx-datatable/src/lib/components/body/body-row.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.directive.ts
@@ -2,8 +2,7 @@ import { Directive } from '@angular/core';
 import { Row } from '../../types/public.types';
 
 @Directive({
-  selector: '[ngx-datatable-body-row]',
-  standalone: true
+  selector: '[ngx-datatable-body-row]'
 })
 export class DatatableBodyRowDirective {
   static ngTemplateContextGuard<TRow extends Row = any>(

--- a/projects/ngx-datatable/src/lib/components/body/progress-bar.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/progress-bar.component.ts
@@ -9,7 +9,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
       </div>
     </div>
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ProgressBarComponent {}

--- a/projects/ngx-datatable/src/lib/components/body/scroller.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/scroller.component.ts
@@ -18,8 +18,7 @@ import {
   host: {
     class: 'datatable-scroll'
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ScrollerComponent implements OnInit, OnDestroy {
   private renderer = inject(Renderer2);

--- a/projects/ngx-datatable/src/lib/components/body/selection.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/selection.component.ts
@@ -6,8 +6,7 @@ import { ActivateEvent, SelectEvent, SelectionType } from '../../types/public.ty
 @Component({
   selector: 'datatable-selection',
   template: ` <ng-content></ng-content> `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DataTableSelectionComponent<TRow = any> {
   @Input() rows: TRow[];

--- a/projects/ngx-datatable/src/lib/components/columns/column-cell.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/column-cell.directive.ts
@@ -2,8 +2,7 @@ import { Directive, inject, TemplateRef } from '@angular/core';
 import { CellContext } from '../../types/public.types';
 
 @Directive({
-  selector: '[ngx-datatable-cell-template]',
-  standalone: true
+  selector: '[ngx-datatable-cell-template]'
 })
 export class DataTableColumnCellDirective {
   template = inject<TemplateRef<CellContext>>(TemplateRef);

--- a/projects/ngx-datatable/src/lib/components/columns/column-ghost-cell.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/column-ghost-cell.directive.ts
@@ -1,8 +1,7 @@
 import { Directive } from '@angular/core';
 
 @Directive({
-  selector: '[ngx-datatable-ghost-cell-template]',
-  standalone: true
+  selector: '[ngx-datatable-ghost-cell-template]'
 })
 export class DataTableColumnGhostCellDirective {
   static ngTemplateContextGuard(

--- a/projects/ngx-datatable/src/lib/components/columns/column-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/column-header.directive.ts
@@ -2,8 +2,7 @@ import { Directive } from '@angular/core';
 import { HeaderCellContext } from '../../types/public.types';
 
 @Directive({
-  selector: '[ngx-datatable-header-template]',
-  standalone: true
+  selector: '[ngx-datatable-header-template]'
 })
 export class DataTableColumnHeaderDirective {
   static ngTemplateContextGuard(

--- a/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
@@ -18,8 +18,7 @@ import { DataTableColumnGhostCellDirective } from './column-ghost-cell.directive
 import { CellContext, HeaderCellContext } from '../../types/public.types';
 
 @Directive({
-  selector: 'ngx-datatable-column',
-  standalone: true
+  selector: 'ngx-datatable-column'
 })
 export class DataTableColumnDirective<TRow> implements TableColumn, OnChanges {
   private columnChangesService = inject(ColumnChangesService);

--- a/projects/ngx-datatable/src/lib/components/columns/tree.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/tree.directive.ts
@@ -1,8 +1,7 @@
 import { Directive, inject, TemplateRef } from '@angular/core';
 
 @Directive({
-  selector: '[ngx-datatable-tree-toggle]',
-  standalone: true
+  selector: '[ngx-datatable-tree-toggle]'
 })
 export class DataTableColumnCellTreeToggle {
   template = inject<TemplateRef<any>>(TemplateRef);

--- a/projects/ngx-datatable/src/lib/components/footer/footer-template.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer-template.directive.ts
@@ -2,8 +2,7 @@ import { Directive } from '@angular/core';
 import { FooterContext } from '../../types/public.types';
 
 @Directive({
-  selector: '[ngx-datatable-footer-template]',
-  standalone: true
+  selector: '[ngx-datatable-footer-template]'
 })
 export class DataTableFooterTemplateDirective {
   static ngTemplateContextGuard(

--- a/projects/ngx-datatable/src/lib/components/footer/footer.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.directive.ts
@@ -3,8 +3,7 @@ import { DataTableFooterTemplateDirective } from './footer-template.directive';
 import { FooterContext } from '../../types/public.types';
 
 @Directive({
-  selector: 'ngx-datatable-footer',
-  standalone: true
+  selector: 'ngx-datatable-footer'
 })
 export class DatatableFooterDirective {
   @Input({ transform: numberAttribute }) footerHeight: number;

--- a/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
@@ -43,8 +43,7 @@ import { Page } from '../../types/internal.types';
     class: 'datatable-pager'
   },
   styleUrl: './pager.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DataTablePagerComponent {
   @Input() pagerLeftArrowIcon?: string;

--- a/projects/ngx-datatable/src/lib/components/row-detail/row-detail-template.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/row-detail/row-detail-template.directive.ts
@@ -2,8 +2,7 @@ import { Directive } from '@angular/core';
 import { RowDetailContext } from '../../types/public.types';
 
 @Directive({
-  selector: '[ngx-datatable-row-detail-template]',
-  standalone: true
+  selector: '[ngx-datatable-row-detail-template]'
 })
 export class DatatableRowDetailTemplateDirective {
   static ngTemplateContextGuard(

--- a/projects/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
@@ -3,8 +3,7 @@ import { DatatableRowDetailTemplateDirective } from './row-detail-template.direc
 import { DetailToggleEvents, RowDetailContext } from '../../types/public.types';
 
 @Directive({
-  selector: 'ngx-datatable-row-detail',
-  standalone: true
+  selector: 'ngx-datatable-row-detail'
 })
 export class DatatableRowDetailDirective<TRow = any> {
   /**

--- a/projects/ngx-datatable/src/lib/directives/disable-row.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/disable-row.directive.ts
@@ -12,8 +12,7 @@ import { booleanAttribute, Directive, ElementRef, inject, Input } from '@angular
  * 		</div>
  */
 @Directive({
-  selector: '[disable-row]',
-  standalone: true
+  selector: '[disable-row]'
 })
 export class DisableRowDirective {
   private element = inject(ElementRef);

--- a/projects/ngx-datatable/src/lib/directives/draggable.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/draggable.directive.ts
@@ -23,8 +23,7 @@ import { DraggableDragEvent, TableColumnInternal } from '../types/internal.types
  *
  */
 @Directive({
-  selector: '[draggable]',
-  standalone: true
+  selector: '[draggable]'
 })
 export class DraggableDirective implements OnDestroy, OnChanges {
   @Input() dragEventTarget: any;

--- a/projects/ngx-datatable/src/lib/directives/long-press.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/long-press.directive.ts
@@ -13,8 +13,7 @@ import { fromEvent, Subscription } from 'rxjs';
 import { TableColumnInternal } from '../types/internal.types';
 
 @Directive({
-  selector: '[long-press]',
-  standalone: true
+  selector: '[long-press]'
 })
 export class LongPressDirective implements OnDestroy {
   @Input({ transform: booleanAttribute }) pressEnabled = true;

--- a/projects/ngx-datatable/src/lib/directives/orderable.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/orderable.directive.ts
@@ -28,8 +28,7 @@ interface OrderPosition {
 }
 
 @Directive({
-  selector: '[orderable]',
-  standalone: true
+  selector: '[orderable]'
 })
 export class OrderableDirective implements AfterContentInit, OnDestroy {
   private document = inject(DOCUMENT);

--- a/projects/ngx-datatable/src/lib/directives/visibility.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/visibility.directive.ts
@@ -22,8 +22,7 @@ import {
  *
  */
 @Directive({
-  selector: '[visibilityObserver]',
-  standalone: true
+  selector: '[visibilityObserver]'
 })
 export class VisibilityDirective implements OnInit, OnDestroy {
   private element = inject(ElementRef);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The angular subproject contained explicit `standalone: true`, which is the new default and no longer required.

**What is the new behavior?**

There are no longer any explicit `standalone: true`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
