### PR TITLE
fix: frozen column duplication issue

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -102,8 +102,7 @@ import {
   ]
 })
 export class DatatableComponent<TRow extends Row = any>
-  implements OnInit, DoCheck, AfterViewInit, AfterContentInit, OnDestroy
-{
+  implements OnInit, DoCheck, AfterViewInit, AfterContentInit, OnDestroy {
   private scrollbarHelper = inject(ScrollbarHelper);
   private cd = inject(ChangeDetectorRef);
   private columnChangesService = inject(ColumnChangesService);
@@ -1122,9 +1121,15 @@ export class DatatableComponent<TRow extends Row = any>
   onColumnReorder(event: ReorderEventInternal): void {
     const { column, newValue, prevValue } = event;
     const cols = this._internalColumns.map(c => ({ ...c }));
+    const prevCol = cols[newValue];
+    if (
+      (column.frozenLeft !== prevCol.frozenLeft) ||
+      (column.frozenRight !== prevCol.frozenRight)
+    ) {
+      return;
+    }
 
     if (this.swapColumns) {
-      const prevCol = cols[newValue];
       cols[newValue] = column;
       cols[prevValue] = prevCol;
     } else {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When frozen column are reordered, it duplicates the column

**What is the new behavior?**
Now, it won't duplicate the columns while reordering and will  reorder only if the  other is in frozen too in the same order.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Fixes: https://github.com/siemens/ngx-datatable/issues/145
