### PR TITLE
feat!: add localisation for a11y labels

### DIFF
--- a/docs/api/table/inputs.md
+++ b/docs/api/table/inputs.md
@@ -62,7 +62,23 @@ Static messages in the table you can override for localization.
   totalMessage: 'total',
 
   // Footer selected message
-  selectedMessage: 'selected'
+  selectedMessage: 'selected',
+
+  // Pager screen reader message for the first page button
+  ariaFirstPageMessage: 'go to first page',
+
+  // Pager screen reader message for the previous page button
+  ariaPreviousPageMessage: 'go to previous page',
+
+  // Pager screen reader message for the n-th page button.
+  // It will be rendered as: `{{ariaPageNMessage}} {{n}}`.
+  ariaPageNMessage: 'page',
+
+  // Pager screen reader message for the next page button
+  ariaNextPageMessage: 'go to next page',
+
+  // Pager screen reader message for the last page button
+  ariaLastPageMessage: 'go to last page'
 }
 ```
 

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -367,7 +367,12 @@ export class DatatableComponent<TRow extends Row = any>
    * {
    *   emptyMessage: 'No data to display',
    *   totalMessage: 'total',
-   *   selectedMessage: 'selected'
+   *   selectedMessage: 'selected',
+   *   ariaFirstPageMessage: 'go to first page',
+   *   ariaPreviousPageMessage: 'go to previous page',
+   *   ariaPageNMessage: 'page',
+   *   ariaNextPageMessage: 'go to next page',
+   *   ariaLastPageMessage: 'go to last page'
    * }
    * ```
    */

--- a/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
@@ -1,24 +1,40 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  inject,
+  Input,
+  Output
+} from '@angular/core';
 import { PagerPageEvent } from '../../types/public.types';
 import { Page } from '../../types/internal.types';
+import { DatatableComponent } from '../datatable.component';
 
 @Component({
   selector: 'datatable-pager',
   template: `
     <ul class="pager">
       <li [class.disabled]="!canPrevious()">
-        <a role="button" aria-label="go to first page" (click)="selectPage(1)">
+        <a
+          role="button"
+          [attr.aria-label]="messages.ariaFirstPageMessage ?? 'go to first page'"
+          (click)="selectPage(1)"
+        >
           <i class="{{ pagerPreviousIcon ?? 'datatable-icon-prev' }}"></i>
         </a>
       </li>
       <li [class.disabled]="!canPrevious()">
-        <a role="button" aria-label="go to previous page" (click)="prevPage()">
+        <a
+          role="button"
+          [attr.aria-label]="messages.ariaPreviousPageMessage ?? 'go to previous page'"
+          (click)="prevPage()"
+        >
           <i class="{{ pagerLeftArrowIcon ?? 'datatable-icon-left' }}"></i>
         </a>
       </li>
       @for (pg of pages; track pg.number) {
         <li
-          [attr.aria-label]="'page ' + pg.number"
+          [attr.aria-label]="(messages.ariaPageNMessage ?? 'page') + ' ' + pg.number"
           class="pages"
           [class.active]="pg.number === page"
         >
@@ -28,12 +44,20 @@ import { Page } from '../../types/internal.types';
         </li>
       }
       <li [class.disabled]="!canNext()">
-        <a role="button" aria-label="go to next page" (click)="nextPage()">
+        <a
+          role="button"
+          [attr.aria-label]="messages.ariaNextPageMessage ?? 'go to next page'"
+          (click)="nextPage()"
+        >
           <i class="{{ pagerRightArrowIcon ?? 'datatable-icon-right' }}"></i>
         </a>
       </li>
       <li [class.disabled]="!canNext()">
-        <a role="button" aria-label="go to last page" (click)="selectPage(totalPages)">
+        <a
+          role="button"
+          [attr.aria-label]="messages.ariaLastPageMessage ?? 'go to last page'"
+          (click)="selectPage(totalPages)"
+        >
           <i class="{{ pagerNextIcon ?? 'datatable-icon-skip' }}"></i>
         </a>
       </li>
@@ -46,6 +70,12 @@ import { Page } from '../../types/internal.types';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DataTablePagerComponent {
+  private dataTable = inject(DatatableComponent, { optional: true });
+
+  get messages(): DatatableComponent['messages'] {
+    return this.dataTable?.messages ?? {};
+  }
+
   @Input() pagerLeftArrowIcon?: string;
   @Input() pagerRightArrowIcon?: string;
   @Input() pagerPreviousIcon?: string;

--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -77,6 +77,19 @@ export interface INgxDatatableConfig {
     totalMessage: string;
     /** Footer selected message */
     selectedMessage: string;
+    /** Pager screen reader message for the first page button */
+    ariaFirstPageMessage: string;
+    /**
+     * Pager screen reader message for the n-th page button.
+     * It will be rendered as: `{{ariaPageNMessage}} {{n}}`.
+     */
+    ariaPageNMessage: string;
+    /** Pager screen reader message for the previous page button */
+    ariaPreviousPageMessage: string;
+    /** Pager screen reader message for the next page button */
+    ariaNextPageMessage: string;
+    /** Pager screen reader message for the last page button */
+    ariaLastPageMessage: string;
   };
   cssClasses?: {
     sortAscending: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,12 @@ bootstrapApplication(AppComponent, {
         messages: {
           emptyMessage: 'No data to display', // Message to show when array is presented, but contains no values
           totalMessage: 'total', // Footer total message
-          selectedMessage: 'selected' // Footer selected message
+          selectedMessage: 'selected', // Footer selected message
+          ariaFirstPageMessage: 'go to first page', // Pager screen reader message for the first page button
+          ariaPreviousPageMessage: 'go to previous page', // Pager screen reader message for the previous page button
+          ariaPageNMessage: 'page', // Pager screen reader message for the n-th page button
+          ariaNextPageMessage: 'go to next page', // Pager screen reader message for the next page button
+          ariaLastPageMessage: 'go to last page' // Pager screen reader message for the last page button
         }
       })
     ),


### PR DESCRIPTION
This adds localisation for a11y labels (used on the pager).

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

#229 
The aria labels are hard coded and in english.

**What is the new behavior?**

The aria labels can be optionally configured via the already existing "messages" object / input.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

There are additional "messages" properties, that must be specified when using a global config.

**Other information**:
