### PR TITLE
fix: introduce a default value for rows

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -141,7 +141,7 @@ export class DatatableComponent<TRow extends Row = any>
   @Input() set groupRowsBy(val: keyof TRow) {
     if (val) {
       this._groupRowsBy = val;
-      if (this._rows && this._groupRowsBy) {
+      if (this._groupRowsBy) {
         // creates a new array with the data grouped
         this.groupedRows = this.groupArrayBy(this._rows, this._groupRowsBy);
       }
@@ -856,7 +856,7 @@ export class DatatableComponent<TRow extends Row = any>
         optionalGetterForProp(this.treeToRelation)
       );
 
-      if (this._rows && this._groupRowsBy) {
+      if (this._groupRowsBy) {
         // If a column has been specified in _groupRowsBy create a new array with the data grouped by that row
         this.groupedRows = this.groupArrayBy(this._rows, this._groupRowsBy);
       }

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -696,7 +696,7 @@ export class DatatableComponent<TRow extends Row = any>
   _limit: number | undefined;
   _count = 0;
   _offset = 0;
-  _rows: TRow[];
+  _rows: TRow[] = [];
   _groupRowsBy: keyof TRow;
   _internalRows: TRow[] = [];
   _internalColumns: TableColumnInternal<TRow>[];


### PR DESCRIPTION
In #192 we introduced `rows` that are always defined internally. As other setters may use `rows` before initialization (via input), a default value is required.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The property `rows` has no default value. Since the table is making use of setters to update computed values, it may be accessed before initialisation.

**What is the new behavior?**
The property `rows` can be accessed by other setters and internal logic, even before initialisation.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

See discussion in #192.