### PR TITLE
refactor: add missing Row type for TRow

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-group-header.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-group-header.directive.ts
@@ -1,11 +1,11 @@
 import { ContentChild, Directive, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
 import { DatatableGroupHeaderTemplateDirective } from './body-group-header-template.directive';
-import { Group, GroupContext, GroupToggleEvents } from '../../types/public.types';
+import { Group, GroupContext, GroupToggleEvents, Row } from '../../types/public.types';
 
 @Directive({
   selector: 'ngx-datatable-group-header'
 })
-export class DatatableGroupHeaderDirective<TRow = any> {
+export class DatatableGroupHeaderDirective<TRow extends Row = any> {
   /**
    * Row height is required when virtual scroll is enabled.
    */

--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
@@ -23,7 +23,7 @@ import {
 } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 import { DatatableComponentToken } from '../../utils/table-token';
-import { Group, GroupContext, RowDetailContext, RowOrGroup } from '../../types/public.types';
+import { Group, GroupContext, Row, RowDetailContext, RowOrGroup } from '../../types/public.types';
 import { DatatableGroupHeaderDirective } from './body-group-header.directive';
 import { DatatableRowDetailDirective } from '../row-detail/row-detail.directive';
 
@@ -74,7 +74,9 @@ import { DatatableRowDetailDirective } from '../row-detail/row-detail.directive'
   styleUrl: './body-row-wrapper.component.scss',
   imports: [NgTemplateOutlet]
 })
-export class DataTableRowWrapperComponent<TRow = any> implements DoCheck, OnInit, OnChanges {
+export class DataTableRowWrapperComponent<TRow extends Row = any>
+  implements DoCheck, OnInit, OnChanges
+{
   @ViewChild('select') checkBoxInput!: ElementRef<HTMLInputElement>;
   @Input() innerWidth: number;
   @Input() rowDetail: DatatableRowDetailDirective;
@@ -162,7 +164,7 @@ export class DataTableRowWrapperComponent<TRow = any> implements DoCheck, OnInit
     // mark group header checkbox state as indeterminate
     if (this.groupHeader?.checkboxable && this.selectedRowsDiffer.diff(this.selected)) {
       const selectedRows = this.selected.filter(row =>
-        this.group()?.value.find(item => item === row)
+        this.group()?.value.find((item: TRow) => item === row)
       );
       if (this.checkBoxInput) {
         if (selectedRows.length && selectedRows.length !== this.group()?.value.length) {
@@ -183,7 +185,7 @@ export class DataTableRowWrapperComponent<TRow = any> implements DoCheck, OnInit
   onCheckboxChange(groupSelected: boolean): void {
     // First remove all rows of this group from `selected`
     this.selected = [
-      ...this.selected.filter(row => !this.group().value.find(item => item === row))
+      ...this.selected.filter(row => !this.group().value.find((item: TRow) => item === row))
     ];
     // If checkbox is checked then add all rows of this group in `selected`
     if (groupSelected) {

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -18,7 +18,7 @@ import {
 
 import { columnGroupWidths, columnsByPin, columnsByPinArr } from '../../utils/column';
 import { Keys } from '../../utils/keys';
-import { ActivateEvent, RowOrGroup, TreeStatus } from '../../types/public.types';
+import { ActivateEvent, Row, RowOrGroup, TreeStatus } from '../../types/public.types';
 import {
   ColumnGroupWidth,
   PinnedColumns,
@@ -65,7 +65,7 @@ import { DataTableBodyCellComponent } from './body-cell.component';
   styleUrl: './body-row.component.scss',
   imports: [DataTableBodyCellComponent]
 })
-export class DataTableBodyRowComponent<TRow = any> implements DoCheck, OnChanges {
+export class DataTableBodyRowComponent<TRow extends Row = any> implements DoCheck, OnChanges {
   private cd = inject(ChangeDetectorRef);
 
   @Input() set columns(val: TableColumnInternal[]) {

--- a/projects/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
@@ -1,11 +1,11 @@
 import { ContentChild, Directive, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
 import { DatatableRowDetailTemplateDirective } from './row-detail-template.directive';
-import { DetailToggleEvents, RowDetailContext } from '../../types/public.types';
+import { DetailToggleEvents, Row, RowDetailContext } from '../../types/public.types';
 
 @Directive({
   selector: 'ngx-datatable-row-detail'
 })
-export class DatatableRowDetailDirective<TRow = any> {
+export class DatatableRowDetailDirective<TRow extends Row = any> {
   /**
    * The detail row height is required especially
    * when virtual scroll is enabled.

--- a/projects/ngx-datatable/src/lib/types/internal.types.ts
+++ b/projects/ngx-datatable/src/lib/types/internal.types.ts
@@ -1,6 +1,6 @@
 import { TableColumn, TableColumnProp } from './table-column.type';
 import { ValueGetter } from '../utils/column-prop-getters';
-import { SortDirection } from './public.types';
+import { Row, SortDirection } from './public.types';
 
 export type PinDirection = 'left' | 'center' | 'right';
 
@@ -51,7 +51,7 @@ export interface InnerSortEvent {
   newValue: SortDirection;
 }
 
-export interface TableColumnInternal<TRow = any> extends TableColumn<TRow> {
+export interface TableColumnInternal<TRow extends Row = any> extends TableColumn<TRow> {
   /** Internal unique id */
   $$id: string;
 

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -52,13 +52,13 @@ export interface HeaderCellContext {
   selectFn: () => void;
 }
 
-export interface GroupContext<TRow = any> {
+export interface GroupContext<TRow extends Row = any> {
   group: Group<TRow>;
   expanded: boolean;
   rowIndex: number;
 }
 
-export interface CellContext<TRow = any> {
+export interface CellContext<TRow extends Row = any> {
   onCheckboxChangeFn: (event: Event) => void;
   activateFn: (event: ActivateEvent<TRow>) => void;
   row: TRow;
@@ -99,7 +99,7 @@ export interface Group<TRow> {
 /** Type for either a row or a group */
 export type RowOrGroup<TRow> = TRow | Group<TRow>;
 
-export interface RowDetailContext<TRow = any> {
+export interface RowDetailContext<TRow extends Row = any> {
   row: TRow;
   expanded: boolean;
   rowIndex: number;

--- a/projects/ngx-datatable/src/lib/types/table-column.type.ts
+++ b/projects/ngx-datatable/src/lib/types/table-column.type.ts
@@ -1,5 +1,5 @@
 import { PipeTransform, TemplateRef } from '@angular/core';
-import { CellContext, HeaderCellContext } from './public.types';
+import { CellContext, HeaderCellContext, Row } from './public.types';
 
 /**
  * Column property that indicates how to retrieve this column's
@@ -11,7 +11,7 @@ export type TableColumnProp = string | number;
 /**
  * Column Type
  */
-export interface TableColumn<TRow = any> {
+export interface TableColumn<TRow extends Row = any> {
   /**
    * Determines if column is checkbox
    */


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Sometimes declarations of the generic type `TRow` has no type constraint although in fact the table generally has one. So far the constrain was only added when needed.

**What is the new behavior?**

Declarations of `TRow` now always have a constraint.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This is mainly for consitantancy but it seems like it is also needed in certain cases for strict null checks.