### PR TITLE
refactor(scss): migrate from `@import` to `@use`

### DIFF
--- a/docs/introduction/themes.md
+++ b/docs/introduction/themes.md
@@ -8,9 +8,9 @@ include that in your application `themes/material.css` and add the CSS class `ma
 This is a simple way to apply the style of the demo.
 
 ```scss
-@import '~@siemens/ngx-datatable/index.css';
-@import '~@siemens/ngx-datatable/themes/material.scss';
-@import '~@siemens/ngx-datatable/assets/icons.css';
+@use '~@siemens/ngx-datatable/index.css' as *;
+@use '~@siemens/ngx-datatable/themes/material.scss' as *;
+@use '~@siemens/ngx-datatable/assets/icons.css' as *;
 ```
 
 You can just add above to your `scss` file and then specify the class of your ngx-datatable to `<ngx-datatable class="material">`

--- a/projects/ngx-datatable/src/lib/themes/bootstrap.scss
+++ b/projects/ngx-datatable/src/lib/themes/bootstrap.scss
@@ -11,8 +11,8 @@ $datatable-ghost-cell-strip-background-image: linear-gradient(
 $datatable-ghost-cell-strip-radius: 0 !default;
 $datatble-ghost-cell-animation-duration: 10s;
 
-@import './ghost';
-@import './rows';
+@use './ghost' as *;
+@use './rows' as *;
 
 .ngx-datatable.bootstrap {
   box-shadow: none;

--- a/projects/ngx-datatable/src/lib/themes/material.scss
+++ b/projects/ngx-datatable/src/lib/themes/material.scss
@@ -9,9 +9,9 @@
   $ngx-datatable-selected-active-background: yellow;
   $ngx-datatable-selected-active-background-hover: rgba(yellow, 0.2);
 
-  @import '~@siemens/ngx-datatable/index.css';
-  @import '~@siemens/ngx-datatable/themes/material.scss';
-  @import '~@siemens/ngx-datatable/assets/icons.css';
+  @use '~@siemens/ngx-datatable/index.css' as *;
+  @use '~@siemens/ngx-datatable/themes/material.scss' as *;
+  @use '~@siemens/ngx-datatable/assets/icons.css' as *;
 
 That's all.
 */
@@ -81,8 +81,8 @@ $datatable-ghost-cell-strip-background-image: linear-gradient(
 $datatable-ghost-cell-strip-radius: 0 !default;
 $datatble-ghost-cell-animation-duration: 10s;
 
-@import './ghost';
-@import './rows';
+@use './ghost' as *;
+@use './rows' as *;
 
 .ngx-datatable.material {
   background: $ngx-datatable-background;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,6 +2,6 @@
 
 $datatable-pager-color: rgba(0, 0, 0, 0.64);
 
-@import '../projects/ngx-datatable/src/lib/themes/material';
-@import '../projects/ngx-datatable/src/lib/themes/dark';
-@import '../projects/ngx-datatable/src/lib/themes/bootstrap';
+@use '../projects/ngx-datatable/src/lib/themes/material' as *;
+@use '../projects/ngx-datatable/src/lib/themes/dark' as *;
+@use '../projects/ngx-datatable/src/lib/themes/bootstrap' as *;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The stylesheets are using the deprecated `@import` statement, hence throwing deprecation warnings.

**What is the new behavior?**

The stylesheets are using the recommended `@use` statement.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Follow-up to https://github.com/siemens/ngx-datatable/pull/207.
