### PR TITLE
fix: prevent errors with row-specific ghost loading in combination with grouping, selection and trees

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -276,14 +276,14 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     return this._pageSize;
   }
 
-  @Input() set rows(val: TRow[]) {
+  @Input() set rows(val: (TRow | undefined)[]) {
     if (val !== this._rows) {
       this._rows = val;
       this.recalcLayout();
     }
   }
 
-  get rows(): TRow[] {
+  get rows(): (TRow | undefined)[] {
     return this._rows;
   }
 
@@ -386,11 +386,11 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   offsetY = 0;
   indexes = signal<{ first: number; last: number }>({ first: 0, last: 0 });
   columnGroupWidths: ColumnGroupWidth;
-  rowTrackingFn: TrackByFunction<RowOrGroup<TRow>>;
+  rowTrackingFn: TrackByFunction<RowOrGroup<TRow> | undefined>;
   listener: any;
   rowExpansions: any[] = [];
 
-  _rows: TRow[];
+  _rows: (TRow | undefined)[];
   _bodyHeight: string;
   _columns: TableColumnInternal[];
   _rowCount: number;
@@ -540,7 +540,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   /**
    * Updates the rows in the view port
    */
-  updateRows(): RowOrGroup<TRow>[] {
+  updateRows(): (RowOrGroup<TRow> | undefined)[] {
     const { first, last } = this.indexes();
     // if grouprowsby has been specified treat row paging
     // parameters as group paging parameters ie if limit 10 has been
@@ -682,7 +682,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
       const rowExpansions = new Set<TRow>();
       if (this.rowDetail) {
         for (const row of this.rows) {
-          if (this.getRowExpanded(row)) {
+          if (row && this.getRowExpanded(row)) {
             rowExpansions.add(row);
           }
         }
@@ -1067,7 +1067,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     return !!this.groupedRows;
   }
 
-  protected isRow(row: RowOrGroup<TRow>): row is TRow {
+  protected isRow(row: RowOrGroup<TRow> | undefined): row is TRow {
     return !this.groupedRows;
   }
 }

--- a/projects/ngx-datatable/src/lib/utils/selection.ts
+++ b/projects/ngx-datatable/src/lib/utils/selection.ts
@@ -12,7 +12,7 @@ export function selectRows<TRow>(selected: TRow[], row: TRow, comparefn: any) {
 
 export function selectRowsBetween<TRow>(
   selected: TRow[],
-  rows: TRow[],
+  rows: (TRow | undefined)[],
   index: number,
   prevIndex: number
 ): TRow[] {
@@ -39,7 +39,7 @@ export function selectRowsBetween<TRow>(
     if ((reverse && lesser) || (!reverse && greater)) {
       // if in the positive range to be added to `selected`, and
       // not already in the selected array, add it
-      if (i >= range.start && i <= range.end) {
+      if (i >= range.start && i <= range.end && row) {
         selected.push(row);
       }
     }

--- a/projects/ngx-datatable/src/lib/utils/tree.ts
+++ b/projects/ngx-datatable/src/lib/utils/tree.ts
@@ -44,12 +44,12 @@ export function optionalGetterForProp(prop: TableColumnProp): OptionalValueGette
  *
  */
 export function groupRowsByParents<TRow extends Row>(
-  rows: TRow[],
+  rows: (TRow | undefined)[],
   from?: OptionalValueGetter,
   to?: OptionalValueGetter
-): TRow[] {
+): (TRow | undefined)[] {
   if (from && to) {
-    const treeRows = rows.map(row => new TreeNode(row));
+    const treeRows = rows.filter(row => !!row).map(row => new TreeNode(row));
     const uniqIDs = new Map(treeRows.map(node => [to(node.row), node]));
 
     const rootNodes = treeRows.reduce((root, node) => {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When using row-specific ghost loading, so providing `undefined` rows, the table will break if this is used with grouping, selection and trees.

**What is the new behavior?**

Grouping, selection and trees are guarded against undefined rows. 
This is just preventing runtime errors and not supporting the combination. Since we use `undefined` to mark loading rows, we do not have access to group keys and things alike. So it is not possible yet to have loading rows inside a group or a tree structure.

To solve this, we need to enhance the API.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This is just fixing typescript errors that occurs when adding strict null checks.
As written above, for an actual solution, we need to change the API.