### PR TITLE
feat: enforce `prop` or `name` on `TableColumn`

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
@@ -400,6 +400,7 @@ describe('DatatableComponent With Custom Templates', () => {
   });
 
   it('should sort when the table is initially rendered if `sorts` are provided', () => {
+    component.columnTwoProp = '---';
     component.rows = [{ id: 5 }, { id: 20 }, { id: 12 }];
     component.sorts = [
       {

--- a/projects/ngx-datatable/src/lib/utils/column-helper.ts
+++ b/projects/ngx-datatable/src/lib/utils/column-helper.ts
@@ -5,8 +5,9 @@ import { TableColumn } from '../types/table-column.type';
 import { QueryList } from '@angular/core';
 import { DataTableColumnDirective } from '../components/columns/column.directive';
 import { TableColumnInternal } from '../types/internal.types';
+import { Row } from '../types/public.types';
 
-export function toInternalColumn<T>(
+export function toInternalColumn<T extends Row>(
   columns: TableColumn<T>[] | QueryList<DataTableColumnDirective<T>>,
   defaultColumnWidth = 150
 ): TableColumnInternal<T>[] {
@@ -14,10 +15,14 @@ export function toInternalColumn<T>(
   // TS fails to infer the type here.
   return (columns as TableColumn<T>[]).map(column => {
     const prop = column.prop ?? (column.name ? camelCase(column.name) : undefined);
+    // prop = 0 is valid
+    if (prop === undefined) {
+      throw new Error(`Column prop or name is required.`);
+    }
     // Only one column should hold the tree view,
     // Thus if multiple columns are provided with
     // isTreeColumn as true, we take only the first one
-    const isTreeColumn = column.isTreeColumn && !hasTreeColumn;
+    const isTreeColumn = !!column.isTreeColumn && !hasTreeColumn;
     hasTreeColumn = hasTreeColumn || isTreeColumn;
     return {
       ...column,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Not providing `prop` and `name` already breaks the table, but not obvious error is reported.

**What is the new behavior?**
An explicit error is thrown, if neither `prop` or `name` are provided.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
This is needed to enable strict null checks.