### PR TITLE
refactor: drop useless stable sort code

### DIFF
--- a/projects/ngx-datatable/src/lib/utils/sort.ts
+++ b/projects/ngx-datatable/src/lib/utils/sort.ts
@@ -83,13 +83,6 @@ export function sortRows<TRow>(rows: TRow[], columns: TableColumn[], dirs: SortP
     return [...rows];
   }
 
-  /**
-   * record the row ordering of results from prior sort operations (if applicable)
-   * this is necessary to guarantee stable sorting behavior
-   */
-  const rowToIndexMap = new Map<TRow, number>();
-  rows.forEach((row, index) => rowToIndexMap.set(row, index));
-
   const temp = [...rows];
   const cols = columns.reduce(
     (obj, col) => {
@@ -139,14 +132,7 @@ export function sortRows<TRow>(rows: TRow[], columns: TableColumn[], dirs: SortP
       }
     }
 
-    if (!(rowToIndexMap.has(rowA) && rowToIndexMap.has(rowB))) {
-      return 0;
-    }
-
-    /**
-     * all else being equal, preserve original order of the rows (stable sort)
-     */
-    return rowToIndexMap.get(rowA) < rowToIndexMap.get(rowB) ? -1 : 1;
+    return 0;
   });
 }
 


### PR DESCRIPTION
Since ES2019 Array.sort is guaranteed to be stable.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Useless code to make output of sorting stable. (No longer needed since ES2019, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_stability)

**What is the new behavior?**

Dropped useless code for making sort output stable.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
