### PR TITLE
refactor: split activation event

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -24,7 +24,7 @@ import {
   TreeStatus
 } from '../../types/public.types';
 import { NgTemplateOutlet } from '@angular/common';
-import { RowIndex, TableColumnInternal } from '../../types/internal.types';
+import { CellActiveEvent, RowIndex, TableColumnInternal } from '../../types/internal.types';
 
 @Component({
   selector: 'datatable-body-cell',
@@ -209,7 +209,7 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
 
   @Input() ghostLoadingIndicator = false;
 
-  @Output() activate = new EventEmitter<ActivateEvent<TRow>>();
+  @Output() activate = new EventEmitter<CellActiveEvent<TRow>>();
 
   @Output() treeAction = new EventEmitter<any>();
 

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -20,6 +20,7 @@ import { columnGroupWidths, columnsByPin, columnsByPinArr } from '../../utils/co
 import { Keys } from '../../utils/keys';
 import { ActivateEvent, Row, RowOrGroup, TreeStatus } from '../../types/public.types';
 import {
+  CellActiveEvent,
   ColumnGroupWidth,
   PinnedColumns,
   RowIndex,
@@ -171,10 +172,8 @@ export class DataTableBodyRowComponent<TRow extends Row = any> implements DoChec
     }
   }
 
-  onActivate(event: ActivateEvent<TRow>, index: number): void {
-    event.cellIndex = index;
-    event.rowElement = this._element;
-    this.activate.emit(event);
+  onActivate(event: CellActiveEvent<TRow>, index: number): void {
+    this.activate.emit({ ...event, rowElement: this._element, cellIndex: index });
   }
 
   @HostListener('keydown', ['$event'])

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -961,7 +961,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
       }
       if (!model.cellElement || !isCellSelection) {
         this.focusRow(model.rowElement, key);
-      } else if (isCellSelection) {
+      } else if (isCellSelection && model.cellIndex) {
         this.focusCell(model.cellElement, model.rowElement, key, model.cellIndex);
       }
     }

--- a/projects/ngx-datatable/src/lib/types/internal.types.ts
+++ b/projects/ngx-datatable/src/lib/types/internal.types.ts
@@ -1,6 +1,6 @@
 import { TableColumn, TableColumnProp } from './table-column.type';
 import { ValueGetter } from '../utils/column-prop-getters';
-import { Row, SortDirection } from './public.types';
+import { Row, SortDirection, TreeStatus } from './public.types';
 
 export type PinDirection = 'left' | 'center' | 'right';
 
@@ -49,6 +49,18 @@ export interface InnerSortEvent {
   column: TableColumnInternal;
   prevValue: SortDirection;
   newValue: SortDirection;
+}
+
+export interface CellActiveEvent<TRow> {
+  type: 'checkbox' | 'click' | 'dblclick' | 'keydown' | 'mouseenter';
+  event: Event;
+  row: TRow;
+  group?: TRow[];
+  rowHeight?: number;
+  column?: TableColumn;
+  value?: any;
+  cellElement?: HTMLElement;
+  treeStatus?: TreeStatus;
 }
 
 export interface BaseTableColumnInternal<TRow extends Row = any> extends TableColumn<TRow> {

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -41,7 +41,7 @@ export interface ActivateEvent<TRow> {
   cellElement?: HTMLElement;
   treeStatus?: TreeStatus;
   cellIndex?: number;
-  rowElement?: HTMLElement;
+  rowElement: HTMLElement;
 }
 
 export interface HeaderCellContext {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The `ActivationEvent` type is used in two difference context:
- on a higher level, always including the activated row HTML element
- on a lower level, not including the HTML element

**What is the new behavior?**

The type is split into the two individual ones:

- `ActivationEvent` now enforcing a `rowElement` being defined
- `CellActivationEvent` (internal) never having a `rowElement` defined

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This whole activation thing is a huge mess, based on what I understood so far.
It generally needs an overhaul, but for now this allows us at least to use strict `null` checks.
