### PR TITLE
feat: include sorts in page event

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -758,7 +758,8 @@ export class DatatableComponent<TRow extends Row = any>
           count: this.count,
           pageSize: this.pageSize,
           limit: this.limit,
-          offset: 0
+          offset: 0,
+          sorts: this.sorts
         });
       }
     });
@@ -999,7 +1000,8 @@ export class DatatableComponent<TRow extends Row = any>
         count: this.count,
         pageSize: this.pageSize,
         limit: this.limit,
-        offset: this.offset
+        offset: this.offset,
+        sorts: this.sorts
       });
     }
   }
@@ -1023,7 +1025,8 @@ export class DatatableComponent<TRow extends Row = any>
       count: this.count,
       pageSize: this.pageSize,
       limit: this.limit,
-      offset: this.offset
+      offset: this.offset,
+      sorts: this.sorts
     });
 
     if (this.selectAllRowsOnPage) {
@@ -1194,7 +1197,8 @@ export class DatatableComponent<TRow extends Row = any>
       count: this.count,
       pageSize: this.pageSize,
       limit: this.limit,
-      offset: this.offset
+      offset: this.offset,
+      sorts: this.sorts
     });
     this.sort.emit(event);
   }

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -128,6 +128,7 @@ export interface PageEvent {
   /** @deprecated Use {@link pageSize} instead. */
   limit: number | undefined;
   offset: number;
+  sorts: SortPropDir[];
 }
 
 export interface PagerPageEvent {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The page event is currently used for two main use cases:

- custom pagination
- server side paging

Currently this event does not contain the `sorts` object for server side paging, hence consumers always must listen to sort changes as well.
This turned into a problem with #45+. Since the sort and page events are always emitted together on sort change as it may reset the page to 0.  So when implementing server side paging one has to merge the two events in case of sorting to prevent duplicate backend calls.

**What is the new behavior?**

The page event now also contains  the `sorts` object. With this change, apps can now always use the page event and no longer need to subscribe to the sort event.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

I initially planned to introduce a new event for external state, but it turned out that this would have basically the same properties as the existing page event and it is also always fired in the same location. So I just extended the page event.

In the long run we should consider options to clean up those events. I don't see a reason to maintain a separate sort and page event. With this change, the sort event becomes useless (unless someone needs to know what exactly was changed.

So we could consider deprecating both and introduce something like a `stateChange` event. But this is up for a later discussion I guess.
