### PR TITLE
chore(lfs): swtich LFS target from `siemens-research` to `siemens`

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,3 +1,3 @@
 [lfs]
-	url = https://github.com/siemens-research/ngx-datatable-snapshots.git/info/lfs
-	pushurl = https://github.com/siemens-research/ngx-datatable-snapshots.git/info/lfs
+	url = https://github.com/siemens/ngx-datatable-snapshots.git/info/lfs
+	pushurl = https://github.com/siemens/ngx-datatable-snapshots.git/info/lfs


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The Git LFS target points to the https://github.com/siemens-research/ngx-datatable-snapshots project.

**What is the new behavior?**

The Git LFS target points to the https://github.com/siemens/ngx-datatable-snapshots project.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The previous Git LFS issues were resolved by the GitHub support team and the old project is usable again. All files were synced manually.
