### PR TITLE
refactor: all header pinned columns should be flex

### DIFF
--- a/projects/ngx-datatable/src/lib/components/header/header.component.scss
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.scss
@@ -13,4 +13,8 @@
   }
 }
 
+.datatable-row-group {
+  display: flex;
+}
+
 @include shared.pinned-columns();

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -21,7 +21,7 @@ import {
   SortPropDir,
   SortType
 } from '../../types/public.types';
-import { NgStyle } from '@angular/common';
+import { NgClass, NgStyle } from '@angular/common';
 import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
 import {
   ColumnResizeEventInternal,
@@ -50,7 +50,11 @@ import { OrderableDirective } from '../../directives/orderable.directive';
     >
       @for (colGroup of _columnsByPin; track colGroup.type) {
         @if (colGroup.columns.length) {
-          <div [class]="'datatable-row-' + colGroup.type" [ngStyle]="_styleByGroup[colGroup.type]">
+          <div
+            class="datatable-row-group"
+            [ngClass]="'datatable-row-' + colGroup.type"
+            [ngStyle]="_styleByGroup[colGroup.type]"
+          >
             @for (column of colGroup.columns; track column.$$id) {
               <datatable-header-cell
                 role="columnheader"
@@ -100,7 +104,8 @@ import { OrderableDirective } from '../../directives/orderable.directive';
     NgStyle,
     DataTableHeaderCellComponent,
     LongPressDirective,
-    DraggableDirective
+    DraggableDirective,
+    NgClass
   ]
 })
 export class DataTableHeaderComponent implements OnDestroy, OnChanges {


### PR DESCRIPTION
We accidentally removed the flex container on column groups for pinning. Please note that we have the same in body rows where we kept the container as flex.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

We were missing `display: flex` on column groups in the header. This was accidentally removed. Body rows are still having this.

**What is the new behavior?**

Column groups in the header are now also flex container again.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This is labelled as refactoring since we never released the previous change.
