### PR TITLE
refactor: remove general `box-sizing: border-box`

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.scss
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.scss
@@ -4,10 +4,4 @@
   justify-content: center;
   position: relative;
   transform: translate3d(0, 0, 0);
-
-  *,
-  *:before,
-  *:after {
-    box-sizing: border-box;
-  }
 }

--- a/projects/ngx-datatable/src/lib/themes/bootstrap.scss
+++ b/projects/ngx-datatable/src/lib/themes/bootstrap.scss
@@ -17,6 +17,13 @@ $datatble-ghost-cell-animation-duration: 10s;
 .ngx-datatable.bootstrap {
   box-shadow: none;
   font-size: 13px;
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
+
   .datatable-header {
     height: unset !important;
     .datatable-header-cell {

--- a/projects/ngx-datatable/src/lib/themes/dark.scss
+++ b/projects/ngx-datatable/src/lib/themes/dark.scss
@@ -5,6 +5,12 @@
   color: #fff;
   font-size: 13px;
 
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
+
   .datatable-header {
     background: #181b24;
     color: #72809b;

--- a/projects/ngx-datatable/src/lib/themes/material.scss
+++ b/projects/ngx-datatable/src/lib/themes/material.scss
@@ -88,6 +88,12 @@ $datatble-ghost-cell-animation-duration: 10s;
   background: $ngx-datatable-background;
   box-shadow: $ngx-datatable-box-shadow;
 
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
+
   &.striped {
     .datatable-row-odd {
       background: $ngx-datatable-row-odd-background;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`box-sizing: border-box;` applied everywhere by default.

**What is the new behavior?**

`box-sizing: border-box;` must be applied by a custom theme if required for whatever custom reason.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Apps need to define `box-sizing: border-box;` on their own if they need it.

**Other information**:

This is part of our efforts to enable view encapsulation.
