### PR TITLE
refactor: move or replace `[hidden]` style to drop in from global styles

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.scss
@@ -17,3 +17,7 @@ datatable-scroller {
     white-space: nowrap;
   }
 }
+
+[hidden] {
+  display: none !important;
+}

--- a/projects/ngx-datatable/src/lib/components/datatable.component.scss
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.scss
@@ -5,10 +5,6 @@
   position: relative;
   transform: translate3d(0, 0, 0);
 
-  [hidden] {
-    display: none !important;
-  }
-
   *,
   *:before,
   *:after {

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
@@ -158,19 +158,13 @@ describe('DataTableFooterComponent', () => {
       component.pageSize = 5;
       page.detectChangesAndRunQueries();
 
-      expect(page.datatablePager.nativeElement.hidden).toBe(
-        false,
-        'DataTablePagerComponent should be hidden'
-      );
+      expect(page.datatablePager).toBeTruthy();
 
       component.rowCount = 1;
       component.pageSize = 2;
       page.detectChangesAndRunQueries();
 
-      expect(page.datatablePager.nativeElement.hidden).toBe(
-        true,
-        'DataTablePagerComponent should not be hidden'
-      );
+      expect(page.datatablePager).toBeFalsy();
     });
   });
 

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
@@ -30,18 +30,19 @@ import { NgClass, NgTemplateOutlet } from '@angular/common';
           }
           {{ rowCount?.toLocaleString() }} {{ totalMessage }}
         </div>
-        <datatable-pager
-          [pagerLeftArrowIcon]="pagerLeftArrowIcon"
-          [pagerRightArrowIcon]="pagerRightArrowIcon"
-          [pagerPreviousIcon]="pagerPreviousIcon"
-          [pagerNextIcon]="pagerNextIcon"
-          [page]="curPage"
-          [size]="pageSize"
-          [count]="rowCount"
-          [hidden]="!isVisible"
-          (change)="page.emit($event)"
-        >
-        </datatable-pager>
+        @if (isVisible) {
+          <datatable-pager
+            [pagerLeftArrowIcon]="pagerLeftArrowIcon"
+            [pagerRightArrowIcon]="pagerRightArrowIcon"
+            [pagerPreviousIcon]="pagerPreviousIcon"
+            [pagerNextIcon]="pagerNextIcon"
+            [page]="curPage"
+            [size]="pageSize"
+            [count]="rowCount"
+            (change)="page.emit($event)"
+          >
+          </datatable-pager>
+        }
       }
     </div>
   `,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Hidden styling is integrated into the root style and used in multiple components.

**What is the new behavior?**

Hidden styling is moved to body, where we keep it using to avoid recreation of elements while loading.
In the footer it is replaced by `@if`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Brings us closer to the overall goal to enable view encapsulation.