### PR TITLE
feat: introduce a new `providedNgxDatatableConfig`

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -30,7 +30,6 @@ import {
 import { DatatableGroupHeaderDirective } from './body/body-group-header.directive';
 
 import { Subscription } from 'rxjs';
-import { INgxDatatableConfig } from '../ngx-datatable.module';
 import { groupRowsByParents, optionalGetterForProp } from '../utils/tree';
 import { TableColumn } from '../types/table-column.type';
 import { DataTableColumnDirective } from './columns/column.directive';
@@ -75,6 +74,7 @@ import {
   ReorderEventInternal,
   TableColumnInternal
 } from '../types/internal.types';
+import { NGX_DATATABLE_CONFIG, NgxDatatableConfig } from '../ngx-datatable.config';
 
 @Component({
   selector: 'ngx-datatable',
@@ -107,7 +107,10 @@ export class DatatableComponent<TRow extends Row = any>
   private scrollbarHelper = inject(ScrollbarHelper);
   private cd = inject(ChangeDetectorRef);
   private columnChangesService = inject(ColumnChangesService);
-  private configuration = inject<INgxDatatableConfig>('configuration' as any, { optional: true });
+  private configuration =
+    inject(NGX_DATATABLE_CONFIG, { optional: true }) ??
+    // This is the old injection token for backward compatibility.
+    inject<NgxDatatableConfig>('configuration' as any, { optional: true });
 
   /**
    * Template for the target marker of drag target columns.
@@ -357,7 +360,7 @@ export class DatatableComponent<TRow extends Row = any>
   /**
    * Css class overrides
    */
-  @Input() cssClasses: Partial<Required<INgxDatatableConfig>['cssClasses']> = {};
+  @Input() cssClasses: Partial<Required<NgxDatatableConfig>['cssClasses']> = {};
 
   /**
    * Message overrides for localization
@@ -376,7 +379,7 @@ export class DatatableComponent<TRow extends Row = any>
    * }
    * ```
    */
-  @Input() messages: Partial<Required<INgxDatatableConfig>['messages']> = {};
+  @Input() messages: Partial<Required<NgxDatatableConfig>['messages']> = {};
 
   /**
    * A function which is called with the row and should return either:

--- a/projects/ngx-datatable/src/lib/ngx-datatable.config.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.config.ts
@@ -1,0 +1,76 @@
+import { InjectionToken, Provider } from '@angular/core';
+
+/** Interface for messages to override default table texts. */
+export interface NgxDatatableMessages {
+  /** Message to show when the array is present but empty */
+  emptyMessage: string;
+  /** Footer total message */
+  totalMessage: string;
+  /** Footer selected message */
+  selectedMessage: string;
+  /** Pager screen reader message for the first page button */
+  ariaFirstPageMessage: string;
+  /**
+   * Pager screen reader message for the n-th page button.
+   * It will be rendered as: `{{ariaPageNMessage}} {{n}}`.
+   */
+  ariaPageNMessage: string;
+  /** Pager screen reader message for the previous page button */
+  ariaPreviousPageMessage: string;
+  /** Pager screen reader message for the next page button */
+  ariaNextPageMessage: string;
+  /** Pager screen reader message for the last page button */
+  ariaLastPageMessage: string;
+}
+
+/** CSS classes for icons that override the default table icons. */
+export interface NgxDatatableCssClasses {
+  sortAscending: string;
+  sortDescending: string;
+  sortUnset: string;
+  pagerLeftArrow: string;
+  pagerRightArrow: string;
+  pagerPrevious: string;
+  pagerNext: string;
+}
+
+/**
+ * Interface definition for ngx-datatable global configuration
+ */
+// TODO those properties should all be required in the interface. Should be changed with signal migration.
+export interface NgxDatatableConfig {
+  messages?: NgxDatatableMessages;
+  cssClasses?: NgxDatatableCssClasses;
+  headerHeight?: number;
+  footerHeight?: number;
+  rowHeight?: number;
+  defaultColumnWidth?: number;
+}
+
+export const NGX_DATATABLE_CONFIG = new InjectionToken<NgxDatatableConfig>('ngx-datatable.config');
+
+/**
+ * This makes all properties recursively optional.
+ *
+ * @internal
+ */
+export type AllPartial<T> = { [K in keyof T]?: AllPartial<T[K]> };
+
+/**
+ * Interface definition for INgxDatatableConfig global configuration.
+ *
+ * @deprecated Use {@link NgxDatatableConfig} instead.
+ */
+export type INgxDatatableConfig = NgxDatatableConfig;
+
+/**
+ * Provides a global configuration for ngx-datatable.
+ *
+ * @param overrides The overrides of the table configuration.
+ */
+export function providedNgxDatatableConfig(overrides: AllPartial<NgxDatatableConfig>): Provider {
+  return {
+    provide: NGX_DATATABLE_CONFIG,
+    useValue: overrides
+  };
+}

--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -16,6 +16,7 @@ import {
   DatatableRowDefComponent,
   DatatableRowDefDirective
 } from './components/body/body-row-def.component';
+import { AllPartial, NgxDatatableConfig, providedNgxDatatableConfig } from './ngx-datatable.config';
 
 @NgModule({
   imports: [
@@ -58,50 +59,12 @@ export class NgxDatatableModule {
    * Configure global configuration via INgxDatatableConfig
    * @param configuration
    */
-  static forRoot(configuration: INgxDatatableConfig): ModuleWithProviders<NgxDatatableModule> {
+  static forRoot(
+    configuration: AllPartial<NgxDatatableConfig>
+  ): ModuleWithProviders<NgxDatatableModule> {
     return {
       ngModule: NgxDatatableModule,
-      providers: [{ provide: 'configuration', useValue: configuration }]
+      providers: [providedNgxDatatableConfig(configuration)]
     };
   }
-}
-
-/**
- * Interface definition for INgxDatatableConfig global configuration
- */
-export interface INgxDatatableConfig {
-  messages?: {
-    /** Message to show when the array is present but empty */
-    emptyMessage: string;
-    /** Footer total message */
-    totalMessage: string;
-    /** Footer selected message */
-    selectedMessage: string;
-    /** Pager screen reader message for the first page button */
-    ariaFirstPageMessage: string;
-    /**
-     * Pager screen reader message for the n-th page button.
-     * It will be rendered as: `{{ariaPageNMessage}} {{n}}`.
-     */
-    ariaPageNMessage: string;
-    /** Pager screen reader message for the previous page button */
-    ariaPreviousPageMessage: string;
-    /** Pager screen reader message for the next page button */
-    ariaNextPageMessage: string;
-    /** Pager screen reader message for the last page button */
-    ariaLastPageMessage: string;
-  };
-  cssClasses?: {
-    sortAscending: string;
-    sortDescending: string;
-    sortUnset: string;
-    pagerLeftArrow: string;
-    pagerRightArrow: string;
-    pagerPrevious: string;
-    pagerNext: string;
-  };
-  headerHeight?: number;
-  footerHeight?: number;
-  rowHeight?: number;
-  defaultColumnWidth?: number;
 }

--- a/projects/ngx-datatable/src/public-api.ts
+++ b/projects/ngx-datatable/src/public-api.ts
@@ -24,3 +24,10 @@ export * from './lib/directives/disable-row.directive';
 // types
 export * from './lib/types/public.types';
 export * from './lib/types/table-column.type';
+
+export {
+  providedNgxDatatableConfig,
+  NgxDatatableConfig,
+  NgxDatatableMessages,
+  NgxDatatableCssClasses
+} from './lib/ngx-datatable.config';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
-import { enableProdMode, importProvidersFrom } from '@angular/core';
+import { enableProdMode } from '@angular/core';
 
 import { environment } from './environments/environment';
 import { provideHttpClient } from '@angular/common/http';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { routes } from './app/app-routing.module';
-import { NgxDatatableModule } from 'projects/ngx-datatable/src/public-api';
+import { providedNgxDatatableConfig } from 'projects/ngx-datatable/src/public-api';
 import { AppComponent } from './app/app.component';
 import { provideRouter, withHashLocation } from '@angular/router';
 
@@ -14,20 +14,18 @@ if (environment.production) {
 
 bootstrapApplication(AppComponent, {
   providers: [
-    importProvidersFrom(
-      NgxDatatableModule.forRoot({
-        messages: {
-          emptyMessage: 'No data to display', // Message to show when array is presented, but contains no values
-          totalMessage: 'total', // Footer total message
-          selectedMessage: 'selected', // Footer selected message
-          ariaFirstPageMessage: 'go to first page', // Pager screen reader message for the first page button
-          ariaPreviousPageMessage: 'go to previous page', // Pager screen reader message for the previous page button
-          ariaPageNMessage: 'page', // Pager screen reader message for the n-th page button
-          ariaNextPageMessage: 'go to next page', // Pager screen reader message for the next page button
-          ariaLastPageMessage: 'go to last page' // Pager screen reader message for the last page button
-        }
-      })
-    ),
+    providedNgxDatatableConfig({
+      messages: {
+        emptyMessage: 'No data to display', // Message to show when array is presented, but contains no values
+        totalMessage: 'total', // Footer total message
+        selectedMessage: 'selected', // Footer selected message
+        ariaFirstPageMessage: 'go to first page', // Pager screen reader message for the first page button
+        ariaPreviousPageMessage: 'go to previous page', // Pager screen reader message for the previous page button
+        ariaPageNMessage: 'page', // Pager screen reader message for the n-th page button
+        ariaNextPageMessage: 'go to next page', // Pager screen reader message for the next page button
+        ariaLastPageMessage: 'go to last page' // Pager screen reader message for the last page button
+      }
+    }),
     provideRouter(routes, withHashLocation()),
     provideHttpClient()
   ]


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

- config is provided using the string `configuration` (Angular types do not even allow injecting a string)
- there is no provider function for a standalone way
- messages and css classes are  all required when globally provided (although this is no needed)

**What is the new behavior?**

- proper injection token is used (but `configuration` still works)
- new function to provide config in a standalone manner
- messages and css classes are all optional too and global provider

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

In Element we depend on `configuration` to override the table config. So I kept it for now. See https://github.com/siemens/element/blob/main/projects/element-ng/datatable/index.ts#L71.

**This also removes the previous breaking change of requiring new messages. Since all messages are now optional.**
