### PR TITLE
refactor: base internal row length on rowCount property

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -5,6 +5,8 @@ import { DatatableComponentToken } from '../../utils/table-token';
 import { By } from '@angular/platform-browser';
 import { DataTableBodyRowComponent } from './body-row.component';
 import { toInternalColumn } from '../../utils/column-helper';
+import { ScrollerComponent } from './scroller.component';
+import { DataTableGhostLoaderComponent } from './ghost-loader/ghost-loader.component';
 
 describe('DataTableBodyComponent', () => {
   let fixture: ComponentFixture<DataTableBodyComponent>;
@@ -91,6 +93,30 @@ describe('DataTableBodyComponent', () => {
       const expectedIndexes = { first: 0, last: 5 };
       component.updateIndexes();
       expect(component.indexes()).toEqual(expectedIndexes);
+    });
+
+    it('should render ghost rows based rowCount', () => {
+      component.trackByProp = 'num';
+      component.rows = [{ num: 1 }, { num: 2 }, { num: 3 }, { num: 4 }];
+      component.externalPaging = true;
+      component.scrollbarV = true;
+      component.virtualization = true;
+      component.rowHeight = 50;
+      component.ghostLoadingIndicator = true;
+      component.bodyHeight = 200;
+      component.pageSize = 5;
+      component.rowCount = 10;
+      component.offset = 0;
+      fixture.detectChanges();
+      expect(component.indexes()).toEqual({ first: 0, last: 5 });
+      fixture.debugElement
+        .query(By.directive(ScrollerComponent))
+        .triggerEventHandler('scroll', { scrollYPos: 250, scrollXPos: 0 });
+      fixture.detectChanges();
+      expect(component.indexes()).toEqual({ first: 5, last: 10 });
+      expect(fixture.debugElement.queryAll(By.directive(DataTableGhostLoaderComponent))).toHaveSize(
+        5
+      );
     });
   });
 

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -414,7 +414,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
       if (this.ghostLoadingIndicator) {
         return index;
       }
-      if (this.trackByProp) {
+      if (this.trackByProp && row) {
         return (row as any)[this.trackByProp];
       } else {
         return row;
@@ -549,11 +549,12 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     // if grouprowsby has been specified treat row paging
     // parameters as group paging parameters ie if limit 10 has been
     // specified treat it as 10 groups rather than 10 rows
-    if (this.groupedRows) {
-      return this.groupedRows.slice(first, Math.min(last, this.groupedRows.length));
-    } else {
-      return this.rows.slice(first, Math.min(last, this.rowCount));
-    }
+    const rows = this.groupedRows
+      ? this.groupedRows.slice(first, Math.min(last, this.groupedRows.length))
+      : this.rows.slice(first, Math.min(last, this.rowCount));
+
+    rows.length = last - first;
+    return rows;
   }
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

There are never more rows rendered than the `rows` input is long. Even if ghost loading is enabled, which leads to the problem that no ghost loading rows are shown while data is fetched.

**What is the new behavior?**

There are never more rows rendered than the potentially provided `rowCount`. When ghost loading is enabled and rows do not contain all rows to be rendered, the table will fill up the missing rows with `undefined` and thus ghost loading is shown for them.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This is a regression in `v23`, so no fix commit scope. Unit testing needs overhaul, but so we can at least verify the behavior since there is no e2e for this.
