### PR TITLE
refactor(disable-row): migrate to input signals

### DIFF
--- a/projects/ngx-datatable/src/lib/directives/disable-row.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/disable-row.directive.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, ElementRef, inject, Input } from '@angular/core';
+import { booleanAttribute, Directive, effect, ElementRef, inject, input } from '@angular/core';
 
 /**
  * Row Disable Directive
@@ -15,26 +15,27 @@ import { booleanAttribute, Directive, ElementRef, inject, Input } from '@angular
   selector: '[disable-row]'
 })
 export class DisableRowDirective {
-  private element = inject(ElementRef);
-  private _disabled = false;
-  @Input({ transform: booleanAttribute }) set disabled(val: boolean) {
-    this._disabled = val;
-    if (val) {
-      this.disableAllElements();
-    }
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  readonly disabled = input(false, {
+    transform: booleanAttribute
+  });
+
+  constructor() {
+    effect(() => {
+      if (this.disabled()) {
+        this.disableAllElements();
+      }
+    });
   }
 
-  get disabled() {
-    return this._disabled;
-  }
-
-  disableAllElements() {
-    const el = this.element?.nativeElement;
-    if (!el) {
+  private disableAllElements() {
+    const hostElement = this.elementRef?.nativeElement;
+    if (!hostElement) {
       return;
     }
-    Array.from(el.querySelectorAll('*') as HTMLAllCollection).forEach(child => {
-      child?.setAttribute('disabled', '');
+    Array.from(hostElement.querySelectorAll<HTMLElement>('*')).forEach(child => {
+      child.setAttribute('disabled', '');
     });
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`DisableRowDirective` uses @Input and Setter / Getter

**What is the new behavior?**

`DisableRowDirective` uses input signal and effects

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This pull request refactors the `DisableRowDirective` to improve readability, simplify the code, and leverage Angular's reactive primitives for better state management. Changes include replacing manual state handling with the reactive `input` API, introducing the `effect` API for automatic reactivity, and updating variable naming for clarity.

I tested the change on the `Disable Row` page in the demo.