### PR TITLE
build: compile examples and lib in separate directories

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
-          name: build
-          path: dist/ngx-datatable
+          name: dist
+          path: dist
 
       - name: Test
         run: npm run ci
@@ -81,8 +81,8 @@ jobs:
       - name: Download build
         uses: actions/download-artifact@v4
         with:
-          name: build
-          path: dist/ngx-datatable
+          name: dist
+          path: dist
 
       - name: Install
         run: npm ci

--- a/angular.json
+++ b/angular.json
@@ -22,7 +22,7 @@
           "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": {
-              "base": "dist/ngx-datatable",
+              "base": "dist/ngx-datatable-examples",
               "browser": ""
             },
             "index": "src/index.html",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "start:prod": "http-server dist/ngx-datatable -s -p 4200 -a 127.0.0.1",
+    "start:prod": "http-server dist/ngx-datatable-examples -s -p 4200 -a 127.0.0.1",
     "build": "ng build",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -22,7 +22,7 @@
     "e2e:update": "yarn e2e --update-snapshots",
     "build-docs": "cross-env NODE_ENV=production ng build --configuration production --base-href=\"/ngx-datatable/\"",
     "predeploy-docs": "npm run build-docs",
-    "deploy-docs": "angular-cli-ghpages --dir ./dist/ngx-datatable",
+    "deploy-docs": "angular-cli-ghpages --dir ./dist/ngx-datatable-examples",
     "package": "run-s build:lib:prod copy-files build:css",
     "prepublish:lib": "run-s ci package",
     "publish:lib": "npm publish ./dist/ngx-datatable",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The example application and the actual library have the same output path.
So it is impossible to have build artifacts at the same time.

**What is the new behavior?**

The example app is now compiled into `dist/ngx-datatable-examples` instead of `dist/ngx-datatable`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
