### PR TITLE
fix: calculate correct column width in flex mode after resize

### DIFF
--- a/projects/ngx-datatable/src/lib/utils/math.spec.ts
+++ b/projects/ngx-datatable/src/lib/utils/math.spec.ts
@@ -1,5 +1,8 @@
+import { TableColumnInternal } from '../types/internal.types';
 import { toInternalColumn } from './column-helper';
+import { emptyStringGetter } from './column-prop-getters';
 import { adjustColumnWidths, forceFillColumnWidths } from './math';
+import { orderByComparator } from './sort';
 
 describe('Math function', () => {
   describe('forceFillColumnWidths', () => {
@@ -133,6 +136,47 @@ describe('Math function', () => {
         for (const col of cols) {
           expect(col.width - col.minWidth!).toBeGreaterThanOrEqual(0);
         }
+      });
+
+      it('should scale columns after resizing', () => {
+        const cols: TableColumnInternal[] = [
+          {
+            $$id: 'id1',
+            $$valueGetter: emptyStringGetter,
+            comparator: orderByComparator,
+            prop: 'id1',
+            sortable: false,
+            name: 'Column 1',
+            canAutoResize: true,
+            width: 100,
+            flexGrow: 1
+          },
+          {
+            $$id: 'id2',
+            $$valueGetter: emptyStringGetter,
+            $$oldWidth: 100,
+            comparator: orderByComparator,
+            prop: 'id2',
+            sortable: false,
+            name: 'Column 2',
+            canAutoResize: true,
+            width: 200
+          },
+          {
+            $$id: 'id3',
+            $$valueGetter: emptyStringGetter,
+            comparator: orderByComparator,
+            prop: 'id3',
+            sortable: false,
+            name: 'Column 3',
+            canAutoResize: true,
+            width: 100,
+            flexGrow: 2
+          }
+        ];
+
+        adjustColumnWidths(cols, 500);
+        expect(cols.map(c => c.width)).toEqual([100, 200, 200]);
       });
     });
   });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

In flex mode, resizing is broken. The problem is that when calculating the new sizes after resizing, the original `maxWidth ` is subtracted by the width of columns that cannot be rescaled (typically the column that was resized).
But in the end it is checked whether the sum of ALL columns matches the `maxWidth` to compensate rounding errors.
Yet this never happens, as the non rescalable are missing so the table over compensates.

**What is the new behavior?**

The original `maxWidth` is not modified so the table no longer overcompensates.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closes #155
