### PR TITLE
refactor: enable naming-convention rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,7 +48,23 @@ export const tsConfig = typescriptEslint.config({
       }
     ],
     '@typescript-eslint/no-deprecated': ['off'],
-    '@typescript-eslint/naming-convention': ['off'],
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'variable',
+        format: ['camelCase', 'UPPER_CASE'],
+        leadingUnderscore: 'allow'
+      },
+      {
+        selector: 'memberLike',
+        format: ['camelCase'],
+        leadingUnderscore: 'allow'
+      },
+      {
+        selector: 'objectLiteralProperty',
+        format: null
+      }
+    ],
     '@angular-eslint/no-input-rename': ['off'],
     '@angular-eslint/no-output-native': ['off'],
     '@angular-eslint/directive-class-suffix': ['off'],

--- a/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
@@ -29,7 +29,7 @@ import { RowOrGroup } from '../../types/public.types';
   }`
 })
 export class DatatableRowDefComponent {
-  rowDef = inject(RowDefToken);
+  rowDef = inject(ROW_DEF_TOKEN);
   rowContext = {
     ...this.rowDef.rowDefInternal,
     disabled: this.rowDef.rowDefInternalDisabled
@@ -70,7 +70,7 @@ export class DatatableRowDefInternalDirective implements OnInit {
         injector: Injector.create({
           providers: [
             {
-              provide: RowDefToken,
+              provide: ROW_DEF_TOKEN,
               useValue: this
             }
           ]
@@ -79,7 +79,7 @@ export class DatatableRowDefInternalDirective implements OnInit {
     );
   }
 }
-const RowDefToken = new InjectionToken<DatatableRowDefInternalDirective>('RowDef');
+const ROW_DEF_TOKEN = new InjectionToken<DatatableRowDefInternalDirective>('RowDef');
 interface RowDefContext {
   template: TemplateRef<unknown>;
   rowTemplate: TemplateRef<unknown>;

--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
@@ -23,7 +23,7 @@ import {
 } from '@angular/core';
 
 import { Group, GroupContext, Row, RowDetailContext, RowOrGroup } from '../../types/public.types';
-import { DatatableComponentToken } from '../../utils/table-token';
+import { DATATABLE_COMPONENT_TOKEN } from '../../utils/table-token';
 import { DatatableRowDetailDirective } from '../row-detail/row-detail.directive';
 import { DatatableGroupHeaderDirective } from './body-group-header.directive';
 
@@ -109,7 +109,7 @@ export class DataTableRowWrapperComponent<TRow extends Row = any>
     .create();
   private iterableDiffers = inject(IterableDiffers);
   private selectedRowsDiffer!: IterableDiffer<TRow>;
-  private tableComponent = inject(DatatableComponentToken);
+  private tableComponent = inject(DATATABLE_COMPONENT_TOKEN);
   private cd = inject(ChangeDetectorRef);
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -3,7 +3,7 @@ import { By } from '@angular/platform-browser';
 
 import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
 import { toInternalColumn } from '../../utils/column-helper';
-import { DatatableComponentToken } from '../../utils/table-token';
+import { DATATABLE_COMPONENT_TOKEN } from '../../utils/table-token';
 import { DataTableBodyRowComponent } from './body-row.component';
 import { DataTableBodyComponent } from './body.component';
 import { DataTableGhostLoaderComponent } from './ghost-loader/ghost-loader.component';
@@ -17,7 +17,7 @@ describe('DataTableBodyComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DataTableBodyComponent],
-      providers: [ScrollbarHelper, { provide: DatatableComponentToken, useValue: {} }]
+      providers: [ScrollbarHelper, { provide: DATATABLE_COMPONENT_TOKEN, useValue: {} }]
     }).compileComponents();
     fixture = TestBed.createComponent(DataTableBodyComponent);
     component = fixture.componentInstance;

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -61,7 +61,7 @@ import { TableColumn } from '../types/table-column.type';
 import { toInternalColumn } from '../utils/column-helper';
 import { adjustColumnWidths, forceFillColumnWidths } from '../utils/math';
 import { sortGroupedRows, sortRows } from '../utils/sort';
-import { DatatableComponentToken } from '../utils/table-token';
+import { DATATABLE_COMPONENT_TOKEN } from '../utils/table-token';
 import { throttleable } from '../utils/throttle';
 import { groupRowsByParents, optionalGetterForProp } from '../utils/tree';
 import { DatatableGroupHeaderDirective } from './body/body-group-header.directive';
@@ -91,7 +91,7 @@ import { DatatableRowDetailDirective } from './row-detail/row-detail.directive';
   },
   providers: [
     {
-      provide: DatatableComponentToken,
+      provide: DATATABLE_COMPONENT_TOKEN,
       useExisting: DatatableComponent
     },
     ColumnChangesService

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -14,6 +14,7 @@ export interface SortPropDir {
  * const sortDir: SortDirection = 'asc';
  * ```
  */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const SortDirection = {
   asc: 'asc',
   desc: 'desc'
@@ -37,6 +38,7 @@ export interface SortEvent {
  * const sortType: SortType = 'single';
  * ```
  */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const SortType = {
   single: 'single',
   multi: 'multi'
@@ -53,6 +55,7 @@ export type SortType = (typeof SortType)[keyof typeof SortType];
  * <ngx-datatable [columnMode]="'force'"></ngx-datatable>
  * ```
  */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ColumnMode = {
   standard: 'standard',
   flex: 'flex',
@@ -125,6 +128,7 @@ export interface FooterContext {
  * const contextmenuType: ContextmenuType = 'header';
  * ```
  */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ContextmenuType = {
   header: 'header',
   body: 'body'
@@ -223,6 +227,7 @@ export type DetailToggleEvents<TRow> = DetailToggleEvent<TRow> | AllDetailToggle
  * <ngx-datatable [selectionType]="'multi'"></ngx-datatable>
  * ```
  */
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const SelectionType = {
   single: 'single',
   multi: 'multi',

--- a/projects/ngx-datatable/src/lib/utils/table-token.ts
+++ b/projects/ngx-datatable/src/lib/utils/table-token.ts
@@ -6,6 +6,6 @@ import type { DatatableComponent } from '../components/datatable.component';
  * This token is created to break cycling import error which occurs when we import
  * DatatableComponent in DataTableRowWrapperComponent.
  */
-export const DatatableComponentToken = new InjectionToken<DatatableComponent>(
+export const DATATABLE_COMPONENT_TOKEN = new InjectionToken<DatatableComponent>(
   'DatatableComponentToken'
 );

--- a/src/app/basic/disabled-rows.component.ts
+++ b/src/app/basic/disabled-rows.component.ts
@@ -3,8 +3,7 @@ import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
   DatatableComponent,
-  DisableRowDirective,
-  SelectionType
+  DisableRowDirective
 } from 'projects/ngx-datatable/src/public-api';
 
 import { FullEmployee } from '../data.model';
@@ -95,8 +94,6 @@ import { DataService } from '../data.service';
 })
 export class DisabledRowsComponent {
   rows: (FullEmployee & { isDisabled?: boolean })[] = [];
-
-  SelectionType = SelectionType;
 
   private dataService = inject(DataService);
 

--- a/src/app/sorting/sorting-client.component.ts
+++ b/src/app/sorting/sorting-client.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { DatatableComponent, SortType, TableColumn } from 'projects/ngx-datatable/src/public-api';
+import { DatatableComponent, TableColumn } from 'projects/ngx-datatable/src/public-api';
 
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
@@ -23,9 +23,9 @@ import { DataService } from '../data.service';
       <ngx-datatable
         class="material"
         columnMode="force"
+        sortType="multi"
         [rows]="rows"
         [columns]="columns"
-        [sortType]="SortType.multi"
         [headerHeight]="50"
         [footerHeight]="50"
         [rowHeight]="50"
@@ -38,8 +38,6 @@ export class ClientSortingComponent {
   rows: Employee[] = [];
 
   columns: TableColumn[] = [{ name: 'Company' }, { name: 'Name' }, { name: 'Gender' }];
-
-  SortType = SortType;
 
   private dataService = inject(DataService);
 

--- a/src/app/sorting/sorting-server.component.ts
+++ b/src/app/sorting/sorting-server.component.ts
@@ -64,10 +64,10 @@ export class ServerSortingComponent {
       // your server would return the result for
       // you and you would just set the rows prop
       const sort = event.sorts[0];
-      type sortProp = 'company' | 'name' | 'gender';
+      type SortProp = 'company' | 'name' | 'gender';
       rows.sort(
         (a, b) =>
-          a[sort.prop as sortProp].localeCompare(b[sort.prop as sortProp]) *
+          a[sort.prop as SortProp].localeCompare(b[sort.prop as SortProp]) *
           (sort.dir === 'desc' ? -1 : 1)
       );
 


### PR DESCRIPTION
Internal member with _ prefix which were public before are now marked as private or protected.
These members were never meant to be public.

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
