### PR TITLE
refactor: replace key object with separate constants

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -23,7 +23,7 @@ import {
   SortPropDir,
   TreeStatus
 } from '../../types/public.types';
-import { Keys } from '../../utils/keys';
+import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../utils/keys';
 
 @Component({
   selector: 'datatable-body-cell',
@@ -392,11 +392,11 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
     const isTargetCell = event.target === this._element;
 
     const isAction =
-      key === Keys.return ||
-      key === Keys.down ||
-      key === Keys.up ||
-      key === Keys.left ||
-      key === Keys.right;
+      key === ENTER ||
+      key === ARROW_DOWN ||
+      key === ARROW_UP ||
+      key === ARROW_LEFT ||
+      key === ARROW_RIGHT;
 
     if (isAction && isTargetCell) {
       event.preventDefault();

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -25,7 +25,7 @@ import {
 } from '../../types/internal.types';
 import { ActivateEvent, Row, RowOrGroup, TreeStatus } from '../../types/public.types';
 import { columnGroupWidths, columnsByPin, columnsByPinArr } from '../../utils/column';
-import { Keys } from '../../utils/keys';
+import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../utils/keys';
 import { DataTableBodyCellComponent } from './body-cell.component';
 
 @Component({
@@ -181,11 +181,11 @@ export class DataTableBodyRowComponent<TRow extends Row = any> implements DoChec
     const isTargetRow = event.target === this._element;
 
     const isAction =
-      key === Keys.return ||
-      key === Keys.down ||
-      key === Keys.up ||
-      key === Keys.left ||
-      key === Keys.right;
+      key === ENTER ||
+      key === ARROW_DOWN ||
+      key === ARROW_UP ||
+      key === ARROW_LEFT ||
+      key === ARROW_RIGHT;
 
     const isCtrlA = event.key === 'a' && (event.ctrlKey || event.metaKey);
 

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -30,7 +30,7 @@ import {
   SelectionType
 } from '../../types/public.types';
 import { columnGroupWidths, columnsByPin } from '../../utils/column';
-import { Keys } from '../../utils/keys';
+import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../utils/keys';
 import { RowHeightCache } from '../../utils/row-height-cache';
 import { selectRows, selectRowsBetween } from '../../utils/selection';
 import { DatatableRowDetailDirective } from '../row-detail/row-detail.directive';
@@ -937,7 +937,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     if (select) {
       this.selectRow(event, index, row);
     } else if (type === 'keydown') {
-      if ((event as KeyboardEvent).key === Keys.return) {
+      if ((event as KeyboardEvent).key === ENTER) {
         this.selectRow(event, index, row);
       } else if (
         (event as KeyboardEvent).key === 'a' &&
@@ -954,7 +954,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   onKeyboardFocus(model: ActivateEvent<TRow>): void {
     const { key } = model.event as KeyboardEvent;
     const shouldFocus =
-      key === Keys.up || key === Keys.down || key === Keys.right || key === Keys.left;
+      key === ARROW_UP || key === ARROW_DOWN || key === ARROW_RIGHT || key === ARROW_LEFT;
 
     if (shouldFocus) {
       const isCellSelection = this.selectionType === SelectionType.cell;
@@ -972,21 +972,21 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     }
   }
 
-  focusRow(rowElement: HTMLElement, key: Keys): void {
+  focusRow(rowElement: HTMLElement, key: string): void {
     const nextRowElement = this.getPrevNextRow(rowElement, key);
     if (nextRowElement) {
       nextRowElement.focus();
     }
   }
 
-  getPrevNextRow(rowElement: HTMLElement, key: Keys): any {
+  getPrevNextRow(rowElement: HTMLElement, key: string): any {
     const parentElement = rowElement.parentElement;
 
     if (parentElement) {
       let focusElement: Element | null = null;
-      if (key === Keys.up) {
+      if (key === ARROW_UP) {
         focusElement = parentElement.previousElementSibling;
-      } else if (key === Keys.down) {
+      } else if (key === ARROW_DOWN) {
         focusElement = parentElement.nextElementSibling;
       }
 
@@ -996,14 +996,19 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     }
   }
 
-  focusCell(cellElement: HTMLElement, rowElement: HTMLElement, key: Keys, cellIndex: number): void {
+  focusCell(
+    cellElement: HTMLElement,
+    rowElement: HTMLElement,
+    key: string,
+    cellIndex: number
+  ): void {
     let nextCellElement: Element | null = null;
 
-    if (key === Keys.left) {
+    if (key === ARROW_LEFT) {
       nextCellElement = cellElement.previousElementSibling;
-    } else if (key === Keys.right) {
+    } else if (key === ARROW_RIGHT) {
       nextCellElement = cellElement.nextElementSibling;
-    } else if (key === Keys.up || key === Keys.down) {
+    } else if (key === ARROW_UP || key === ARROW_DOWN) {
       const nextRowElement = this.getPrevNextRow(rowElement, key);
       if (nextRowElement) {
         const children = nextRowElement.getElementsByClassName('datatable-body-cell');

--- a/projects/ngx-datatable/src/lib/utils/keys.ts
+++ b/projects/ngx-datatable/src/lib/utils/keys.ts
@@ -1,19 +1,6 @@
-/**
- * @deprecated The constant `Keys` should no longer be used. Instead use the value directly:
- * ```
- * // old
- * const keys: Keys = Keys.up;
- * // new
- * const keys: Keys = 'up';
- * ```
- */
-export const Keys = {
-  up: 'ArrowUp',
-  down: 'ArrowDown',
-  return: 'Enter',
-  escape: 'Escape',
-  left: 'ArrowLeft',
-  right: 'ArrowRight'
-} as const;
-
-export type Keys = (typeof Keys)[keyof typeof Keys];
+export const ARROW_UP = 'ArrowUp';
+export const ARROW_DOWN = 'ArrowDown';
+export const ENTER = 'Enter';
+export const ESCAPE = 'Escape';
+export const ARROW_LEFT = 'ArrowLeft';
+export const ARROW_RIGHT = 'ArrowRight';


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
We have the Keys recently migrated from the enum to constant / type.
In this case this migration was kinda pointless, as we mainly need the constant here and not the type.

**What is the new behavior?**
The type was dropped, as the html event is also just a string.
The needed keys are now exported as separate constants to follow the cdk style.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

I guess it is debatable whether there should be different exports or a constant. But this is anyway internally.