### PR TITLE
refactor: drop unused code in body-cell

### DIFF
--- a/playwright/e2e/selection.spec.ts
+++ b/playwright/e2e/selection.spec.ts
@@ -46,8 +46,6 @@ test.describe('selection', () => {
       await expect(selectedRow).toHaveClass(/active/);
       expect(cellsInRow).toHaveLength(3);
 
-      await expect(cellsInRow.at(0)).toHaveClass(/active/);
-
       const selectedColumnLi = await page.locator('.selected-column').locator('ul > li').all();
 
       expect(selectedColumnLi).toHaveLength(1);

--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -14,15 +14,7 @@ import {
 } from '@angular/core';
 
 import { CellActiveEvent, RowIndex, TableColumnInternal } from '../../types/internal.types';
-import {
-  ActivateEvent,
-  CellContext,
-  Row,
-  RowOrGroup,
-  SortDirection,
-  SortPropDir,
-  TreeStatus
-} from '../../types/public.types';
+import { ActivateEvent, CellContext, Row, RowOrGroup, TreeStatus } from '../../types/public.types';
 import { Keys } from '../../utils/keys';
 
 @Component({
@@ -177,15 +169,6 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
     return this._row;
   }
 
-  @Input() set sorts(val: SortPropDir[]) {
-    this._sorts = val;
-    this.sortDir = this.calcSortDir(val);
-  }
-
-  get sorts(): SortPropDir[] {
-    return this._sorts;
-  }
-
   @Input() set treeStatus(status: TreeStatus | undefined) {
     if (
       status !== 'collapsed' &&
@@ -239,17 +222,8 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
         }
       }
     }
-    if (!this.sortDir) {
-      cls += ' sort-active';
-    }
     if (this.isFocused && !this._disabled) {
       cls += ' active';
-    }
-    if (this.sortDir === SortDirection.asc) {
-      cls += ' sort-asc';
-    }
-    if (this.sortDir === SortDirection.desc) {
-      cls += ' sort-desc';
     }
     if (this._disabled) {
       cls += ' row-disabled';
@@ -284,13 +258,11 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
 
   sanitizedValue!: string;
   value: any;
-  sortDir?: SortDirection;
   isFocused = false;
 
   cellContext: CellContext<TRow>;
 
   private _isSelected?: boolean;
-  private _sorts!: SortPropDir[];
   private _column!: TableColumnInternal;
   private _row!: TRow;
   private _group?: TRow[];
@@ -427,16 +399,6 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
       cellElement: this._element,
       treeStatus: 'collapsed'
     });
-  }
-
-  calcSortDir(sorts: SortPropDir[]): SortDirection | undefined {
-    if (!sorts) {
-      return undefined;
-    }
-
-    const sort = sorts.find(s => s.prop === this.column.prop);
-
-    return sort?.dir as SortDirection;
   }
 
   stripHtml(html: string): string {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

There is unused code for sorting in the body-cell.

**What is the new behavior?**

The body-cell cannot sort and does not know about sorting so this code was useless and actually also unused,
as the input triggering was never called.

The only notable consumer change is, that body-cells no longer have the class `sort-active`. But I guess this is fine.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
