### PR TITLE
ci(codeowners): switch from single users to GitHub teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @timowolf @kfenner @fh1ch @spike-rabbit
+* @siemens/siemens-element-owners


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The `CODEOWNERS` file was mentioning individual users.

**What is the new behavior?**

The `CODEOWNERS` file is using GitHub teams to directly derive the intended code owners.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
