### PR TITLE
feat: export pager component for reuse in custom footer

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -23,6 +23,7 @@ import {
   QueryList,
   signal,
   TemplateRef,
+  viewChild,
   ViewChild
 } from '@angular/core';
 import { Subscription } from 'rxjs';
@@ -707,6 +708,12 @@ export class DatatableComponent<TRow extends Row = any>
   _subscriptions: Subscription[] = [];
   _ghostLoadingIndicator = false;
   _defaultColumnWidth?: number;
+  /**
+   * To have this available for all components.
+   * The Footer itself is not available in the injection context in templates,
+   * so we need to get if from here until we have a state service.
+   */
+  readonly _footerComponent = viewChild(DataTableFooterComponent);
   protected verticalScrollVisible = false;
   // In case horizontal scroll is enabled
   // the column widths are initially calculated without vertical scroll offset

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
@@ -1,9 +1,9 @@
-import { Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
+import { Component, DebugElement, TemplateRef, viewChild, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { DATATABLE_COMPONENT_TOKEN } from '../../utils/table-token';
 import { DataTableFooterComponent } from './footer.component';
-import { DataTablePagerComponent } from './pager.component';
 
 let fixture: ComponentFixture<TestFixtureComponent>;
 let component: TestFixtureComponent;
@@ -75,82 +75,6 @@ describe('DataTableFooterComponent', () => {
       page.detectChangesAndRunQueries();
 
       expect(page.datatablePager).not.toBeNull();
-    });
-
-    it('should propagate page change events upward from the DataTablePagerComponent', () => {
-      component.footerTemplate = undefined;
-      page.detectChangesAndRunQueries();
-      const spy = spyOn(component, 'onPageEvent');
-      const pageChangeEvent = { page: 7 };
-      const datatablePagerComponent: DataTablePagerComponent =
-        page.datatablePager.componentInstance;
-      // mimic the act of changing the page through the datatable pager
-      datatablePagerComponent.change.emit(pageChangeEvent);
-
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('should bind to DataTablePagerComponent pagerLeftArrowIcon input', () => {
-      component.pagerLeftArrowIcon = 'pager-left-arrow-icon';
-      page.detectChangesAndRunQueries();
-      const datatablePagerComponent: DataTablePagerComponent =
-        page.datatablePager.componentInstance;
-
-      expect(datatablePagerComponent.pagerLeftArrowIcon).toBe(component.pagerLeftArrowIcon);
-    });
-
-    it('should bind to DataTablePagerComponent pagerRightArrowIcon input', () => {
-      component.pagerRightArrowIcon = 'pager-right-arrow-icon';
-      page.detectChangesAndRunQueries();
-      const datatablePagerComponent: DataTablePagerComponent =
-        page.datatablePager.componentInstance;
-
-      expect(datatablePagerComponent.pagerRightArrowIcon).toBe(component.pagerRightArrowIcon);
-    });
-
-    it('should bind to DataTablePagerComponent pagerNextIcon input', () => {
-      component.pagerNextIcon = 'pager-next-icon';
-      page.detectChangesAndRunQueries();
-      const datatablePagerComponent: DataTablePagerComponent =
-        page.datatablePager.componentInstance;
-
-      expect(datatablePagerComponent.pagerNextIcon).toBe(component.pagerNextIcon);
-    });
-
-    it('should bind to DataTablePagerComponent pagerPreviousIcon input', () => {
-      component.pagerPreviousIcon = 'pager-previous-icon';
-      page.detectChangesAndRunQueries();
-      const datatablePagerComponent: DataTablePagerComponent =
-        page.datatablePager.componentInstance;
-
-      expect(datatablePagerComponent.pagerPreviousIcon).toBe(component.pagerPreviousIcon);
-    });
-
-    it('should bind to DataTablePagerComponent size input', () => {
-      component.pageSize = 4;
-      page.detectChangesAndRunQueries();
-      const datatablePagerComponent: DataTablePagerComponent =
-        page.datatablePager.componentInstance;
-
-      expect(datatablePagerComponent.size).toBe(component.pageSize);
-    });
-
-    it('should bind to DataTablePagerComponent count input', () => {
-      component.rowCount = 40;
-      page.detectChangesAndRunQueries();
-      const datatablePagerComponent: DataTablePagerComponent =
-        page.datatablePager.componentInstance;
-
-      expect(datatablePagerComponent.count).toBe(component.rowCount);
-    });
-
-    it('should bind to DataTablePagerComponent page input', () => {
-      component.offset = 200;
-      page.detectChangesAndRunQueries();
-      const datatablePagerComponent: DataTablePagerComponent =
-        page.datatablePager.componentInstance;
-
-      expect(datatablePagerComponent.page).toBe(201);
     });
 
     it('should show & hide the DataTablePagerComponent', () => {
@@ -242,7 +166,8 @@ describe('DataTableFooterComponent', () => {
         <li>offset {{ offset }}</li>
       </ul>
     </ng-template>
-  `
+  `,
+  providers: [{ provide: DATATABLE_COMPONENT_TOKEN, useExisting: TestFixtureComponent }]
 })
 class TestFixtureComponent {
   footerHeight = 0;
@@ -265,6 +190,9 @@ class TestFixtureComponent {
    */
   @ViewChild('testTemplate', { read: TemplateRef, static: true })
   testTemplate!: TemplateRef<any>;
+
+  // Used to mimic the DatatableComponent
+  readonly _footerComponent = viewChild(DataTableFooterComponent);
 
   onPageEvent() {
     return;
@@ -291,6 +219,6 @@ class Page {
     this.datatableFooterInner = de.query(By.css('.datatable-footer-inner'));
     this.templateList = de.query(By.css('#template-list'));
     this.pageCount = de.query(By.css('.page-count'));
-    this.datatablePager = de.query(By.css('datatable-pager'));
+    this.datatablePager = de.query(By.css('ngx-datatable-pager'));
   }
 }

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
@@ -3,11 +3,11 @@ import { ChangeDetectionStrategy, Component, computed, input, output, Signal } f
 
 import { FooterContext, PagerPageEvent } from '../../types/public.types';
 import { DatatableFooterDirective } from './footer.directive';
-import { DataTablePagerComponent } from './pager.component';
+import { DatatablePagerComponent } from './pager.component';
 
 @Component({
   selector: 'datatable-footer',
-  imports: [NgClass, NgTemplateOutlet, DataTablePagerComponent],
+  imports: [NgClass, NgTemplateOutlet, DatatablePagerComponent],
   template: `
     <div
       class="datatable-footer-inner"
@@ -27,16 +27,7 @@ import { DataTablePagerComponent } from './pager.component';
           {{ rowCount()?.toLocaleString() }} {{ totalMessage() }}
         </div>
         @if (isVisible()) {
-          <datatable-pager
-            [pagerLeftArrowIcon]="pagerLeftArrowIcon()"
-            [pagerRightArrowIcon]="pagerRightArrowIcon()"
-            [pagerPreviousIcon]="pagerPreviousIcon()"
-            [pagerNextIcon]="pagerNextIcon()"
-            [page]="curPage()"
-            [size]="pageSize()"
-            [count]="rowCount()"
-            (change)="page.emit($event)"
-          />
+          <ngx-datatable-pager />
         }
       }
     </div>

--- a/projects/ngx-datatable/src/lib/components/footer/testing/pager.harness.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/testing/pager.harness.ts
@@ -1,7 +1,7 @@
 import { ComponentHarness, parallel } from '@angular/cdk/testing';
 
 export class PagerHarness extends ComponentHarness {
-  static readonly hostSelector = 'datatable-pager';
+  static readonly hostSelector = 'ngx-datatable-pager';
 
   private pages = this.locatorForAll('.pages a');
   private previous = this.locatorFor('li:has([aria-label="go to previous page"])');

--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -14,6 +14,7 @@ import { DataTableColumnCellTreeToggle } from './components/columns/tree.directi
 import { DatatableComponent } from './components/datatable.component';
 import { DataTableFooterTemplateDirective } from './components/footer/footer-template.directive';
 import { DatatableFooterDirective } from './components/footer/footer.directive';
+import { DatatablePagerComponent } from './components/footer/pager.component';
 import { DatatableRowDetailTemplateDirective } from './components/row-detail/row-detail-template.directive';
 import { DatatableRowDetailDirective } from './components/row-detail/row-detail.directive';
 import { DisableRowDirective } from './directives/disable-row.directive';
@@ -32,6 +33,7 @@ import { AllPartial, NgxDatatableConfig, providedNgxDatatableConfig } from './ng
     DataTableColumnGhostCellDirective,
     DataTableColumnCellTreeToggle,
     DatatableFooterDirective,
+    DatatablePagerComponent,
     DatatableGroupHeaderTemplateDirective,
     DisableRowDirective,
     DatatableRowDefComponent,
@@ -49,6 +51,7 @@ import { AllPartial, NgxDatatableConfig, providedNgxDatatableConfig } from './ng
     DataTableColumnCellTreeToggle,
     DataTableFooterTemplateDirective,
     DatatableFooterDirective,
+    DatatablePagerComponent,
     DatatableGroupHeaderTemplateDirective,
     DisableRowDirective,
     DatatableRowDefComponent,

--- a/projects/ngx-datatable/src/public-api.ts
+++ b/projects/ngx-datatable/src/public-api.ts
@@ -9,6 +9,7 @@ export * from './lib/components/body/body-group-header.directive';
 export * from './lib/components/body/body-group-header-template.directive';
 export * from './lib/components/footer/footer.directive';
 export * from './lib/components/footer/footer-template.directive';
+export * from './lib/components/footer/pager.component';
 export * from './lib/components/columns/column.directive';
 export * from './lib/components/columns/column-header.directive';
 export * from './lib/components/columns/column-cell.directive';

--- a/src/app/basic/footer.component.ts
+++ b/src/app/basic/footer.component.ts
@@ -3,7 +3,8 @@ import {
   DatatableComponent,
   DatatableFooterDirective,
   DataTableFooterTemplateDirective,
-  TableColumn
+  TableColumn,
+  DatatablePagerComponent
 } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
@@ -11,7 +12,12 @@ import { DataService } from '../data.service';
 
 @Component({
   selector: 'footer-demo',
-  imports: [DatatableComponent, DatatableFooterDirective, DataTableFooterTemplateDirective],
+  imports: [
+    DatatableComponent,
+    DatatableFooterDirective,
+    DataTableFooterTemplateDirective,
+    DatatablePagerComponent
+  ],
   template: `
     <div>
       <h3>
@@ -51,6 +57,7 @@ import { DataService } from '../data.service';
                 {{ offset }}</div
               >
             </div>
+            <ngx-datatable-pager />
           </ng-template>
         </ngx-datatable-footer>
       </ngx-datatable>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When building a custom footer, our pagination is no longer included, but typically still required. With previous versions, apps could re-use our internal pager, as everything was exported. This was stopped for good reasons.

**What is the new behavior?**

This commit now adjusts the pager to being exported again. Now the pager automatically picks the table state, leading to the removal of all input/outputs. The selector is also changed to `ngx-datatable-pager` to match the pattern of the already exported components.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closes #324
