### PR TITLE
fix: no error on undefined limit

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -60,6 +60,7 @@ import {
 import { TableColumn } from '../types/table-column.type';
 import { toInternalColumn } from '../utils/column-helper';
 import { adjustColumnWidths, forceFillColumnWidths } from '../utils/math';
+import { numberOrUndefinedAttribute } from '../utils/number-or-undefined-attribute';
 import { sortGroupedRows, sortRows } from '../utils/sort';
 import { DATATABLE_COMPONENT_TOKEN } from '../utils/table-token';
 import { throttleable } from '../utils/throttle';
@@ -252,7 +253,7 @@ export class DatatableComponent<TRow extends Row = any>
    * The page size to be shown.
    * Default value: `undefined`
    */
-  @Input({ transform: numberAttribute }) set limit(val: number | undefined) {
+  @Input({ transform: numberOrUndefinedAttribute }) set limit(val: number | undefined) {
     this._limit = val;
 
     // recalculate sizes/etc

--- a/projects/ngx-datatable/src/lib/utils/number-or-undefined-attribute.ts
+++ b/projects/ngx-datatable/src/lib/utils/number-or-undefined-attribute.ts
@@ -1,0 +1,16 @@
+import { numberAttribute } from '@angular/core';
+
+/**
+ * Same as {@link numberAttribute} but returns `undefined` if the value is `undefined`.
+ * {@link numberAttribute} would return `NaN` in that case.
+ * @param value
+ */
+// Must be a function.
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+export function numberOrUndefinedAttribute(value: unknown | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return numberAttribute(value);
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When passing a limit, it is always transformed by the `numberAttribute` converter. This always converts `undefined` to `NaN` which breaks the table.

**What is the new behavior?**

With this change, we use a modified version that passes undefined through.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closes #349