### PR TITLE
build(release): use `release` instead of `maintenance`

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -5,8 +5,8 @@ export default {
   tagFormat: '${version}',
   branches: [
     {
-      name: 'maintenance/+([0-9])?(.{+([0-9]),x}).x',
-      channel: "${name.replace(/^maintenance\\\\//g, '')}"
+      name: 'release/+([0-9])?(.{+([0-9]),x}).x',
+      channel: "${name.replace(/^release\\\\//g, '')}"
     },
     'main',
     {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

We used a non-aligned `maintenance/*` branch for back-merge releases.

**What is the new behavior?**

We used a aligned `release/*` branch for back-merge releases.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
