### PR TITLE
chore(deps): drop cross-env dependency since no longer used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@types/node": "^22.0.0",
         "angular-eslint": "20.1.1",
         "cpy-cli": "^5.0.0",
-        "cross-env": "^7.0.3",
         "eslint": "^9.30.1",
         "eslint-plugin-headers": "1.3.3",
         "eslint-plugin-jsdoc": "51.4.1",
@@ -10624,25 +10623,6 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@types/node": "^22.0.0",
     "angular-eslint": "20.1.1",
     "cpy-cli": "^5.0.0",
-    "cross-env": "^7.0.3",
     "eslint": "^9.30.1",
     "eslint-plugin-headers": "1.3.3",
     "eslint-plugin-jsdoc": "51.4.1",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The `cross-env` dependency was part of the `package.json`, but no longer used (see https://github.com/search?q=repo%3Asiemens%2Fngx-datatable%20cross-env&type=code), causing pointless version bumps: https://github.com/siemens/ngx-datatable/pull/369.

**What is the new behavior?**

The unused `cross-env` dependency is no longer part of the `package.json`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
