### PR TITLE
fix: rows are not interactive when using disableRowCheck with grouped rows

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -422,6 +422,8 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
       }
       if (this.trackByProp && row) {
         return (row as any)[this.trackByProp];
+      } else if (row && this.isGroup(row)) {
+        return row.key ?? index;
       } else {
         return row ?? index;
       }

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -768,7 +768,7 @@ export class DatatableComponent<TRow extends Row = any>
         optionalGetterForProp(this.treeToRelation)
       );
 
-      if (this._groupRowsBy) {
+      if (this._groupRowsBy && rowDiffers) {
         // If a column has been specified in _groupRowsBy create a new array with the data grouped by that row
         this.groupedRows = this.groupArrayBy(this._rows, this._groupRowsBy);
       }


### PR DESCRIPTION

fix to prevent rows keeps getting rerendered on DOM infinitely when table is grouped by rows and having `disableRowCheck`.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
