### PR TITLE
build(semantic-release): fix scope for hidden commit types with notes

### DIFF
--- a/tools/semantic-release/writer-opts.js
+++ b/tools/semantic-release/writer-opts.js
@@ -28,12 +28,13 @@ function transform(commit) {
 
   if (hiddenTypes.has(commit.type)) {
     if (normalizedNotes.length > 0) {
-      normalizedNotes.map(note => ({
+      const transformedNotes = normalizedNotes.map(note => ({
+        ...note,
         text: `${commit.scope ? `**${commit.scope}:** ` : ''}${note.text}`
       }));
       // Add to the hiddenTypeCommitNotes if there are notes and the type is hidden
       // The notes will be added to the context in finalizeContext
-      hiddenTypeCommitNotes.push(...normalizedNotes);
+      hiddenTypeCommitNotes.push(...transformedNotes);
     }
     return;
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Commits with hidden types with notes were not showing their scope. 

> The term notes in the context of semantic release means all options like NOTE:, DEPRECATED: or BREAKING CHANGE:.

**What is the new behavior?**

Commits with hidden types that include notes now display their scope when a changelog is generated with semantic release.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:  Same as https://github.com/siemens/element/pull/526
