### PR TITLE
fix(sort): sort on grouped header column throws errors

### DIFF
--- a/projects/ngx-datatable/src/lib/utils/sort.ts
+++ b/projects/ngx-datatable/src/lib/utils/sort.ts
@@ -79,7 +79,8 @@ export const orderByComparator = (a: any, b: any): number => {
 export const sortRows = <TRow>(
   rows: TRow[],
   columns: TableColumnInternal[],
-  dirs: SortPropDir[]
+  dirs: SortPropDir[],
+  sortOnGroupHeader?: SortPropDir
 ): TRow[] => {
   if (!rows) {
     return [];
@@ -102,12 +103,14 @@ export const sortRows = <TRow>(
   // cache valueGetter and compareFn so that they
   // do not need to be looked-up in the sort function body
   const cachedDirs = dirs.map(dir => {
-    const prop = dir.prop;
+    // When sorting on group header, override prop to 'key'
+    const prop = sortOnGroupHeader?.prop === dir.prop ? 'key' : dir.prop;
+    const compareFn = cols[dir.prop];
     return {
       prop,
       dir: dir.dir,
       valueGetter: getterForProp(prop),
-      compareFn: cols[prop]
+      compareFn
     };
   });
 
@@ -148,12 +151,7 @@ export const sortGroupedRows = <TRow>(
   sortOnGroupHeader: SortPropDir | undefined
 ): Group<TRow>[] => {
   if (sortOnGroupHeader) {
-    groupedRows = sortRows(groupedRows, columns, [
-      {
-        dir: sortOnGroupHeader.dir,
-        prop: 'key'
-      }
-    ]);
+    groupedRows = sortRows(groupedRows, columns, dirs, sortOnGroupHeader);
   }
   return groupedRows.map(group => ({ ...group, value: sortRows(group.value, columns, dirs) }));
 };


### PR DESCRIPTION
console throws errors and sort doesn't work when doing sort on column which is also used as a grouped row key

steps to reproduce:

- go to https://siemens.github.io/ngx-datatable/#/row-grouping
- click on age column to sort
- see console

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
