### PR TITLE
ci(publish): use newly released version when deploying to github pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,22 @@ jobs:
       pages: write
       id-token: write
     needs:
-      - build-and-test
+      - publish
     steps:
-      - uses: actions/configure-pages@v5
-      - uses: actions/download-artifact@v5
+      # semantic release will update the package.json version so
+      # we need to build the artifacts again to have the correct version number in the docs.
+      - uses: actions/checkout@v5
         with:
-          name: dist
-          path: dist
+          fetch-depth: 0
+          token: ${{ secrets.ELEMENT_BOT_GITHUB_TOKEN }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/jod
+          cache: 'npm'
+      - run: npm ci --prefer-offline --no-audit
+      - run: npm run build:lib:prod
+      - run: npm run build:prod
+      - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
         with:
           path: 'dist/ngx-datatable-examples'


### PR DESCRIPTION
currently gh pages uses existing build artifacts from main which contains old version number (https://siemens.github.io/ngx-datatable/#/  shows 24.1.0 where as latest version is 24.2.0).

semantic release will bump the package number so github pages needs to first build with new version number and then deploy build artifacts on gh pages to correctly display latest version.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
