### PR TITLE
build: move e2e packages to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,8 @@
         "@angular/cli": "19.2.15",
         "@angular/compiler-cli": "19.2.14",
         "@angular/language-service": "19.2.14",
+        "@axe-core/playwright": "4.10.2",
+        "@playwright/test": "1.55.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@siemens/commitlint-config": "^2.2.1",
@@ -37,6 +39,7 @@
         "@types/jasminewd2": "^2.0.13",
         "@types/node": "^22.0.0",
         "angular-eslint": "20.3.0",
+        "axe-html-reporter": "2.2.11",
         "cpy-cli": "^6.0.0",
         "eslint": "^9.30.1",
         "eslint-plugin-headers": "1.3.3",
@@ -64,11 +67,6 @@
         "ts-node": "^10.9.2",
         "typescript": "~5.5.4",
         "typescript-eslint": "8.44.1"
-      },
-      "optionalDependencies": {
-        "@axe-core/playwright": "4.10.2",
-        "@playwright/test": "1.55.0",
-        "axe-html-reporter": "2.2.11"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1502,8 +1500,8 @@
       "version": "4.10.2",
       "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
       "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+      "dev": true,
       "license": "MPL-2.0",
-      "optional": true,
       "dependencies": {
         "axe-core": "~4.10.3"
       },
@@ -6211,8 +6209,8 @@
       "version": "1.55.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
       "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "playwright": "1.55.0"
       },
@@ -8752,8 +8750,8 @@
       "version": "4.10.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
       "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
       "license": "MPL-2.0",
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -8762,8 +8760,8 @@
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/axe-html-reporter/-/axe-html-reporter-2.2.11.tgz",
       "integrity": "sha512-WlF+xlNVgNVWiM6IdVrsh+N0Cw7qupe5HT9N6Uyi+aN7f6SSi92RDomiP1noW8OWIV85V6x404m5oKMeqRV3tQ==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mustache": "^4.0.1"
       },
@@ -16308,8 +16306,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -20847,8 +20845,8 @@
       "version": "1.55.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
       "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "playwright-core": "1.55.0"
       },
@@ -20866,8 +20864,8 @@
       "version": "1.55.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
       "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -20879,6 +20877,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "@angular/cli": "19.2.15",
     "@angular/compiler-cli": "19.2.14",
     "@angular/language-service": "19.2.14",
+    "@axe-core/playwright": "4.10.2",
+    "@playwright/test": "1.55.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@siemens/commitlint-config": "^2.2.1",
@@ -62,6 +64,7 @@
     "@types/jasminewd2": "^2.0.13",
     "@types/node": "^22.0.0",
     "angular-eslint": "20.3.0",
+    "axe-html-reporter": "2.2.11",
     "cpy-cli": "^6.0.0",
     "eslint": "^9.30.1",
     "eslint-plugin-headers": "1.3.3",
@@ -89,10 +92,5 @@
     "ts-node": "^10.9.2",
     "typescript": "~5.5.4",
     "typescript-eslint": "8.44.1"
-  },
-  "optionalDependencies": {
-    "@axe-core/playwright": "4.10.2",
-    "@playwright/test": "1.55.0",
-    "axe-html-reporter": "2.2.11"
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

E2E dependencies are listed as optional dependency.

**What is the new behavior?**

E2E dependencies are listed as dev dependency.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Having them as optional dependency was never used. They were also always installed on every CI build.
So just moving them dev dependencies. Also aligns it with element where we are no longer having them as optional.