### PR TITLE
fix: show the correct number of pages when using row grouping

### DIFF
--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--default-chromium-linux.png
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--default-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4bcf52aa6484038b4f278f3a4dd7102988a48f5f514fc7a704fb6e9f6213826
-size 51863
+oid sha256:0cf41b34b103f4afb7feabb238ee80c9f41096d63b6d55a5493cbb249658c53f
+size 51721

--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-collapsed-chromium-linux.png
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-collapsed-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:983060f46ed8492f4646c3becf8e395394c0bafba31ba390b10fe8091170c947
-size 38238
+oid sha256:7f1956af5fd3799fed2c328fa5edecacff731c6c7fdb7c92f8d46b639f2d4bfd
+size 38099

--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-expanded-chromium-linux.png
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-expanded-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4bcf52aa6484038b4f278f3a4dd7102988a48f5f514fc7a704fb6e9f6213826
-size 51863
+oid sha256:0cf41b34b103f4afb7feabb238ee80c9f41096d63b6d55a5493cbb249658c53f
+size 51721

--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-selected-chromium-linux.png
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-selected-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe3479e6ab4eacaaf820727c814685128d3dbcfb4eaafefaaecc04e4642f1d3a
-size 52377
+oid sha256:1719a5551b29bd721915644e028fca7e0cb23fd0dc873086c2c5abb9f154ebc5
+size 52211

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -96,6 +96,7 @@
   @if (footerHeight) {
     <datatable-footer
       [rowCount]="groupedRows !== undefined ? _internalRows.length : rowCount"
+      [groupCount]="groupedRows !== undefined ? rowCount : undefined"
       [pageSize]="pageSize"
       [offset]="offset"
       [footerHeight]="footerHeight"

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
@@ -136,6 +136,7 @@ describe('DataTableFooterComponent', () => {
   template: `
     <datatable-footer
       [rowCount]="rowCount"
+      [groupCount]="undefined"
       [pageSize]="pageSize"
       [offset]="offset"
       [footerHeight]="footerHeight"

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
@@ -41,6 +41,7 @@ import { DatatablePagerComponent } from './pager.component';
 export class DataTableFooterComponent {
   readonly footerHeight = input.required<number>();
   readonly rowCount = input.required<number>();
+  readonly groupCount = input.required<number | undefined>();
   readonly pageSize = input.required<number>();
   readonly offset = input.required<number>();
   readonly pagerLeftArrowIcon = input<string | undefined>();

--- a/projects/ngx-datatable/src/lib/components/footer/pager.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/pager.component.spec.ts
@@ -18,6 +18,7 @@ interface MockFooter {
   curPage: WritableSignal<number>;
   pageSize: WritableSignal<number>;
   rowCount: WritableSignal<number>;
+  groupCount: WritableSignal<number | undefined>;
   pagerNextIcon: WritableSignal<string | undefined>;
   pagerRightArrowIcon: WritableSignal<string | undefined>;
   pagerLeftArrowIcon: WritableSignal<string | undefined>;
@@ -36,6 +37,7 @@ describe('DataTablePagerComponent', () => {
       curPage: signal(0),
       pageSize: signal(1),
       rowCount: signal(0),
+      groupCount: signal<number | undefined>(undefined),
       pagerNextIcon: signal(''),
       pagerRightArrowIcon: signal(''),
       pagerLeftArrowIcon: signal(''),
@@ -75,6 +77,13 @@ describe('DataTablePagerComponent', () => {
       footer.pageSize.set(10);
       footer.rowCount.set(0);
       expect(await harness.pageCount()).toEqual(1);
+    });
+
+    it('should prefer using groupCount if available', async () => {
+      footer.pageSize.set(10);
+      footer.rowCount.set(28);
+      footer.groupCount.set(53);
+      expect(await harness.pageCount()).toEqual(5);
     });
   });
 

--- a/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
@@ -112,7 +112,11 @@ export class DatatablePagerComponent {
 
   protected readonly page = computed(() => this.datatable._footerComponent()!.curPage());
   protected readonly pageSize = computed(() => this.datatable._footerComponent()!.pageSize());
-  protected readonly count = computed(() => this.datatable._footerComponent()!.rowCount());
+  protected readonly count = computed(
+    () =>
+      this.datatable._footerComponent()!.groupCount() ??
+      this.datatable._footerComponent()!.rowCount()
+  );
   protected readonly pagerNextIcon = computed(() =>
     this.datatable._footerComponent()!.pagerNextIcon()
   );


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When using grouping and `limit` (maximum number of rows per page) together, the table will count the groups, not the rows. So a limit 4 means that 4 groups are rendered per page. Yet, the pager was counting the number rows within a group. 

**What is the new behavior?**

With this fix, the pager will be aligned with the body, and also count the groups.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

See https://siemens.github.io/ngx-datatable/#/row-grouping and try to open page 5 or 6.