### PR TITLE
feat(summary-row): allow pinning summary rows

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.scss
@@ -25,3 +25,15 @@ datatable-scroller {
 [hidden] {
   display: none !important; // stylelint-disable-line declaration-no-important
 }
+
+datatable-summary-row.sticky {
+  position: sticky;
+  z-index: 99;
+
+  &.top {
+    top: 0;
+  }
+  &.bottom {
+    bottom: 0;
+  }
+}

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -83,6 +83,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
       >
         @if (summaryRow && summaryPosition === 'top') {
           <datatable-summary-row
+            [class]="stickySummaryRow ? 'sticky top' : ''"
             [rowHeight]="summaryHeight"
             [innerWidth]="innerWidth"
             [rows]="rows"
@@ -207,6 +208,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
       @if (summaryRow && summaryPosition === 'bottom') {
         <datatable-summary-row
           role="row"
+          [class]="stickySummaryRow ? 'sticky bottom' : ''"
           [rowHeight]="summaryHeight"
           [innerWidth]="innerWidth"
           [rows]="rows"
@@ -355,6 +357,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   @Input() verticalScrollVisible = false;
   @Input({ required: true }) ariaRowCheckboxMessage!: string;
   @Input({ required: true }) cssClasses!: Partial<Required<NgxDatatableConfig>['cssClasses']>;
+  @Input({ required: true }) stickySummaryRow!: boolean;
 
   @Output() readonly scroll = new EventEmitter<ScrollEvent>();
   @Output() readonly page = new EventEmitter<number>();

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -72,6 +72,7 @@
       [rowDragEvents]="rowDragEvents"
       [rowDefTemplate]="rowDefTemplate"
       [cssClasses]="cssClasses"
+      [stickySummaryRow]="stickySummaryRow"
       (page)="onBodyPage($event)"
       (activate)="activate.emit($event)"
       (rowContextmenu)="onRowContextmenu($event)"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -482,6 +482,11 @@ export class DatatableComponent<TRow extends Row = any>
   @Input({ transform: booleanAttribute }) enableClearingSortState = false;
 
   /**
+   * When enabled it will keep the summary row always visible on top or bottom when scrolling.
+   */
+  @Input({ transform: booleanAttribute }) stickySummaryRow = false;
+
+  /**
    * Body was scrolled typically in a `scrollbarV:true` scenario.
    */
   @Output() readonly scroll = new EventEmitter<ScrollEvent>();


### PR DESCRIPTION
Introduces `stickySummaryRow` input which can be enabled to stick summary rows on top or bottom while scrolling regular rows.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
