### PR TITLE
fix: only use trackByProp on row level with strict type

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -276,7 +276,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   readonly groupHeader = input<DatatableGroupHeaderDirective>();
   readonly selectCheck = input<(value: TRow, index: number, array: TRow[]) => boolean>();
   readonly displayCheck = input<(row: TRow, column: TableColumn, value?: any) => boolean>();
-  readonly trackByProp = input<string>();
+  readonly trackByProp = input<keyof TRow>();
   readonly rowClass = input<(row: TRow) => string | Record<string, boolean>>();
   readonly groupedRows = input<Group<TRow>[]>();
   // TODO: Find a better way to handle default expansion state with signal input
@@ -392,8 +392,8 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
         return index;
       }
       const trackByProp = this.trackByProp();
-      if (trackByProp && row) {
-        return (row as any)[trackByProp];
+      if (trackByProp && row && this.isRow(row)) {
+        return row[trackByProp];
       } else if (row && this.isGroup(row)) {
         return row.key ?? index;
       } else {

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -359,7 +359,7 @@ export class DatatableComponent<TRow extends Row = any>
    * Property to which you can use for custom tracking of rows.
    * Example: 'name'
    */
-  readonly trackByProp = input<string>();
+  readonly trackByProp = input<keyof TRow>();
 
   /**
    * Property to which you can use for determining select all


### PR DESCRIPTION
fix `DatatableComponent.trackByProp` which always returned undefined on group level by using key as index for group.

BREAKING CHANGE: `DatatableComponent.trackByProp` input now enforce strict type check as key of row.

Before:

// Even though name is not a valid prop on rows it is allowed to be used with `trackByProp`.

```
<ngx-datatable
 trackByProp="'name'"
 [rows]="[{id: 1}, {id: 2}]"
>
```
After:
Typescript would give compilation error as name is not know property in rows.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
