### PR TITLE
refactor(header): rename `DraggableDirective` to `DatatableDraggableD…

### DIFF
--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -16,7 +16,10 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { DragEvent, DraggableDirective } from '../../directives/draggable.directive';
+import {
+  DragEvent,
+  DatatableDraggableDirective
+} from '../../directives/datatable-draggable.directive';
 import {
   InnerSortEvent,
   SortableTableColumnInternal,
@@ -33,7 +36,7 @@ import { nextSortDir } from '../../utils/sort';
 
 @Component({
   selector: 'datatable-header-cell',
-  imports: [NgTemplateOutlet, DraggableDirective],
+  imports: [NgTemplateOutlet, DatatableDraggableDirective],
   template: `
     <div class="datatable-header-cell-template-wrap">
       @if (isTarget()) {
@@ -70,7 +73,7 @@ import { nextSortDir } from '../../utils/sort';
     @if (showResizeHandle()) {
       <span
         class="resize-handle"
-        draggable
+        datatableDraggable
         (dragStart)="onMousedown()"
         (dragMove)="move($event)"
         (dragEnd)="onMouseup()"

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -15,7 +15,7 @@ import {
   TemplateRef
 } from '@angular/core';
 
-import { DraggableDirective } from '../../directives/draggable.directive';
+import { DatatableDraggableDirective } from '../../directives/datatable-draggable.directive';
 import { OrderableDirective } from '../../directives/orderable.directive';
 import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
 import {
@@ -40,7 +40,13 @@ import { DataTableHeaderCellComponent } from './header-cell.component';
 
 @Component({
   selector: 'datatable-header',
-  imports: [OrderableDirective, NgStyle, DataTableHeaderCellComponent, NgClass, DraggableDirective],
+  imports: [
+    OrderableDirective,
+    NgStyle,
+    DataTableHeaderCellComponent,
+    NgClass,
+    DatatableDraggableDirective
+  ],
   template: `
     <div
       role="row"
@@ -62,7 +68,7 @@ import { DataTableHeaderCellComponent } from './header-cell.component';
               <datatable-header-cell
                 role="columnheader"
                 dragStartDelay="500"
-                [draggable]="reorderable && column.draggable"
+                [datatableDraggable]="reorderable && column.draggable"
                 [dragModel]="column"
                 [headerHeight]="headerHeight"
                 [isTarget]="column.isTarget"

--- a/projects/ngx-datatable/src/lib/directives/datatable-draggable.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/datatable-draggable.directive.ts
@@ -22,7 +22,7 @@ export interface DragEvent {
 }
 
 @Directive({
-  selector: '[draggable]',
+  selector: '[datatableDraggable]',
   host: {
     '[class.draggable]': 'enabled()',
     '[class.dragging]': 'isDragging()',
@@ -31,13 +31,13 @@ export interface DragEvent {
     '(touchstart)': 'touchstart($event)'
   }
 })
-export class DraggableDirective implements OnDestroy {
+export class DatatableDraggableDirective implements OnDestroy {
   private document = inject(DOCUMENT);
   readonly element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
 
   readonly dragModel = input<TableColumnInternal>();
   readonly dragStartDelay = input(0, { transform: numberAttribute });
-  readonly enabled = input(true, { transform: booleanAttribute, alias: 'draggable' });
+  readonly enabled = input(true, { transform: booleanAttribute, alias: 'datatableDraggable' });
   readonly dragMove = output<DragEvent>();
   readonly dragEnd = output<void>();
   readonly dragStart = output<void>();

--- a/projects/ngx-datatable/src/lib/directives/draggable.directive.spec.ts
+++ b/projects/ngx-datatable/src/lib/directives/draggable.directive.spec.ts
@@ -2,14 +2,14 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component, signal } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
-import { DragEvent, DraggableDirective } from './draggable.directive';
+import { DragEvent, DatatableDraggableDirective } from './datatable-draggable.directive';
 import { DraggableHarness } from './testing/draggable.harness';
 
 import Spy = jasmine.Spy;
 
 @Component({
   selector: 'test-fixture-component',
-  imports: [DraggableDirective],
+  imports: [DatatableDraggableDirective],
   template: `
     <div
       [draggable]="enabled()"

--- a/projects/ngx-datatable/src/lib/directives/orderable.directive.spec.ts
+++ b/projects/ngx-datatable/src/lib/directives/orderable.directive.spec.ts
@@ -5,23 +5,24 @@ import { By } from '@angular/platform-browser';
 
 import { TableColumnInternal } from '../types/internal.types';
 import { toInternalColumn } from '../utils/column-helper';
-import { DraggableDirective } from './draggable.directive';
+import { DatatableDraggableDirective } from './datatable-draggable.directive';
 import { OrderableDirective } from './orderable.directive';
 
 @Component({
   selector: 'test-fixture-component',
-  imports: [OrderableDirective, DraggableDirective],
+  imports: [OrderableDirective, DatatableDraggableDirective],
   template: `
     <div orderable>
       @for (item of draggables; track $index) {
-        <div draggable [dragModel]="item"></div>
+        <div datatableDraggable [dragModel]="item"></div>
       }
     </div>
   `
 })
 class TestFixtureComponent {
   draggables: TableColumnInternal[] = [];
-  @ViewChildren(DraggableDirective) draggableDirectives!: QueryList<DraggableDirective>;
+  @ViewChildren(DatatableDraggableDirective)
+  draggableDirectives!: QueryList<DatatableDraggableDirective>;
 }
 
 describe('OrderableDirective', () => {

--- a/projects/ngx-datatable/src/lib/directives/orderable.directive.ts
+++ b/projects/ngx-datatable/src/lib/directives/orderable.directive.ts
@@ -21,7 +21,7 @@ import {
   TableColumnInternal,
   TargetChangedEvent
 } from '../types/internal.types';
-import { DragEvent, DraggableDirective } from './draggable.directive';
+import { DragEvent, DatatableDraggableDirective } from './datatable-draggable.directive';
 
 interface OrderPosition {
   left: number;
@@ -42,15 +42,15 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
   // This should be contentChildren() query, but there is an open Angular issue with signal queries (https://github.com/angular/angular/issues/59067)
   // This problem causes the orderable directive to fail because the contentChildren query is resolved too early.
   // At that state, the input is not yet set, resulting in a NG0950 error.
-  @ContentChildren(DraggableDirective, { descendants: true })
-  draggablesQueryList!: QueryList<DraggableDirective>;
+  @ContentChildren(DatatableDraggableDirective, { descendants: true })
+  draggablesQueryList!: QueryList<DatatableDraggableDirective>;
 
-  readonly draggables = signal<DraggableDirective[]>([]);
+  readonly draggables = signal<DatatableDraggableDirective[]>([]);
 
   readonly subscriptions = new Map<string, OutputRefSubscription[]>();
 
   positions?: Record<string, OrderPosition>;
-  readonly differ: KeyValueDiffer<string, DraggableDirective> = inject(KeyValueDiffers)
+  readonly differ: KeyValueDiffer<string, DatatableDraggableDirective> = inject(KeyValueDiffers)
     .find({})
     .create();
   lastDraggingIndex?: number;
@@ -62,7 +62,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
           acc[curr.dragModel()!.$$id] = curr;
           return acc;
         },
-        {} as Record<string, DraggableDirective>
+        {} as Record<string, DatatableDraggableDirective>
       );
 
       this.updateSubscriptions(diffMap);
@@ -79,7 +79,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
     this.subscriptions.forEach(subList => subList.forEach(sub => sub.unsubscribe()));
   }
 
-  updateSubscriptions(diffMap: Record<string, DraggableDirective>): void {
+  updateSubscriptions(diffMap: Record<string, DatatableDraggableDirective>): void {
     const differResult = this.differ.diff(diffMap);
     if (!differResult) {
       return;
@@ -89,7 +89,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
   }
 
   private subscribeToDraggable = (
-    record: KeyValueChangeRecord<string, DraggableDirective>
+    record: KeyValueChangeRecord<string, DatatableDraggableDirective>
   ): void => {
     this.unsubscribeFromDraggable(record);
     const { key, currentValue } = record;
@@ -112,7 +112,7 @@ export class OrderableDirective implements AfterContentInit, OnDestroy {
   };
 
   private unsubscribeFromDraggable = (
-    record: KeyValueChangeRecord<string, DraggableDirective>
+    record: KeyValueChangeRecord<string, DatatableDraggableDirective>
   ): void => {
     const { key, previousValue } = record;
     if (!previousValue) {

--- a/src/app/basic/basic-auto.component.ts
+++ b/src/app/basic/basic-auto.component.ts
@@ -24,6 +24,7 @@ import { DataService } from '../data.service';
         class="material"
         rowHeight="auto"
         columnMode="force"
+        [rowDraggable]="true"
         [rows]="rows"
         [loadingIndicator]="loadingIndicator"
         [columns]="columns"


### PR DESCRIPTION
…irective`

We should have a common naming pattern and more important, we should not use standard DOM attributes as a selector of directives.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The `DraggableDirective` diverges from the typical naming pattern were classes are usually called `Datatable...`.
It also uses `[draggable]` as a selector which is also a native HTML attribute.
This is leading to confusion as in other places, we are only using the HTML attribute without this directive.

**What is the new behavior?**

The directive class is called `DatatableDraggableDirective` and the new selector is `[datatableDraggable]`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Internal only change. New names are open for discussion. For me it is only important to change selector.