### PR TITLE
refactor: body simplify selection state updating

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -8,18 +9,17 @@ import {
   HostBinding,
   inject,
   Input,
+  input,
+  model,
+  OnChanges,
   OnDestroy,
   OnInit,
+  output,
   signal,
+  SimpleChanges,
   TemplateRef,
   TrackByFunction,
-  ViewChild,
-  input,
-  booleanAttribute,
-  model,
-  output,
-  SimpleChanges,
-  OnChanges
+  ViewChild
 } from '@angular/core';
 
 import { NgxDatatableConfig } from '../../ngx-datatable.config';
@@ -31,7 +31,6 @@ import {
   Row,
   RowOrGroup,
   ScrollEvent,
-  SelectEvent,
   SelectionType
 } from '../../types/public.types';
 import { columnGroupWidths, columnsByPin } from '../../utils/column';
@@ -260,7 +259,7 @@ export class DataTableBodyComponent<TRow extends Row = any>
   readonly rowHeight = input.required<number | 'auto' | ((row?: any) => number)>();
   readonly offsetX = model.required<number>();
   readonly selectionType = input<SelectionType>();
-  readonly selected = input<any[]>([]);
+  readonly selected = model<any[]>([]);
   readonly rowIdentity = input.required<(x: RowOrGroup<TRow>) => unknown>();
   readonly rowDetail = input<DatatableRowDetailDirective>();
   readonly groupHeader = input<DatatableGroupHeaderDirective>();
@@ -309,7 +308,6 @@ export class DataTableBodyComponent<TRow extends Row = any>
   readonly scroll = output<ScrollEvent>();
   readonly page = output<number>();
   readonly activate = output<ActivateEvent<TRow>>();
-  readonly select = output<SelectEvent<TRow>>();
   readonly rowContextmenu = output<{
     event: MouseEvent;
     row: RowOrGroup<TRow>;
@@ -887,15 +885,8 @@ export class DataTableBodyComponent<TRow extends Row = any>
       selected = selected.filter(rowData => !this.disableRowCheck()!(rowData));
     }
 
-    const selectedValue = this.selected();
-    this.selected().splice(0, selectedValue.length);
-    selectedValue.push(...selected);
-
+    this.selected.set(selected);
     this.prevIndex = index;
-
-    this.select.emit({
-      selected
-    });
   }
 
   onActivate(modelObject: ActivateEvent<TRow>, index: number): void {

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -75,7 +75,7 @@
       (page)="onBodyPage($event)"
       (activate)="activate.emit($event)"
       (rowContextmenu)="onRowContextmenu($event)"
-      (select)="onBodySelect($event)"
+      (selectedChange)="onBodySelect($event)"
       (scroll)="onBodyScroll($event)"
       (treeAction)="onTreeAction($event)"
     >

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -1264,8 +1264,9 @@ export class DatatableComponent<TRow extends Row = any>
   /**
    * A row was selected from body
    */
-  onBodySelect(event: SelectEvent<TRow>): void {
-    this.select.emit(event);
+  onBodySelect(selected: TRow[]): void {
+    this.selected.splice(0, this.selected.length, ...selected);
+    this.select.emit({ selected });
   }
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The body components maintains an array of currently selected rows. When a selection is changed by the user, values will be added / remove in the array but a new reference is never created.
Since there is no new reference, the input of the of row-wrapper is never updated, so computed signals do not work.
So a `IterableDiffer` is used instead to detect potential changes.

**What is the new behavior?**

The `selected` input of the body component is now a modal which also reflects its true behavior.
As a consequence, the corresponding output was removed in favor of `selectedChange`.
In order to allow proper usage of signals, the `selected` input will now always get a new reference on modification.
This allows us to drop the `IterableDiffer` in the body-wrapper in favor of `computed`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

There are more improvements coming. As there are clearly many flaws around the handling of selection and also expansion states.