### PR TITLE
fix: support parallel usage of grouping and details

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.scss
@@ -1,0 +1,9 @@
+:host {
+  display: flex;
+  flex-direction: column;
+}
+
+.datatable-group-header {
+  inset-inline-start: 0;
+  position: sticky;
+}

--- a/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.ts
@@ -1,0 +1,89 @@
+import { NgTemplateOutlet } from '@angular/common';
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output
+} from '@angular/core';
+
+import { Group, GroupContext, Row } from '../../types/public.types';
+import { DatatableGroupHeaderDirective } from './body-group-header.directive';
+
+@Component({
+  selector: 'datatable-group-wrapper',
+  imports: [NgTemplateOutlet],
+  template: `
+    @let groupHeader = this.groupHeader();
+    @if (groupHeader && groupHeader.template) {
+      <div
+        class="datatable-group-header"
+        [style.height.px]="groupHeaderRowHeight()"
+        [style.width.px]="innerWidth()"
+      >
+        <div class="datatable-group-cell">
+          @if (groupHeader.checkboxable) {
+            <div>
+              <label class="datatable-checkbox">
+                <input
+                  #select
+                  type="checkbox"
+                  [attr.aria-label]="ariaGroupHeaderCheckboxMessage()"
+                  [checked]="checked()"
+                  [indeterminate]="indeterminate()"
+                  (change)="onCheckboxChange(select.checked)"
+                />
+              </label>
+            </div>
+          }
+          <ng-template
+            [ngTemplateOutlet]="groupHeader.template"
+            [ngTemplateOutletContext]="context()"
+          />
+        </div>
+      </div>
+    }
+    @if (expanded()) {
+      <ng-content />
+    }
+  `,
+  styleUrl: './body-group-wrapper.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'datatable-group-wrapper'
+  }
+})
+export class DataTableGroupWrapperComponent<TRow extends Row = any> {
+  readonly innerWidth = input.required<number>();
+  readonly groupHeader = input.required<DatatableGroupHeaderDirective | undefined>();
+  readonly groupHeaderRowHeight = input.required<number>();
+  readonly group = input.required<Group<TRow>>();
+  readonly groupedRows = input<Group<TRow>[]>();
+  readonly selected = input.required<TRow[]>();
+  readonly disabled = input<boolean>();
+  readonly rowIndex = input.required<number>();
+  readonly expanded = input(false, { transform: booleanAttribute });
+  readonly ariaGroupHeaderCheckboxMessage = input.required<string>();
+  readonly groupSelectedChange = output<boolean>();
+
+  readonly context = computed<GroupContext<TRow>>(() => {
+    return {
+      group: this.group(),
+      expanded: this.expanded(),
+      rowIndex: this.rowIndex()
+    };
+  });
+  readonly selectedRowsOfGroup = computed(() => {
+    const groupValue = this.group().value;
+    return this.selected().filter(row => groupValue.includes(row));
+  });
+  readonly checked = computed(
+    () => this.selectedRowsOfGroup().length === this.group().value.length
+  );
+  readonly indeterminate = computed(() => this.selectedRowsOfGroup().length > 0 && !this.checked());
+
+  onCheckboxChange(groupSelected: boolean): void {
+    this.groupSelectedChange.emit(groupSelected);
+  }
+}

--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.scss
@@ -6,8 +6,3 @@
 .datatable-row-detail {
   overflow-y: hidden;
 }
-
-.datatable-group-header {
-  inset-inline-start: 0;
-  position: sticky;
-}

--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
@@ -8,55 +8,19 @@ import {
   HostListener,
   inject,
   input,
-  KeyValueDiffer,
   KeyValueDiffers,
-  linkedSignal,
   output,
   signal
 } from '@angular/core';
 
-import { Group, GroupContext, Row, RowDetailContext, RowOrGroup } from '../../types/public.types';
-import { DATATABLE_COMPONENT_TOKEN } from '../../utils/table-token';
+import { Row, RowDetailContext, RowOrGroup } from '../../types/public.types';
 import { DatatableRowDetailDirective } from '../row-detail/row-detail.directive';
-import { DatatableGroupHeaderDirective } from './body-group-header.directive';
 
 @Component({
   selector: 'datatable-row-wrapper',
   imports: [NgTemplateOutlet],
   template: `
-    @let row = this.row();
-    @let groupHeader = this.groupHeader();
-    @if (isGroup(row) && groupHeader && groupHeader.template) {
-      <div
-        class="datatable-group-header"
-        [style.height.px]="groupHeaderRowHeight()"
-        [style.width.px]="innerWidth()"
-      >
-        <div class="datatable-group-cell">
-          @if (groupHeader.checkboxable) {
-            <div>
-              <label class="datatable-checkbox">
-                <input
-                  #select
-                  type="checkbox"
-                  [attr.aria-label]="ariaGroupHeaderCheckboxMessage()"
-                  [checked]="checked()"
-                  [indeterminate]="indeterminate()"
-                  (change)="onCheckboxChange(select.checked, row)"
-                />
-              </label>
-            </div>
-          }
-          <ng-template
-            [ngTemplateOutlet]="groupHeader.template"
-            [ngTemplateOutletContext]="context()"
-          />
-        </div>
-      </div>
-    }
-    @if ((groupHeader?.template && expanded()) || !groupHeader || !groupHeader?.template) {
-      <ng-content />
-    }
+    <ng-content />
     @let rowDetailTemplate = rowDetail()?.template();
     @if (rowDetailTemplate && expanded()) {
       <div class="datatable-row-detail" [style.height.px]="detailRowHeight()">
@@ -73,13 +37,8 @@ import { DatatableGroupHeaderDirective } from './body-group-header.directive';
 export class DataTableRowWrapperComponent<TRow extends Row = any> implements DoCheck {
   readonly innerWidth = input.required<number>();
   readonly rowDetail = input<DatatableRowDetailDirective>();
-  readonly groupHeader = input<DatatableGroupHeaderDirective>();
-  readonly offsetX = input.required<number>();
   readonly detailRowHeight = input.required<number>();
-  readonly groupHeaderRowHeight = input.required<number>();
-  readonly row = input.required<RowOrGroup<TRow>>();
-  readonly groupedRows = input<Group<TRow>[]>();
-  readonly selected = input.required<TRow[]>();
+  readonly row = input.required<TRow>();
   readonly disabled = input<boolean>();
   readonly rowContextmenu = output<{
     event: MouseEvent;
@@ -88,83 +47,33 @@ export class DataTableRowWrapperComponent<TRow extends Row = any> implements DoC
 
   readonly rowIndex = input.required<number>();
 
-  readonly selectedGroupRows = signal<TRow[]>([]);
-
   readonly expanded = input(false, { transform: booleanAttribute });
   readonly ariaGroupHeaderCheckboxMessage = input.required<string>();
 
-  readonly context = linkedSignal<RowDetailContext<TRow> | GroupContext<TRow>>(() => {
-    const row = this.row();
-    if (this.isGroup(row)) {
-      return {
-        group: row,
-        expanded: this.expanded(),
-        rowIndex: this.rowIndex()
-      };
-    } else {
-      return {
-        row,
-        expanded: this.expanded(),
-        rowIndex: this.rowIndex(),
-        disabled: this.disabled()
-      };
-    }
+  readonly context = computed<RowDetailContext<TRow>>(() => {
+    this.rowDiffedCount(); // This allows us to get re-evaluated when the row was mutated internally.
+    return {
+      row: this.row(),
+      expanded: this.expanded(),
+      rowIndex: this.rowIndex(),
+      disabled: this.disabled()
+    };
   });
-  readonly selectedRowsOfGroup = computed(() =>
-    (this.row() as Group<TRow>).value.filter(row => this.selected().includes(row))
-  );
-  readonly checked = computed(
-    () => this.selectedRowsOfGroup().length === (this.row() as Group<TRow>).value.length
-  );
-  readonly indeterminate = computed(() => this.selectedRowsOfGroup().length > 0 && !this.checked());
 
-  private rowDiffer: KeyValueDiffer<keyof RowOrGroup<TRow>, any> = inject(KeyValueDiffers)
-    .find({})
-    .create();
-  private tableComponent = inject(DATATABLE_COMPONENT_TOKEN);
+  // This counter will be incremented every time the row object is mutated.
+  readonly rowDiffedCount = signal(0);
+
+  private rowDiffer = inject(KeyValueDiffers).find({}).create<keyof RowOrGroup<TRow>, any>();
 
   ngDoCheck(): void {
     const row = this.row();
     if (this.rowDiffer.diff(row)) {
-      if ('group' in this.context()) {
-        this.context.set({
-          group: row as Group<TRow>,
-          expanded: this.expanded(),
-          rowIndex: this.rowIndex()
-        });
-      } else {
-        this.context.set({
-          row: row as TRow,
-          expanded: this.expanded(),
-          rowIndex: this.rowIndex(),
-          disabled: this.disabled()
-        });
-      }
+      this.rowDiffedCount.update(count => count + 1);
     }
   }
 
   @HostListener('contextmenu', ['$event'])
   onContextmenu($event: MouseEvent): void {
     this.rowContextmenu.emit({ event: $event, row: this.row() });
-  }
-
-  onCheckboxChange(groupSelected: boolean, group: Group<TRow>): void {
-    const selectedSet = new Set(this.selected());
-    group.value.forEach((item: TRow) => {
-      if (groupSelected) {
-        selectedSet.add(item);
-      } else {
-        selectedSet.delete(item);
-      }
-    });
-    const selected = Array.from(selectedSet);
-    // Update `selected` of DatatableComponent with newly evaluated `selected`
-    this.tableComponent.selected = [...selected];
-    // Emit select event with updated values
-    this.tableComponent.onBodySelect(this.tableComponent.selected);
-  }
-
-  isGroup(row: RowOrGroup<TRow>): row is Group<TRow> {
-    return !!this.groupHeader();
   }
 }


### PR DESCRIPTION
Closes #147

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently row-grouping and details are sharing the same expansion state. So it is impossible to use them in parallel.

**What is the new behavior?**

This commit separates them into two different fields. It is done by duplicating the relevant fields in the body-component,
and by splitting row-wrapper into an actual row-wrapper for managing the details and a group-wrapper, for managing groups.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This is a preparation to split the group rendering from the body component.