### PR TITLE
fix: `headerHeight="auto"` should be supported

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -230,7 +230,7 @@ export class DatatableComponent<TRow extends Row = any>
    * The minimum header height in pixels.
    * Pass a falsey for no header
    */
-  @Input({ transform: numberAttribute }) headerHeight = 30;
+  @Input() headerHeight: number | 'auto' = 30;
 
   /**
    * The minimum footer height in pixels.
@@ -667,8 +667,12 @@ export class DatatableComponent<TRow extends Row = any>
   @ViewChild(DataTableHeaderComponent)
   headerComponent!: DataTableHeaderComponent;
 
+  @ViewChild(DataTableHeaderComponent, { read: ElementRef })
+  headerElement?: ElementRef<HTMLElement>;
+
   @ViewChild(DataTableBodyComponent, { read: ElementRef })
   private bodyElement!: ElementRef<HTMLElement>;
+
   @ContentChild(DatatableRowDefDirective, {
     read: TemplateRef
   })
@@ -976,8 +980,8 @@ export class DatatableComponent<TRow extends Row = any>
 
     if (this.scrollbarV) {
       let height = dims.height;
-      if (this.headerHeight) {
-        height = height - this.headerHeight;
+      if (this.headerElement) {
+        height = height - this.headerElement.nativeElement.getBoundingClientRect().height;
       }
       if (this.footerHeight) {
         height = height - this.footerHeight;

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -144,7 +144,7 @@ export class DataTableHeaderComponent implements OnDestroy, OnChanges {
 
   @HostBinding('style.height')
   @Input()
-  set headerHeight(val: any) {
+  set headerHeight(val: number | 'auto') {
     if (val !== 'auto') {
       this._headerHeight = `${val}px`;
     } else {


### PR DESCRIPTION
This used to work previously, but we forgot to reflect this in the type and then broke it by adding a number converter.

Closes #473

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`[headerHeight]="'auto'"` does not work.

**What is the new behavior?**

`[headerHeight]="'auto'"` does work.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

I assume that `headerHeight="auto"` in combination with `scrollbarV` never worked before. With this change it still does not work, but we get a little closer to also get it working. Based on the errors, I assume this is now just an issue of the order of initialization. We fix this later.