### PR TITLE
refactor: use signal compute for RowHeightCache

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -214,23 +214,23 @@ describe('DataTableBodyComponent', () => {
 
       // Initially, group should be collapsed
       expect(component.getGroupExpanded(group)).toBeFalse();
-      expect(component.rowExpansions).toHaveSize(0);
+      expect(component.rowExpansions()).toHaveSize(0);
 
       // Expand the group
       component.toggleGroupExpansion(group);
       fixture.detectChanges();
 
       expect(component.getGroupExpanded(group)).toBeTrue();
-      expect(component.groupExpansions).toHaveSize(1);
-      expect(component.groupExpansions[0]).toBe(group);
+      expect(component.groupExpansions()).toHaveSize(1);
+      expect(component.groupExpansions()[0]).toBe(group);
 
       // Now expand row detail for the first row in the group
       component.toggleRowExpansion(row1);
       fixture.detectChanges();
 
       expect(component.getRowExpanded(row1)).toBeTrue();
-      expect(component.rowExpansions).toHaveSize(1);
-      expect(component.rowExpansions[0]).toBe(row1);
+      expect(component.rowExpansions()).toHaveSize(1);
+      expect(component.rowExpansions()[0]).toBe(row1);
 
       // Group should still be expanded
       expect(component.getGroupExpanded(group)).toBeTrue();
@@ -240,17 +240,17 @@ describe('DataTableBodyComponent', () => {
       fixture.detectChanges();
 
       expect(component.getRowExpanded(row2)).toBeTrue();
-      expect(component.rowExpansions).toHaveSize(2);
-      expect(component.rowExpansions).toContain(row1);
-      expect(component.rowExpansions).toContain(row2);
+      expect(component.rowExpansions()).toHaveSize(2);
+      expect(component.rowExpansions()).toContain(row1);
+      expect(component.rowExpansions()).toContain(row2);
 
       // Collapse the first row detail
       component.toggleRowExpansion(row1);
       fixture.detectChanges();
 
       expect(component.getRowExpanded(row1)).toBeFalse();
-      expect(component.rowExpansions).toHaveSize(1);
-      expect(component.rowExpansions[0]).toBe(row2);
+      expect(component.rowExpansions()).toHaveSize(1);
+      expect(component.rowExpansions()[0]).toBe(row2);
 
       // Group should still be expanded
       expect(component.getGroupExpanded(group)).toBeTrue();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The `rowHeightCache` is a signal, but currently not computed in a signal way.

**What is the new behavior?**

The `rowHeightCache` is a computed signal now.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This serves the overall goals:

- Simplify the body.component
- Signalfy everything, so that we can maintain the data in a global store instead in components
