### PR TITLE
refactor: migrate constructor assigned inputs to signals

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -1,6 +1,6 @@
 <div visibilityObserver (visible)="recalculate()">
   <div role="table">
-    @if (headerHeight) {
+    @if (headerHeight()) {
       <datatable-header
         role="rowgroup"
         [sorts]="sorts"
@@ -10,17 +10,17 @@
         [offsetX]="_offsetX"
         [dealsWithGroup]="groupedRows !== undefined"
         [columns]="_internalColumns"
-        [headerHeight]="headerHeight"
+        [headerHeight]="headerHeight()"
         [reorderable]="reorderable()"
         [targetMarkerTemplate]="targetMarkerTemplate()"
-        [sortAscendingIcon]="cssClasses.sortAscending"
-        [sortDescendingIcon]="cssClasses.sortDescending"
-        [sortUnsetIcon]="cssClasses.sortUnset"
+        [sortAscendingIcon]="cssClasses().sortAscending"
+        [sortDescendingIcon]="cssClasses().sortDescending"
+        [sortUnsetIcon]="cssClasses().sortUnset"
         [allRowsSelected]="allRowsSelected"
         [selectionType]="selectionType()"
         [verticalScrollVisible]="verticalScrollVisible"
         [enableClearingSortState]="enableClearingSortState()"
-        [ariaHeaderCheckboxMessage]="messages.ariaHeaderCheckboxMessage ?? 'Select all rows'"
+        [ariaHeaderCheckboxMessage]="messages().ariaHeaderCheckboxMessage ?? 'Select all rows'"
         (sort)="onColumnSort($event)"
         (resize)="onColumnResize($event)"
         (resizing)="onColumnResizing($event)"
@@ -42,7 +42,7 @@
       [loadingIndicator]="loadingIndicator()"
       [ghostLoadingIndicator]="ghostLoadingIndicator"
       [externalPaging]="externalPaging()"
-      [rowHeight]="rowHeight"
+      [rowHeight]="rowHeight()"
       [rowCount]="rowCount"
       [offset]="offset"
       [trackByProp]="trackByProp()"
@@ -62,15 +62,15 @@
       [summaryHeight]="summaryHeight()"
       [summaryPosition]="summaryPosition()"
       [verticalScrollVisible]="verticalScrollVisible"
-      [ariaRowCheckboxMessage]="messages.ariaRowCheckboxMessage ?? 'Select row'"
+      [ariaRowCheckboxMessage]="messages().ariaRowCheckboxMessage ?? 'Select row'"
       [ariaGroupHeaderCheckboxMessage]="
-        messages.ariaGroupHeaderCheckboxMessage ?? 'Select row group'
+        messages().ariaGroupHeaderCheckboxMessage ?? 'Select row group'
       "
       [disableRowCheck]="disableRowCheck()"
       [rowDraggable]="rowDraggable()"
       [rowDragEvents]="rowDragEvents"
       [rowDefTemplate]="rowDefTemplate"
-      [cssClasses]="cssClasses"
+      [cssClasses]="cssClasses()"
       [(selected)]="selected"
       (page)="onBodyPage($event)"
       (activate)="activate.emit($event)"
@@ -87,27 +87,27 @@
           <div
             role="cell"
             class="empty-row"
-            [innerHTML]="messages.emptyMessage ?? 'No data to display'"
+            [innerHTML]="messages().emptyMessage ?? 'No data to display'"
           ></div>
         </div>
       </ng-content>
     </datatable-body>
   </div>
-  @if (footerHeight) {
+  @if (footerHeight()) {
     <datatable-footer
       [rowCount]="groupedRows !== undefined ? _internalRows.length : rowCount"
       [groupCount]="groupedRows !== undefined ? rowCount : undefined"
       [pageSize]="pageSize"
       [offset]="offset"
-      [footerHeight]="footerHeight"
+      [footerHeight]="footerHeight()"
       [footerTemplate]="footer"
-      [totalMessage]="messages.totalMessage ?? 'total'"
-      [pagerLeftArrowIcon]="cssClasses.pagerLeftArrow"
-      [pagerRightArrowIcon]="cssClasses.pagerRightArrow"
-      [pagerPreviousIcon]="cssClasses.pagerPrevious"
+      [totalMessage]="messages().totalMessage ?? 'total'"
+      [pagerLeftArrowIcon]="cssClasses().pagerLeftArrow"
+      [pagerRightArrowIcon]="cssClasses().pagerRightArrow"
+      [pagerPreviousIcon]="cssClasses().pagerPrevious"
       [selectedCount]="selected().length"
-      [selectedMessage]="!!selectionType() && (messages.selectedMessage ?? 'selected')"
-      [pagerNextIcon]="cssClasses.pagerNext"
+      [selectedMessage]="!!selectionType() && (messages().selectedMessage ?? 'selected')"
+      [pagerNextIcon]="cssClasses().pagerNext"
       (page)="onFooterPage($event)"
     />
   }

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -219,7 +219,9 @@ export class DatatableComponent<TRow extends Row = any>
    * The row height; which is necessary
    * to calculate the height for the lazy rendering.
    */
-  @Input() rowHeight: number | 'auto' | ((row: TRow) => number) = 30;
+  readonly rowHeight = input<number | 'auto' | ((row: TRow) => number)>(
+    this.configuration?.rowHeight ?? 30
+  );
 
   /**
    * Type of column width distribution formula.
@@ -231,13 +233,15 @@ export class DatatableComponent<TRow extends Row = any>
    * The minimum header height in pixels.
    * Pass a falsey for no header
    */
-  @Input() headerHeight: number | 'auto' = 30;
+  readonly headerHeight = input<number | 'auto'>(this.configuration?.headerHeight ?? 30);
 
   /**
    * The minimum footer height in pixels.
    * Pass falsey for no footer
    */
-  @Input({ transform: numberAttribute }) footerHeight = 0;
+  readonly footerHeight = input(this.configuration?.footerHeight ?? 0, {
+    transform: numberAttribute
+  });
 
   /**
    * If the table should use external paging
@@ -359,7 +363,9 @@ export class DatatableComponent<TRow extends Row = any>
   /**
    * Css class overrides
    */
-  @Input() cssClasses: Partial<Required<NgxDatatableConfig>['cssClasses']> = {};
+  readonly cssClasses = input<Partial<Required<NgxDatatableConfig>['cssClasses']>>(
+    this.configuration?.cssClasses ?? {}
+  );
 
   /**
    * Message overrides for localization
@@ -381,7 +387,9 @@ export class DatatableComponent<TRow extends Row = any>
    * }
    * ```
    */
-  @Input() messages: Partial<Required<NgxDatatableConfig>['messages']> = {};
+  readonly messages = input<Partial<Required<NgxDatatableConfig>['messages']>>(
+    this.configuration?.messages ?? {}
+  );
 
   /**
    * A function which is called with the row and should return either:
@@ -554,7 +562,7 @@ export class DatatableComponent<TRow extends Row = any>
    */
   @HostBinding('class.fixed-header')
   get isFixedHeader(): boolean {
-    const headerHeight: number | string = this.headerHeight;
+    const headerHeight: number | string = this.headerHeight();
     return typeof headerHeight === 'string' ? (headerHeight as string) !== 'auto' : true;
   }
 
@@ -564,7 +572,7 @@ export class DatatableComponent<TRow extends Row = any>
    */
   @HostBinding('class.fixed-row')
   get isFixedRow(): boolean {
-    return this.rowHeight !== 'auto';
+    return this.rowHeight() !== 'auto';
   }
 
   /**
@@ -726,7 +734,7 @@ export class DatatableComponent<TRow extends Row = any>
   _columns!: TableColumn[];
   _subscriptions: Subscription[] = [];
   _ghostLoadingIndicator = false;
-  _defaultColumnWidth?: number;
+  _defaultColumnWidth = this.configuration?.defaultColumnWidth ?? 150;
   /**
    * To have this available for all components.
    * The Footer itself is not available in the injection context in templates,
@@ -739,22 +747,6 @@ export class DatatableComponent<TRow extends Row = any>
   // this makes horizontal scroll to appear on load even if columns can fit in view
   // this will be set to true once rows are available and rendered on UI
   private readonly _rowInitDone = signal(false);
-
-  constructor() {
-    // apply global settings from Module.forRoot
-    if (this.configuration) {
-      if (this.configuration.messages) {
-        this.messages = { ...this.configuration.messages };
-      }
-      if (this.configuration.cssClasses) {
-        this.cssClasses = { ...this.configuration.cssClasses };
-      }
-      this.headerHeight = this.configuration.headerHeight ?? this.headerHeight;
-      this.footerHeight = this.configuration.footerHeight ?? this.footerHeight;
-      this.rowHeight = this.configuration.rowHeight ?? this.rowHeight;
-      this._defaultColumnWidth = this.configuration.defaultColumnWidth ?? 150;
-    }
-  }
 
   /**
    * Lifecycle hook that is called after data-bound
@@ -996,8 +988,8 @@ export class DatatableComponent<TRow extends Row = any>
       if (this.headerElement) {
         height = height - this.headerElement.nativeElement.getBoundingClientRect().height;
       }
-      if (this.footerHeight) {
-        height = height - this.footerHeight;
+      if (this.footerHeight()) {
+        height = height - this.footerHeight();
       }
       this.bodyHeight = height;
     }
@@ -1076,7 +1068,7 @@ export class DatatableComponent<TRow extends Row = any>
     // This is because an expanded row is still considered to be a child of
     // the original row.  Hence calculation would use rowHeight only.
     if (this.scrollbarV() && this.virtualization()) {
-      const size = Math.ceil(this.bodyHeight / (this.rowHeight as number));
+      const size = Math.ceil(this.bodyHeight / (this.rowHeight() as number));
       return Math.max(size, 0);
     }
 

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, Signal, TemplateRef, viewChild } from '@angular/core';
+import { Component, DebugElement, signal, Signal, TemplateRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -183,6 +183,7 @@ class TestFixtureComponent {
   footerTemplate?: { template: Signal<TemplateRef<any>> };
   selectedCount = 0;
   selectedMessage?: string;
+  readonly messages = signal({});
 
   /**
    * establishes a reference to a test template that can

--- a/projects/ngx-datatable/src/lib/components/footer/pager.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/pager.component.spec.ts
@@ -8,9 +8,9 @@ import {
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { DatatableComponent } from '@siemens/ngx-datatable';
 
 import { DATATABLE_COMPONENT_TOKEN } from '../../utils/table-token';
-import type { DatatableComponent } from '../datatable.component';
 import { DatatablePagerComponent } from './pager.component';
 import { PagerHarness } from './testing/pager.harness';
 
@@ -28,9 +28,9 @@ interface MockFooter {
 
 describe('DataTablePagerComponent', () => {
   let fixture: ComponentFixture<DatatablePagerComponent>;
-  let pager: DatatablePagerComponent;
   let harness: PagerHarness;
   let footer: MockFooter;
+  let messages: WritableSignal<ReturnType<DatatableComponent['messages']>>;
 
   beforeEach(async () => {
     footer = {
@@ -44,19 +44,19 @@ describe('DataTablePagerComponent', () => {
       pagerPreviousIcon: signal(''),
       page: { emit: ({ page }: { page: number }) => footer.curPage.set(page) }
     };
+    messages = signal({});
     TestBed.overrideComponent(DatatablePagerComponent, {
       set: {
         changeDetection: ChangeDetectionStrategy.Default,
         providers: [
           {
             provide: DATATABLE_COMPONENT_TOKEN,
-            useValue: { _footerComponent: signal(footer) }
+            useValue: { _footerComponent: signal(footer), messages }
           }
         ]
       }
     });
     fixture = TestBed.createComponent(DatatablePagerComponent);
-    pager = fixture.componentInstance;
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, PagerHarness);
   });
 
@@ -273,8 +273,8 @@ describe('DataTablePagerComponent', () => {
     };
 
     describe('takes messages-overrides from table', () => {
-      const setMessages = (messages: DatatableComponent['messages']) => {
-        (pager as any).datatable = { messages };
+      const setMessages = (overrides: ReturnType<DatatableComponent['messages']>) => {
+        messages.set(overrides);
         // do a change detection on the real changeDetectionRef
         fixture.componentRef.injector.get(ChangeDetectorRef).detectChanges();
       };

--- a/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
@@ -106,8 +106,8 @@ export class DatatablePagerComponent {
   // Ideally we can one day fetch those attributes from a global state, but for now this is fine.
   private datatable = inject(DATATABLE_COMPONENT_TOKEN);
 
-  protected get messages(): DatatableComponent['messages'] {
-    return this.datatable?.messages ?? {};
+  protected get messages(): ReturnType<DatatableComponent['messages']> {
+    return this.datatable?.messages() ?? {};
   }
 
   protected readonly page = computed(() => this.datatable._footerComponent()!.curPage());


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Some `@Input` with default assignment in the constructor are not signals yet.

**What is the new behavior?**

All `@Input` from the constructor are now signal inputs and are defaulted at initialization. The constructor is removed and related code places are adjusted.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

For breaking change note refer to 4bfbf6200fc42701b9cfee55bbdb845bd9eda514.

**Other information**:
