### PR TITLE
feat: convert `sorts` to signal model with two-way binding

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -3,7 +3,7 @@
     @if (headerHeight()) {
       <datatable-header
         role="rowgroup"
-        [sorts]="sorts"
+        [sorts]="sorts()"
         [sortType]="sortType()"
         [scrollbarH]="scrollbarH()"
         [innerWidth]="_innerWidth"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -355,7 +355,7 @@ export class DatatableComponent<TRow extends Row = any>
    * Array of sorted columns by property and type.
    * Default value: `[]`
    */
-  @Input() sorts: SortPropDir[] = [];
+  readonly sorts = model<SortPropDir[]>([]);
 
   /**
    * Css class overrides
@@ -517,6 +517,18 @@ export class DatatableComponent<TRow extends Row = any>
 
   /**
    * Column sort was invoked.
+   * @deprecated Use two-way binding on `sorts` instead.
+   *
+   * Before:
+   * ```html
+   * <ngx-datatable [sorts]="mySorts" (sort)="onSort($event)"></ngx-datatable>
+   * ```
+   *
+   * After:
+   * ```html
+   * <ngx-datatable [sorts]="mySorts" (sortsChange)="onSort({sorts: $event})"></ngx-datatable>
+   * <!-- or -->
+   * <ngx-datatable [(sorts)]="mySorts"></ngx-datatable>
    */
   readonly sort = output<SortEvent>();
 
@@ -824,7 +836,7 @@ export class DatatableComponent<TRow extends Row = any>
           pageSize: this.pageSize,
           limit: this.limit,
           offset: 0,
-          sorts: this.sorts
+          sorts: this.sorts()
         });
       }
     });
@@ -1017,7 +1029,7 @@ export class DatatableComponent<TRow extends Row = any>
         pageSize: this.pageSize,
         limit: this.limit,
         offset: this.offset,
-        sorts: this.sorts
+        sorts: this.sorts()
       });
     }
   }
@@ -1042,7 +1054,7 @@ export class DatatableComponent<TRow extends Row = any>
       pageSize: this.pageSize,
       limit: this.limit,
       offset: this.offset,
-      sorts: this.sorts
+      sorts: this.sorts()
     });
 
     if (this.selectAllRowsOnPage()) {
@@ -1192,7 +1204,7 @@ export class DatatableComponent<TRow extends Row = any>
       });
     }
 
-    this.sorts = event.sorts;
+    this.sorts.set(event.sorts);
 
     // this could be optimized better since it will resort
     // the rows again on the 'push' detection...
@@ -1217,7 +1229,7 @@ export class DatatableComponent<TRow extends Row = any>
       pageSize: this.pageSize,
       limit: this.limit,
       offset: this.offset,
-      sorts: this.sorts
+      sorts: this.sorts()
     });
     this.sort.emit(event);
   }
@@ -1287,7 +1299,7 @@ export class DatatableComponent<TRow extends Row = any>
 
   private sortInternalRows(): void {
     // if there are no sort criteria we reset the rows with original rows
-    if (!this.sorts?.length) {
+    if (!this.sorts()?.length) {
       this._internalRows = this._rows;
       // if there is any tree relation then re-group rows accordingly
       if (this.treeFromRelation() && this.treeToRelation()) {
@@ -1299,19 +1311,19 @@ export class DatatableComponent<TRow extends Row = any>
       }
     }
     if (this.groupedRows?.length) {
-      const sortOnGroupHeader = this.sorts?.find(
+      const sortOnGroupHeader = this.sorts()?.find(
         sortColumns => sortColumns.prop === this._groupRowsBy
       );
       this.groupedRows = this.groupArrayBy(this._rows, this._groupRowsBy!);
       this.groupedRows = sortGroupedRows(
         this.groupedRows,
         this._internalColumns,
-        this.sorts,
+        this.sorts(),
         sortOnGroupHeader
       );
       this._internalRows = [...this._internalRows];
     } else {
-      this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts);
+      this._internalRows = sortRows(this._internalRows, this._internalColumns, this.sorts());
     }
   }
 }

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -22,6 +22,7 @@ export const SortDirection = {
 
 export type SortDirection = (typeof SortDirection)[keyof typeof SortDirection];
 
+/** @deprecated See {@link DatatableComponent.sort} */
 export interface SortEvent {
   column: TableColumn;
   prevValue: SortDirection | undefined;

--- a/src/app/sorting/sorting-server.component.ts
+++ b/src/app/sorting/sorting-server.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { DatatableComponent, SortEvent, TableColumn } from '@siemens/ngx-datatable';
+import { DatatableComponent, SortPropDir, TableColumn } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
@@ -30,7 +30,7 @@ import { DataService } from '../data.service';
         [footerHeight]="50"
         [externalSorting]="true"
         [loadingIndicator]="loading"
-        (sort)="onSort($event)"
+        (sortsChange)="onSort($event)"
       />
     </div>
   `
@@ -54,7 +54,7 @@ export class ServerSortingComponent {
     });
   }
 
-  onSort(event: SortEvent) {
+  onSort(event: SortPropDir[]) {
     // event was triggered, start sort sequence
     this.loading = true;
     // emulate a server request with a timeout
@@ -63,7 +63,7 @@ export class ServerSortingComponent {
       // this is only for demo purposes, normally
       // your server would return the result for
       // you and you would just set the rows prop
-      const sort = event.sorts[0];
+      const sort = event[0];
       type SortProp = 'company' | 'name' | 'gender';
       rows.sort(
         (a, b) =>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

There is a `sorts` input and a `sorts` event, which emits the updated value of sorts plus some useless extras.

**What is the new behavior?**

`sorts` is now a signal model, so there is a new `sortsChange` event and the old `sort` event is deprecated.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes, but this was already announced in another commit
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

**Other information**:

The `DatatableComponent.sort` output is deprecated; use `(sortsChange)` or two-way binding instead.

Before:

```html
<ngx-datatable [sorts]="mySorts" (sort)="onSort($event)"></ngx-datatable>
```

After:

```html
<ngx-datatable [sorts]="mySorts" (sortsChange)="onSort({sorts: $event})"></ngx-datatable>
<!-- or -->
<ngx-datatable [(sorts)]="mySorts"></ngx-datatable>
```