### PR TITLE
refactor: convert ghost-loading-indicator to signal input

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -40,7 +40,7 @@
       [scrollbarH]="scrollbarH()"
       [virtualization]="virtualization()"
       [loadingIndicator]="loadingIndicator()"
-      [ghostLoadingIndicator]="ghostLoadingIndicator"
+      [ghostLoadingIndicator]="ghostLoadingIndicator()"
       [externalPaging]="externalPaging()"
       [rowHeight]="rowHeight()"
       [rowCount]="rowCount"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`ghostLoadingIndicator` is a decorator input.

**What is the new behavior?**
`ghostLoadingIndicator` is a signal.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes, but covered in another commit
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Using effects to handle side effects is supposed to be a temporary solution. We must convert most fields to signals, before we can use computed instead.
