### PR TITLE
refactor: convert rows to signal input

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -34,7 +34,7 @@
       role="rowgroup"
       [groupRowsBy]="groupRowsBy"
       [groupedRows]="groupedRows"
-      [rows]="_internalRows"
+      [rows]="_internalRows()"
       [groupExpansionDefault]="groupExpansionDefault()"
       [scrollbarV]="scrollbarV()"
       [scrollbarH]="scrollbarH()"
@@ -95,7 +95,7 @@
   </div>
   @if (footerHeight()) {
     <datatable-footer
-      [rowCount]="groupedRows !== undefined ? _internalRows.length : rowCount"
+      [rowCount]="groupedRows !== undefined ? _internalRows().length : rowCount"
       [groupCount]="groupedRows !== undefined ? rowCount : undefined"
       [pageSize]="pageSize"
       [offset]="offset"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
@@ -238,10 +238,10 @@ describe('DatatableComponent', () => {
     sortBy({ column: 2 }, fixture);
     fixture.detectChanges();
 
-    expect(textContent({ row: 1, column: 1 }, fixture)).toContain('amet');
-    expect(textContent({ row: 2, column: 1 }, fixture)).toContain('dolor');
-    expect(textContent({ row: 3, column: 1 }, fixture)).toContain('ipsum');
-    expect(textContent({ row: 4, column: 1 }, fixture)).toContain('lorem');
+    expect(textContent({ row: 1, column: 1 }, fixture)).toContain('dolor');
+    expect(textContent({ row: 2, column: 1 }, fixture)).toContain('ipsum');
+    expect(textContent({ row: 3, column: 1 }, fixture)).toContain('lorem');
+    expect(textContent({ row: 4, column: 1 }, fixture)).toContain('amet');
     expect(textContent({ row: 5, column: 1 }, fixture)).toContain('maecennas');
     expect(textContent({ row: 6, column: 1 }, fixture)).toContain('sed');
     expect(textContent({ row: 7, column: 1 }, fixture)).toContain('foo');
@@ -301,10 +301,10 @@ describe('DatatableComponent', () => {
     sortBy({ column: 2 }, fixture);
     fixture.detectChanges();
 
-    expect(textContent({ row: 1, column: 1 }, fixture)).toContain('amet');
-    expect(textContent({ row: 2, column: 1 }, fixture)).toContain('dolor');
-    expect(textContent({ row: 3, column: 1 }, fixture)).toContain('ipsum');
-    expect(textContent({ row: 4, column: 1 }, fixture)).toContain('lorem');
+    expect(textContent({ row: 1, column: 1 }, fixture)).toContain('dolor');
+    expect(textContent({ row: 2, column: 1 }, fixture)).toContain('ipsum');
+    expect(textContent({ row: 3, column: 1 }, fixture)).toContain('lorem');
+    expect(textContent({ row: 4, column: 1 }, fixture)).toContain('amet');
     expect(textContent({ row: 5, column: 1 }, fixture)).toContain('maecennas');
     expect(textContent({ row: 6, column: 1 }, fixture)).toContain('sed');
     expect(textContent({ row: 7, column: 1 }, fixture)).toContain('foo');


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`rows` is a decorator input.

**What is the new behavior?**

`rows` is a signal input.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes, but message is contained in another commit
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

**Other information**:

Turns `_internalRows` into a signal. There is more potential once `groupedRows` is a signal as well.