### PR TITLE
refactor: convert groupedRows to signal input

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -284,7 +284,6 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   // TODO: Find a better way to handle default expansion state with signal input
   @Input() groupExpansionDefault?: boolean;
   readonly innerWidth = input.required<number>();
-  readonly groupRowsBy = input<keyof TRow>();
   readonly virtualization = input<boolean>();
   readonly summaryRow = input<boolean>();
   readonly summaryPosition = input.required<string>();

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -8,7 +8,7 @@
         [scrollbarH]="scrollbarH()"
         [innerWidth]="_innerWidth"
         [offsetX]="_offsetX"
-        [dealsWithGroup]="groupedRows !== undefined"
+        [dealsWithGroup]="_internalGroupedRows() !== undefined"
         [columns]="_internalColumns()"
         [headerHeight]="headerHeight()"
         [reorderable]="reorderable()"
@@ -32,8 +32,7 @@
     <datatable-body
       tabindex="0"
       role="rowgroup"
-      [groupRowsBy]="groupRowsBy"
-      [groupedRows]="groupedRows"
+      [groupedRows]="_internalGroupedRows()"
       [rows]="_internalRows()"
       [groupExpansionDefault]="groupExpansionDefault()"
       [scrollbarV]="scrollbarV()"
@@ -95,8 +94,8 @@
   </div>
   @if (footerHeight()) {
     <datatable-footer
-      [rowCount]="groupedRows !== undefined ? _internalRows().length : rowCount"
-      [groupCount]="groupedRows !== undefined ? rowCount : undefined"
+      [rowCount]="_internalGroupedRows() !== undefined ? _internalRows().length : rowCount"
+      [groupCount]="_internalGroupedRows() !== undefined ? rowCount : undefined"
       [pageSize]="pageSize"
       [offset]="offset"
       [footerHeight]="footerHeight()"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`groupedRows` and `groupRowsBy` are decorator based inputs.

**What is the new behavior?**

`groupedRows` and `groupRowsBy` are signal inputs. A new `_internalGroupedRows` contains the calculated combination.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

`groupedRows` will no longer be updated, if grouped rows are calculated based on `groupRowsBy`.

**Other information**:
