### PR TITLE
fix: always apply `role="row"` on summary row

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -59,6 +59,8 @@ import { DataTableBodyCellComponent } from './body-cell.component';
   styleUrl: './body-row.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
+    role: 'row',
+    tabindex: '-1',
     '[class]': 'cssClass()',
     '[class.active]': 'isSelected()',
     '[class.datatable-row-odd]': 'innerRowIndex() % 2 !== 0',

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -131,8 +131,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
           >
             <datatable-body-row
               #rowElement
-              role="row"
-              tabindex="-1"
               [disabled]="disabled"
               [isSelected]="getRowSelected(row)"
               [columns]="columns"
@@ -232,7 +230,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
       </datatable-scroller>
       @if (summaryRow() && summaryPosition() === 'bottom') {
         <datatable-summary-row
-          role="row"
           [rowHeight]="summaryHeight()"
           [innerWidth]="innerWidth()"
           [rows]="rows"

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
@@ -28,7 +28,6 @@ const noopSumFunc = (cells: any[]): void => {
     @let _internalColumns = this._internalColumns();
     @if (summaryRow && _internalColumns.length) {
       <datatable-body-row
-        tabindex="-1"
         ariaRowCheckboxMessage=""
         [columns]="_internalColumns"
         [rowHeight]="rowHeight()"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The position-top summary row is lacking the `role="row"` attribute. The `role="row"` attribute is defined multiple times in the body template.

**What is the new behavior?**

Every row has the `role="row"` attribute and it is only defined once on the respective component.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Solves the a11y issue here: https://github.com/siemens/element/pull/301.