### PR TITLE
fix: column `compareFn` should not use sort direction

### DIFF
--- a/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
@@ -33,8 +33,7 @@ export class DataTableColumnDirective<TRow extends Row> {
     transform: booleanAttribute
   });
   readonly comparator = input<
-    | ((valueA: any, valueB: any, rowA: TRow, rowB: TRow, sortDir: 'desc' | 'asc') => number)
-    | undefined
+    ((valueA: any, valueB: any, rowA: TRow, rowB: TRow) => number) | undefined
   >();
   readonly pipe = input<PipeTransform | undefined>();
   readonly sortable = input<boolean, boolean | string | undefined>(undefined, {

--- a/projects/ngx-datatable/src/lib/types/table-column.type.ts
+++ b/projects/ngx-datatable/src/lib/types/table-column.type.ts
@@ -59,13 +59,7 @@ export interface TableColumn<TRow extends Row = any> {
   /**
    * Custom sort comparator
    */
-  comparator?: (
-    valueA: any,
-    valueB: any,
-    rowA: TRow,
-    rowB: TRow,
-    sortDir: 'desc' | 'asc'
-  ) => number;
+  comparator?: (valueA: any, valueB: any, rowA: TRow, rowB: TRow) => number;
 
   /**
    * Custom pipe transforms

--- a/projects/ngx-datatable/src/lib/utils/sort.ts
+++ b/projects/ngx-datatable/src/lib/utils/sort.ts
@@ -131,8 +131,8 @@ export const sortRows = <TRow>(
       // direction enable more complex sort logic.
       const comparison =
         cachedDir.dir !== SortDirection.desc
-          ? cachedDir.compareFn(propA, propB, rowA, rowB, cachedDir.dir)
-          : -cachedDir.compareFn(propA, propB, rowA, rowB, cachedDir.dir);
+          ? cachedDir.compareFn(propA, propB, rowA, rowB)
+          : -cachedDir.compareFn(propA, propB, rowA, rowB);
 
       // Don't return 0 yet in case of needing to sort by next property
       if (comparison !== 0) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Custom compare functions receive the direction as a parameter.

**What is the new behavior?**

Custom compare functions do not receive the direction as a parameter.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

The table no longer calls `TableColumn.compareFn` with the sort direction. The table already applies the proper direction. This change only removes the parameter, the sorting itself remains unchanged.

Any usages of the direction in custom `compareFn` must be removed. Implementations which use this property can always return the value for `direction='desc'`, to achieve the same result as before.

**Other information**:

The table already takes care of the direction. The compare function should always reliable return the same value independent of the direction.

If an application had used the direction, than it would have always returned the opposite value in order to sort correct.
Instead the application should just always sort direction independent. This already worked before.
