### PR TITLE
build(renovate): rebase when conflicting

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,7 @@
       datasourceTemplate: "docker"
     }
   ],
+  rebaseWhen: "conflicted",
   packageRules: [
     {
       description: [


### PR DESCRIPTION
In theory, this should be already the case, since the default value is `àuto`. See: https://docs.renovatebot.com/configuration-options/#rebasewhen

In reality, this seems to be broken, renovate always rebases. So just force-setting it to `conflicted` should help.

The current situation costs us, as renovate rebases after every merge.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Renovate rebases always

**What is the new behavior?**

Renovate rebases on conflict.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
