### PR TITLE
refactor: remove fixed height from header-cell

### DIFF
--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.spec.ts
@@ -20,7 +20,6 @@ describe('DataTableHeaderCellComponent', () => {
     fixture = TestBed.createComponent(DataTableHeaderCellComponent);
     fixture.componentRef.setInput('ariaHeaderCheckboxMessage', 'Select All');
     fixture.componentRef.setInput('sortType', 'single');
-    fixture.componentRef.setInput('headerHeight', '48');
     component = fixture.componentInstance;
     fixture.componentRef.setInput('column', {
       name: 'test',
@@ -100,12 +99,7 @@ describe('DataTableHeaderCellComponent', () => {
 
 @Component({
   imports: [DataTableHeaderCellComponent],
-  template: `<datatable-header-cell
-      sortType="single"
-      headerHeight="50"
-      [column]="column"
-      (sort)="sort($event)"
-    />
+  template: `<datatable-header-cell sortType="single" [column]="column" (sort)="sort($event)" />
     <ng-template #headerCellTemplate let-sort="sortFn" let-column="column">
       <span class="custom-header">Custom Header for {{ column.name }}</span>
       <button class="custom-sort-button" type="button" (click)="sort($event)"

--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -86,7 +86,6 @@ import { nextSortDir } from '../../utils/sort';
     '[attr.title]': 'name()',
     '[attr.tabindex]': 'column().sortable ? 0 : -1',
     '[class]': 'columnCssClasses()',
-    '[style.height]': 'headerHeight() === "auto" ? "auto" : headerHeight() + "px"',
     '[style.minWidth.px]': 'column().minWidth',
     '[style.maxWidth.px]': 'column().maxWidth',
     '[style.width.px]': 'column().width'
@@ -107,7 +106,6 @@ export class DataTableHeaderCellComponent implements OnInit, OnDestroy {
   readonly allRowsSelected = input(false, { transform: booleanAttribute });
   readonly selectionType = input<SelectionType>();
   readonly column = input.required<TableColumnInternal>();
-  readonly headerHeight = input.required<'auto' | number>();
   readonly sorts = input<SortPropDir[]>([]);
 
   readonly sort = output<InnerSortEvent>();

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -64,7 +64,6 @@ import { DataTableHeaderCellComponent } from './header-cell.component';
                 dragStartDelay="500"
                 [datatableDraggable]="reorderable() && column.draggable"
                 [dragModel]="column"
-                [headerHeight]="headerHeight()"
                 [isTarget]="column.isTarget"
                 [targetMarkerTemplate]="targetMarkerTemplate()"
                 [targetMarkerContext]="column.targetMarkerContext"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Before the signal migration, the header-cell height never worked, as we appended the `px` suffix twice. With the signal migration we fixed this.

**What is the new behavior?**

To avoid breaking changes, we just removed the binding in the header-cell again.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No (it reverts one)

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

In future versions, the idea is to not have a JS defined header height at all.