### PR TITLE
build: enforce npm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "ngx-datatable",
   "version": "24.3.3",
+  "engines": {
+    "npm": "11"
+  },
   "commitlint": {
     "extends": [
       "@siemens/commitlint-config/.commitlintrc.js"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

npm version is not enforced.

**What is the new behavior?**

npm 11 is enforced.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

npm sometimes changes the lockfile format. Enforcing a version guarantees, that the lockfile is always in the same format.