### PR TITLE
test: use config object for runVisualAndA11yTests

### DIFF
--- a/playwright/e2e/custom-template.spec.ts
+++ b/playwright/e2e/custom-template.spec.ts
@@ -16,42 +16,51 @@ test.describe('summary row', () => {
       await enableSummaryRow.click();
       await expect(summaryRow).toHaveCount(0);
 
-      await si.runVisualAndA11yTests('no-summary-row', [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'no-summary-row',
+        axeRulesSet: [
+          {
+            id: 'aria-required-children',
+            enabled: false
+          }
+        ]
+      });
 
       enableSummaryRow.click();
       await expect(summaryRow).toHaveCount(1);
 
-      await si.runVisualAndA11yTests('show-summary-row', [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        },
-        {
-          id: 'aria-required-parent',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'show-summary-row',
+        axeRulesSet: [
+          {
+            id: 'aria-required-children',
+            enabled: false
+          },
+          {
+            id: 'aria-required-parent',
+            enabled: false
+          }
+        ]
+      });
 
       const scrollerElement = await page.locator('datatable-scroller').boundingBox();
       let summaryElementBox = await summaryRow.boundingBox();
 
       expect(scrollerElement.y).toBe(summaryElementBox.y);
 
-      await si.runVisualAndA11yTests('summary-row-at-top', [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        },
-        {
-          id: 'aria-required-parent',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'summary-row-at-top',
+        axeRulesSet: [
+          {
+            id: 'aria-required-children',
+            enabled: false
+          },
+          {
+            id: 'aria-required-parent',
+            enabled: false
+          }
+        ]
+      });
 
       await page.getByLabel('Position').selectOption('bottom');
 
@@ -60,12 +69,15 @@ test.describe('summary row', () => {
 
       expect(summaryElementBox.y).toBe(lastElement.y + lastElement.height);
 
-      await si.runVisualAndA11yTests('summary-row-at-bottom', [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'summary-row-at-bottom',
+        axeRulesSet: [
+          {
+            id: 'aria-required-children',
+            enabled: false
+          }
+        ]
+      });
 
       await testSummaryRowData(page);
     });
@@ -82,16 +94,19 @@ test.describe('summary row', () => {
 
       await testSummaryRowData(page);
 
-      await si.runVisualAndA11yTests('custom-template-default', [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        },
-        {
-          id: 'aria-required-parent',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'custom-template-default',
+        axeRulesSet: [
+          {
+            id: 'aria-required-children',
+            enabled: false
+          },
+          {
+            id: 'aria-required-parent',
+            enabled: false
+          }
+        ]
+      });
     });
   });
 
@@ -125,16 +140,19 @@ test.describe('summary row', () => {
       await expect(genderColumn).toContainText(`${maleCells.length} males`);
       await expect(nameColumn).toContainText(`${maleCells.length + femaleCells.length} total`);
 
-      await si.runVisualAndA11yTests('custom-template', [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        },
-        {
-          id: 'aria-required-parent',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'custom-template',
+        axeRulesSet: [
+          {
+            id: 'aria-required-children',
+            enabled: false
+          },
+          {
+            id: 'aria-required-parent',
+            enabled: false
+          }
+        ]
+      });
     });
   });
 
@@ -168,20 +186,23 @@ test.describe('summary row', () => {
         await expect(nameColumn.getByText(name, { exact: true })).toHaveCount(1);
       }
 
-      await si.runVisualAndA11yTests('custom-template-lastname-only', [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        },
-        {
-          id: 'aria-required-parent',
-          enabled: false
-        },
-        {
-          id: 'scrollable-region-focusable',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'custom-template-lastname-only',
+        axeRulesSet: [
+          {
+            id: 'aria-required-children',
+            enabled: false
+          },
+          {
+            id: 'aria-required-parent',
+            enabled: false
+          },
+          {
+            id: 'scrollable-region-focusable',
+            enabled: false
+          }
+        ]
+      });
     });
   });
 });

--- a/playwright/e2e/paging.spec.ts
+++ b/playwright/e2e/paging.spec.ts
@@ -53,39 +53,45 @@ test.describe('paging', () => {
 
       await expect(page.locator('ghost-loader').first()).not.toBeVisible();
 
-      await si.runVisualAndA11yTests('infinite-scroll-initial', [
-        {
-          id: 'label',
-          enabled: false
-        },
-        {
-          id: 'empty-table-header',
-          enabled: false
-        },
-        {
-          id: 'aria-progressbar-name',
-          enabled: false
-        },
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'infinite-scroll-initial',
+        axeRulesSet: [
+          {
+            id: 'label',
+            enabled: false
+          },
+          {
+            id: 'empty-table-header',
+            enabled: false
+          },
+          {
+            id: 'aria-progressbar-name',
+            enabled: false
+          },
+          {
+            id: 'aria-required-children',
+            enabled: false
+          }
+        ]
+      });
 
       await page.getByRole('row', { name: 'Sarah Massey' }).click();
 
       await page.mouse.wheel(0, 1000);
 
-      await si.runVisualAndA11yTests('infinite-scroll-after-scroll', [
-        {
-          id: 'aria-progressbar-name',
-          enabled: false
-        },
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'infinite-scroll-after-scroll',
+        axeRulesSet: [
+          {
+            id: 'aria-progressbar-name',
+            enabled: false
+          },
+          {
+            id: 'aria-required-children',
+            enabled: false
+          }
+        ]
+      });
     });
   });
 
@@ -109,24 +115,27 @@ test.describe('paging', () => {
 
       await page.waitForSelector('span[title="Freda Mason"]');
 
-      await si.runVisualAndA11yTests('virtual-server-side-navigate', [
-        {
-          id: 'label',
-          enabled: false
-        },
-        {
-          id: 'empty-table-header',
-          enabled: false
-        },
-        {
-          id: 'aria-progressbar-name',
-          enabled: false
-        },
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'virtual-server-side-navigate',
+        axeRulesSet: [
+          {
+            id: 'label',
+            enabled: false
+          },
+          {
+            id: 'empty-table-header',
+            enabled: false
+          },
+          {
+            id: 'aria-progressbar-name',
+            enabled: false
+          },
+          {
+            id: 'aria-required-children',
+            enabled: false
+          }
+        ]
+      });
 
       await page.getByRole('row', { name: 'Freda Mason' }).click();
       await page.mouse.wheel(0, 500);

--- a/playwright/e2e/row-disabled.spec.ts
+++ b/playwright/e2e/row-disabled.spec.ts
@@ -6,9 +6,11 @@ test('disabled rows', async ({ si, page }) => {
     .getByRole('row', { name: 'Merritt Booker' })
     .getByRole('button', { name: 'Disable row' })
     .click();
-  await si.runVisualAndA11yTests(undefined, [
-    { id: 'color-contrast', enabled: false },
-    { id: 'label', enabled: false },
-    { id: 'select-name', enabled: false }
-  ]);
+  await si.runVisualAndA11yTests({
+    axeRulesSet: [
+      { id: 'color-contrast', enabled: false },
+      { id: 'label', enabled: false },
+      { id: 'select-name', enabled: false }
+    ]
+  });
 });

--- a/playwright/e2e/row-group.spec.ts
+++ b/playwright/e2e/row-group.spec.ts
@@ -7,25 +7,31 @@ test.describe('row grouping', () => {
     await si.visitExample(example);
 
     await expect(page.getByText('Ethel Price')).toBeVisible();
-    await si.runVisualAndA11yTests('default', [
-      // interactive elements< (<a/>, <input/> etc) within table cells are failing
-      {
-        id: 'aria-required-children',
-        enabled: false
-      }
-    ]);
+    await si.runVisualAndA11yTests({
+      step: 'default',
+      axeRulesSet: [
+        // interactive elements< (<a/>, <input/> etc) within table cells are failing
+        {
+          id: 'aria-required-children',
+          enabled: false
+        }
+      ]
+    });
 
     const groupCheckbox = page.locator('.datatable-group-cell .datatable-checkbox input').first();
     groupCheckbox.check();
 
     await expect(page.getByText('4 selected')).toBeVisible();
 
-    await si.runVisualAndA11yTests('group-selected', [
-      {
-        id: 'aria-required-children',
-        enabled: false
-      }
-    ]);
+    await si.runVisualAndA11yTests({
+      step: 'group-selected',
+      axeRulesSet: [
+        {
+          id: 'aria-required-children',
+          enabled: false
+        }
+      ]
+    });
   });
 
   test(example + ' expand/collapse', async ({ si, page }) => {
@@ -35,19 +41,25 @@ test.describe('row grouping', () => {
     const groupHeader = page.getByTitle('Expand/Collapse Group').first();
     groupHeader.click();
     await expect(page.getByText('Ethel Price')).not.toBeVisible();
-    await si.runVisualAndA11yTests('group-collapsed', [
-      {
-        id: 'aria-required-children',
-        enabled: false
-      }
-    ]);
+    await si.runVisualAndA11yTests({
+      step: 'group-collapsed',
+      axeRulesSet: [
+        {
+          id: 'aria-required-children',
+          enabled: false
+        }
+      ]
+    });
     groupHeader.click();
     await expect(page.getByText('Ethel Price')).toBeVisible();
-    await si.runVisualAndA11yTests('group-expanded', [
-      {
-        id: 'aria-required-children',
-        enabled: false
-      }
-    ]);
+    await si.runVisualAndA11yTests({
+      step: 'group-expanded',
+      axeRulesSet: [
+        {
+          id: 'aria-required-children',
+          enabled: false
+        }
+      ]
+    });
   });
 });

--- a/playwright/e2e/selection.spec.ts
+++ b/playwright/e2e/selection.spec.ts
@@ -172,32 +172,38 @@ test.describe('selection', () => {
       const selectedNamesLi = page.locator('.selected-column').locator('ul > li');
       await expect(selectedNamesLi).toHaveCount(4);
 
-      await si.runVisualAndA11yTests('checkbox-selection-all-checked', [
-        {
-          id: 'label',
-          enabled: false
-        },
-        {
-          id: 'empty-table-header',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'checkbox-selection-all-checked',
+        axeRulesSet: [
+          {
+            id: 'label',
+            enabled: false
+          },
+          {
+            id: 'empty-table-header',
+            enabled: false
+          }
+        ]
+      });
 
       await rowsWithCheckbox[0].uncheck();
       await rowsWithCheckbox[1].uncheck();
 
       await expect(selectedNamesLi).toHaveCount(2);
 
-      await si.runVisualAndA11yTests('checkbox-selection-uncheck', [
-        {
-          id: 'label',
-          enabled: false
-        },
-        {
-          id: 'empty-table-header',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'checkbox-selection-uncheck',
+        axeRulesSet: [
+          {
+            id: 'label',
+            enabled: false
+          },
+          {
+            id: 'empty-table-header',
+            enabled: false
+          }
+        ]
+      });
     });
   });
 
@@ -260,16 +266,19 @@ test.describe('selection', () => {
       const selectedNamesLi = page.locator('.selected-column').locator('ul > li');
       await expect(selectedNamesLi).toHaveCount(3);
 
-      await si.runVisualAndA11yTests('navigation-using-tab-and-space', [
-        {
-          id: 'label',
-          enabled: false
-        },
-        {
-          id: 'empty-table-header',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'navigation-using-tab-and-space',
+        axeRulesSet: [
+          {
+            id: 'label',
+            enabled: false
+          },
+          {
+            id: 'empty-table-header',
+            enabled: false
+          }
+        ]
+      });
 
       await page.keyboard.press('Shift+Tab');
       await page.keyboard.press('Space');
@@ -278,16 +287,19 @@ test.describe('selection', () => {
 
       await expect(selectedNamesLi).toHaveCount(2);
 
-      await si.runVisualAndA11yTests('backward-navigation-shift+tab+space', [
-        {
-          id: 'label',
-          enabled: false
-        },
-        {
-          id: 'empty-table-header',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'backward-navigation-shift+tab+space',
+        axeRulesSet: [
+          {
+            id: 'label',
+            enabled: false
+          },
+          {
+            id: 'empty-table-header',
+            enabled: false
+          }
+        ]
+      });
     });
   });
 });

--- a/playwright/e2e/sorting.spec.ts
+++ b/playwright/e2e/sorting.spec.ts
@@ -122,16 +122,19 @@ test.describe('sorting', () => {
       await expect(companyHeader).toHaveClass(/sort-active/);
       await expect(companyHeader).toHaveClass(/sort-asc/);
 
-      await si.runVisualAndA11yTests('sorting-asc-again', [
-        {
-          id: 'aria-progressbar-name',
-          enabled: false
-        },
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]);
+      await si.runVisualAndA11yTests({
+        step: 'sorting-asc-again',
+        axeRulesSet: [
+          {
+            id: 'aria-progressbar-name',
+            enabled: false
+          },
+          {
+            id: 'aria-required-children',
+            enabled: false
+          }
+        ]
+      });
     });
   });
 

--- a/playwright/support/test-helpers.ts
+++ b/playwright/support/test-helpers.ts
@@ -50,6 +50,12 @@ export type StaticTestOptions = {
   skipAutoScaleViewport?: boolean;
 };
 
+export type VisualAndA11yTestOptions = {
+  step?: string;
+  axeRulesSet?: (string | { id: string; enabled: boolean })[];
+  maxDiffPixels?: number;
+};
+
 class SiTestHelpers {
   private disableAnimationsTag: ElementHandle<Node> | undefined;
 
@@ -77,10 +83,21 @@ class SiTestHelpers {
   }
 
   public async runVisualAndA11yTests(
-    step?: string,
-    axeRulesSet: (string | { id: string; enabled: boolean })[] = [],
-    maxDiffPixels?: number
+    stepOrOptions?: string | VisualAndA11yTestOptions
   ): Promise<void> {
+    // Handle both signatures - string or object
+    let step: string | undefined;
+    let axeRulesSet: (string | { id: string; enabled: boolean })[] = [];
+    let maxDiffPixels: number | undefined;
+
+    if (typeof stepOrOptions === 'string') {
+      step = stepOrOptions;
+    } else if (stepOrOptions) {
+      step = stepOrOptions.step;
+      axeRulesSet = stepOrOptions.axeRulesSet ?? [];
+      maxDiffPixels = stepOrOptions.maxDiffPixels;
+    }
+
     const example = this.getExampleName() ?? this.testInfo.title;
     const testName = this.makeTestName(example, step);
     await test.step(


### PR DESCRIPTION
This prepares runVisualAndA11yTests for more config parameter.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: test

**What is the current behavior?** (You can also link to an open issue here)

`runVisualAndA11yTests` has a parameter list.

**What is the new behavior?**

`runVisualAndA11yTests` allows either the test name as param or a config object.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This prepares `runVisualAndA11yTests` for more config parameter. Also increases readability.