### PR TITLE
test: add aria snapshots

### DIFF
--- a/playwright/e2e/paging.spec.ts
+++ b/playwright/e2e/paging.spec.ts
@@ -10,7 +10,7 @@ test.describe('paging', () => {
       await si.visitExample(example);
       await pagerTest(page, 10);
 
-      await si.runVisualAndA11yTests('default-paginator');
+      await si.runVisualAndA11yTests({ step: 'default-paginator', ariaSnapshot: true });
     });
   });
 

--- a/playwright/snapshots/e2e/paging.spec.ts-snapshots/client-paging--default-paginator.yaml
+++ b/playwright/snapshots/e2e/paging.spec.ts-snapshots/client-paging--default-paginator.yaml
@@ -1,0 +1,72 @@
+- main:
+  - heading "Client-side Paging Source" [level=3]:
+    - text: ""
+    - link "Source":
+      - /url: https://github.com/siemens/ngx-datatable/blob/main/src/app/paging/paging-client.component.ts
+  - table:
+    - rowgroup:
+      - row "Name c Gender c Company c":
+        - columnheader "Name c"
+        - columnheader "Gender c"
+        - columnheader "Company c"
+    - rowgroup:
+      - row "Consuelo Dickson female Poshome":
+        - cell "Consuelo Dickson"
+        - cell "female"
+        - cell "Poshome"
+      - row "Billie Rowe female Cemention":
+        - cell "Billie Rowe"
+        - cell "female"
+        - cell "Cemention"
+      - row "Bean Donovan male Mantro":
+        - cell "Bean Donovan"
+        - cell "male"
+        - cell "Mantro"
+      - row "Lancaster Patel male Krog":
+        - cell "Lancaster Patel"
+        - cell "male"
+        - cell "Krog"
+      - row "Rosa Dyer female Netility":
+        - cell "Rosa Dyer"
+        - cell "female"
+        - cell "Netility"
+      - row "Christine Compton female Bleeko":
+        - cell "Christine Compton"
+        - cell "female"
+        - cell "Bleeko"
+      - row "Milagros Finch female Handshake":
+        - cell "Milagros Finch"
+        - cell "female"
+        - cell "Handshake"
+      - row "Ericka Alvarado female Lyrichord":
+        - cell "Ericka Alvarado"
+        - cell "female"
+        - cell "Lyrichord"
+      - row "Sylvia Sosa female Circum":
+        - cell "Sylvia Sosa"
+        - cell "female"
+        - cell "Circum"
+      - row "Humphrey Curtis male Corepan":
+        - cell "Humphrey Curtis"
+        - cell "male"
+        - cell "Corepan"
+  - text: /\d+ total/
+  - list:
+    - listitem:
+      - button "go to first page"
+    - listitem:
+      - button "go to previous page"
+    - listitem:
+      - button "page 6"
+    - listitem:
+      - button "page 7"
+    - listitem:
+      - button "page 8"
+    - listitem:
+      - button "page 9"
+    - listitem:
+      - button /page \d+/
+    - listitem:
+      - button "go to next page" [disabled]
+    - listitem:
+      - button "go to last page" [disabled]

--- a/playwright/support/test-helpers.ts
+++ b/playwright/support/test-helpers.ts
@@ -54,6 +54,7 @@ export type VisualAndA11yTestOptions = {
   step?: string;
   axeRulesSet?: (string | { id: string; enabled: boolean })[];
   maxDiffPixels?: number;
+  ariaSnapshot?: boolean;
 };
 
 class SiTestHelpers {
@@ -89,6 +90,7 @@ class SiTestHelpers {
     let step: string | undefined;
     let axeRulesSet: (string | { id: string; enabled: boolean })[] = [];
     let maxDiffPixels: number | undefined;
+    let ariaSnapshot = false;
 
     if (typeof stepOrOptions === 'string') {
       step = stepOrOptions;
@@ -96,6 +98,7 @@ class SiTestHelpers {
       step = stepOrOptions.step;
       axeRulesSet = stepOrOptions.axeRulesSet ?? [];
       maxDiffPixels = stepOrOptions.maxDiffPixels;
+      ariaSnapshot = stepOrOptions.ariaSnapshot ?? false;
     }
 
     const example = this.getExampleName() ?? this.testInfo.title;
@@ -152,6 +155,11 @@ class SiTestHelpers {
             maxDiffPixels,
             stylePath: './playwright/support/vrt-styles.css'
           });
+          if (ariaSnapshot) {
+            await expect(this.page.locator('main')).toMatchAriaSnapshot({
+              name: testName + '.yaml'
+            });
+          }
         }
       },
       { box: true }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: test

**What is the current behavior?** (You can also link to an open issue here)

Aria snapshots are not part of the standard VRT helper function.

**What is the new behavior?**

Aria snapshots are part of the standard VRT helper function, but must be explicitly enabled.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Aria snapshots are disabled by default, as many parts of the page would just be duplicated. So for now, they are just enabled for one example.

As an alternative one could also just call the playwright function directly. But I think for consistency it is nicer to have it as part of the helper.
