### PR TITLE
docs: add loading indicator server side paging

### DIFF
--- a/src/app/paging/paging-server.component.ts
+++ b/src/app/paging/paging-server.component.ts
@@ -34,6 +34,7 @@ import { Page } from './model/page';
         [count]="page.totalElements"
         [offset]="page.pageNumber"
         [limit]="page.size"
+        [loadingIndicator]="loading()"
         (page)="setPage($event.offset)"
       />
     </div>
@@ -48,6 +49,7 @@ export class ServerPagingComponent implements OnInit {
     totalPages: 0
   });
   readonly rows = signal<Employee[]>([]);
+  readonly loading = signal(false);
   private serverResultsService = inject(MockServerResultsService);
 
   ngOnInit() {
@@ -60,9 +62,11 @@ export class ServerPagingComponent implements OnInit {
    */
   setPage(page: number) {
     this.page.update(currentPage => ({ ...currentPage, pageNumber: page }));
+    this.loading.set(true);
     this.serverResultsService.getResults(this.page()).subscribe(pagedData => {
       this.page.set(pagedData.page);
       this.rows.set(pagedData.data);
+      this.loading.set(false);
     });
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Server paging demo does not display the datatable loading indicator while waiting for the mock server response.

**What is the new behavior?**

The server paging demo now toggles the datatable loading indicator whenever a page is requested.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: None.