### PR TITLE
feat(summary): add DatatableSummaryRowDirective for custom templates

### DIFF
--- a/playwright/e2e/summary-row.spec.ts
+++ b/playwright/e2e/summary-row.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '../support/test-helpers';
+
+test.describe('summary-row', () => {
+  const example = 'summary-row-actions';
+
+  test('summary row actions are hidden when no rows are selected', async ({ si, page }) => {
+    await si.visitExample(example);
+
+    const summaryRow = page.locator('datatable-summary-row.sticky');
+    await expect(summaryRow).toHaveCount(0);
+  });
+
+  test('summary row appears on checkbox selection', async ({ si, page }) => {
+    await si.visitExample(example);
+
+    const checkbox = page.locator('datatable-body-row input[type=checkbox]').first();
+    await checkbox.check();
+
+    const summaryRow = page.locator('datatable-summary-row.sticky');
+    await expect(summaryRow).toBeVisible();
+    await expect(page.locator('.summary-row-actions-count')).toContainText('1 row(s) selected');
+
+    await si.runVisualAndA11yTests({
+      step: 'summary-row-actions',
+      axeRulesSet: [
+        { id: 'label', enabled: false },
+        { id: 'empty-table-header', enabled: false }
+      ]
+    });
+  });
+});

--- a/playwright/snapshots/e2e/summary-row.spec.ts-snapshots/summary-row-actions--summary-row-actions-chromium-linux.png
+++ b/playwright/snapshots/e2e/summary-row.spec.ts-snapshots/summary-row-actions--summary-row-actions-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a288fd998c5d382390cc872d4fb87b5521624e459b9c353ff11159d5b0a782b0
+size 47102

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -99,12 +99,14 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
         [class.horizontal-overflow]="innerWidth() < (columnGroupWidths?.total ?? 0)"
         (scroll)="onBodyScroll($event)"
       >
-        @if (summaryRow() && summaryPosition() === 'top') {
+        @if ((summaryRow() || summaryRowTemplate()) && summaryPosition() === 'top') {
           <datatable-summary-row
+            [class.sticky]="summaryRowTemplate()"
             [rowHeight]="summaryHeight()"
             [innerWidth]="innerWidth()"
             [rows]="rows"
             [columns]="columns"
+            [template]="summaryRowTemplate()"
           />
         }
         <ng-template
@@ -233,12 +235,13 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
           }
         </div>
       </datatable-scroller>
-      @if (summaryRow() && summaryPosition() === 'bottom') {
+      @if ((summaryRow() || summaryRowTemplate()) && summaryPosition() === 'bottom') {
         <datatable-summary-row
           [rowHeight]="summaryHeight()"
           [innerWidth]="innerWidth()"
           [rows]="rows"
           [columns]="columns"
+          [template]="summaryRowTemplate()"
         />
       }
     }
@@ -291,6 +294,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   readonly summaryRow = input<boolean>();
   readonly summaryPosition = input.required<string>();
   readonly summaryHeight = input.required<number>();
+  readonly summaryRowTemplate = input<TemplateRef<void>>();
   readonly rowDraggable = input<boolean>();
   readonly rowDragEvents = input.required<OutputEmitterRef<DragEventData>>();
   readonly disableRowCheck = input<(row: TRow) => boolean | undefined>();

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.scss
@@ -1,0 +1,7 @@
+:host {
+  &.sticky {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
+}

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
@@ -1,5 +1,5 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { ComponentRef } from '@angular/core';
+import { Component, ComponentRef, TemplateRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TableColumnInternal } from '../../../types/internal.types';
@@ -153,5 +153,41 @@ describe('DataTableSummaryRowComponent', () => {
         expect(col1Text).toBe(transformed);
       });
     });
+  });
+});
+
+@Component({
+  imports: [DataTableSummaryRowComponent],
+  template: `
+    <datatable-summary-row
+      [rows]="rows"
+      [columns]="columns"
+      [rowHeight]="30"
+      [innerWidth]="100"
+      [template]="tpl()"
+    />
+    <ng-template #summaryTpl>
+      <span class="custom-content">Custom summary content</span>
+    </ng-template>
+  `
+})
+class TestHostComponent {
+  rows = [{ col1: 10 }];
+  columns: TableColumnInternal[] = toInternalColumn([{ prop: 'col1' }]);
+  readonly tpl = viewChild<TemplateRef<void>>('summaryTpl');
+}
+
+describe('DataTableSummaryRowComponent with template', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    fixture = TestBed.createComponent(TestHostComponent);
+    await fixture.whenStable();
+  });
+
+  it('should render custom template content instead of computed columns', () => {
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.custom-content')?.textContent).toBe('Custom summary content');
+    expect(el.querySelector('datatable-body-row')).toBeNull();
   });
 });

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
@@ -1,4 +1,5 @@
-import { Component, computed, input } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { Component, computed, input, TemplateRef } from '@angular/core';
 
 import { TableColumnInternal } from '../../../types/internal.types';
 import { DataTableBodyRowComponent } from '../body-row.component';
@@ -22,21 +23,31 @@ const noopSumFunc = (cells: any[]): void => {
 
 @Component({
   selector: 'datatable-summary-row',
-  imports: [DataTableBodyRowComponent],
+  imports: [DataTableBodyRowComponent, NgTemplateOutlet],
   template: `
-    @let summaryRow = this.summaryRow();
-    @let _internalColumns = this._internalColumns();
-    @if (summaryRow && _internalColumns.length) {
-      <datatable-body-row
-        ariaRowCheckboxMessage=""
-        [columns]="_internalColumns"
-        [rowHeight]="rowHeight()"
-        [row]="summaryRow"
-        [rowIndex]="{ index: -1 }"
-        [cssClasses]="{}"
-      />
+    @let template = this.template();
+    @if (template) {
+      <div class="datatable-body-row" role="row" [style.height.px]="rowHeight()">
+        <div class="datatable-body-cell" role="cell">
+          <ng-container [ngTemplateOutlet]="template" />
+        </div>
+      </div>
+    } @else {
+      @let summaryRow = this.summaryRow();
+      @let _internalColumns = this._internalColumns();
+      @if (summaryRow && _internalColumns.length) {
+        <datatable-body-row
+          ariaRowCheckboxMessage=""
+          [columns]="_internalColumns"
+          [rowHeight]="rowHeight()"
+          [row]="summaryRow"
+          [rowIndex]="{ index: -1 }"
+          [cssClasses]="{}"
+        />
+      }
     }
   `,
+  styleUrl: './summary-row.component.scss',
   host: {
     class: 'datatable-summary-row'
   }
@@ -47,6 +58,7 @@ export class DataTableSummaryRowComponent {
 
   readonly rowHeight = input.required<number>();
   readonly innerWidth = input.required<number>();
+  readonly template = input<TemplateRef<void>>();
 
   protected readonly _internalColumns = computed(() => {
     return this.columns().map(col => ({

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.directive.ts
@@ -1,0 +1,27 @@
+import { Directive, inject, TemplateRef } from '@angular/core';
+
+/**
+ * Directive that provides custom content for the summary row.
+ * When applied, the summary row renders the provided template instead of
+ * computing per-column aggregate values, enabling use cases like summary action bars.
+ *
+ * The row is rendered with sticky positioning at the top of the datatable body.
+ *
+ * @example
+ * ```html
+ * <ngx-datatable [rows]="rows" selectionType="checkbox" [(selected)]="selected">
+ *   @if (selected.length) {
+ *     <ng-template ngx-datatable-summary-row>
+ *       <span>{{ selected.length }} selected</span>
+ *       <button (click)="delete()">Delete</button>
+ *     </ng-template>
+ *   }
+ * </ngx-datatable>
+ * ```
+ */
+@Directive({
+  selector: '[ngx-datatable-summary-row]'
+})
+export class DatatableSummaryRowDirective {
+  readonly template = inject(TemplateRef<void>);
+}

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -59,6 +59,7 @@
       [summaryRow]="summaryRow()"
       [summaryHeight]="summaryHeight()"
       [summaryPosition]="summaryPosition()"
+      [summaryRowTemplate]="summaryRowDirective()?.template"
       [verticalScrollVisible]="verticalScrollVisible"
       [ariaRowCheckboxMessage]="messages().ariaRowCheckboxMessage ?? 'Select row'"
       [ariaGroupHeaderCheckboxMessage]="

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -69,6 +69,7 @@ import { DatatableGroupHeaderDirective } from './body/body-group-header.directiv
 import { DatatableRowDefDirective } from './body/body-row-def.component';
 import { DataTableBodyComponent } from './body/body.component';
 import { ProgressBarComponent } from './body/progress-bar.component';
+import { DatatableSummaryRowDirective } from './body/summary/summary-row.directive';
 import { DataTableColumnDirective } from './columns/column.directive';
 import { DataTableFooterComponent } from './footer/footer.component';
 import { DatatableFooterDirective } from './footer/footer.directive';
@@ -541,6 +542,11 @@ export class DatatableComponent<TRow extends Row = any>
    */
   @ContentChild(DatatableGroupHeaderDirective)
   groupHeader?: DatatableGroupHeaderDirective;
+
+  /**
+   * Custom summary row template gathered from the ContentChild
+   */
+  readonly summaryRowDirective = contentChild(DatatableSummaryRowDirective);
 
   /**
    * Footer template gathered from the ContentChild

--- a/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.module.ts
@@ -6,6 +6,7 @@ import {
   DatatableRowDefComponent,
   DatatableRowDefDirective
 } from './components/body/body-row-def.component';
+import { DatatableSummaryRowDirective } from './components/body/summary/summary-row.directive';
 import { DataTableColumnCellDirective } from './components/columns/column-cell.directive';
 import { DataTableColumnGhostCellDirective } from './components/columns/column-ghost-cell.directive';
 import { DataTableColumnHeaderDirective } from './components/columns/column-header.directive';
@@ -37,7 +38,8 @@ import { AllPartial, NgxDatatableConfig, providedNgxDatatableConfig } from './ng
     DatatableGroupHeaderTemplateDirective,
     DisableRowDirective,
     DatatableRowDefComponent,
-    DatatableRowDefDirective
+    DatatableRowDefDirective,
+    DatatableSummaryRowDirective
   ],
   exports: [
     DatatableComponent,
@@ -55,7 +57,8 @@ import { AllPartial, NgxDatatableConfig, providedNgxDatatableConfig } from './ng
     DatatableGroupHeaderTemplateDirective,
     DisableRowDirective,
     DatatableRowDefComponent,
-    DatatableRowDefDirective
+    DatatableRowDefDirective,
+    DatatableSummaryRowDirective
   ]
 })
 export class NgxDatatableModule {

--- a/projects/ngx-datatable/src/public-api.ts
+++ b/projects/ngx-datatable/src/public-api.ts
@@ -18,6 +18,7 @@ export * from './lib/components/columns/tree.directive';
 export * from './lib/components/row-detail/row-detail.directive';
 export * from './lib/components/row-detail/row-detail-template.directive';
 export * from './lib/components/body/body-row-def.component';
+export * from './lib/components/body/summary/summary-row.directive';
 
 // directives
 export * from './lib/directives/disable-row.directive';

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -283,5 +283,10 @@ export const routes: Routes = [
     path: 'inline-html-summary',
     loadComponent: () =>
       import('./summary/inline-html-summary.component').then(c => c.InlineHtmlSummaryComponent)
+  },
+  {
+    path: 'summary-row-actions',
+    loadComponent: () =>
+      import('./summary/summary-row-actions.component').then(c => c.SummaryRowActionsComponent)
   }
 ];

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -227,6 +227,9 @@
           <li>
             <a routerLink="inline-html-summary">Inline HTML Summary</a>
           </li>
+          <li>
+            <a routerLink="summary-row-actions">Summary Row Actions</a>
+          </li>
         </ul>
       </li>
     </ul>

--- a/src/app/summary/summary-row-actions.component.ts
+++ b/src/app/summary/summary-row-actions.component.ts
@@ -1,0 +1,103 @@
+import { Component, inject, signal } from '@angular/core';
+import {
+  DataTableColumnDirective,
+  DatatableComponent,
+  DatatableSummaryRowDirective
+} from '@siemens/ngx-datatable';
+
+import { Employee } from '../data.model';
+import { DataService } from '../data.service';
+
+@Component({
+  selector: 'summary-row-actions-demo',
+  imports: [DatatableComponent, DataTableColumnDirective, DatatableSummaryRowDirective],
+  template: `
+    <div>
+      <h3>
+        Summary Row Actions
+        <small>
+          <a
+            href="https://github.com/siemens/ngx-datatable/blob/main/src/app/summary/summary-row-actions.component.ts"
+            target="_blank"
+          >
+            Source
+          </a>
+        </small>
+      </h3>
+      @let rows = this.rows();
+      <ngx-datatable
+        class="material selection-row"
+        rowHeight="auto"
+        summaryHeight="auto"
+        columnMode="force"
+        selectionType="checkbox"
+        [rows]="rows"
+        [headerHeight]="50"
+        [footerHeight]="50"
+        [limit]="10"
+        [(selected)]="selected"
+      >
+        @if (selected().length) {
+          <ng-template ngx-datatable-summary-row>
+            <div class="summary-row-actions-bar">
+              <span class="summary-row-actions-count">{{ selected().length }} row(s) selected</span>
+              <div class="summary-row-actions-buttons">
+                <button type="button" (click)="onExport()">Export</button>
+                <button type="button" (click)="onDelete()">Delete</button>
+                <button type="button" (click)="onCancel()">Cancel</button>
+              </div>
+            </div>
+          </ng-template>
+        }
+        <ngx-datatable-column
+          [width]="30"
+          [sortable]="false"
+          [canAutoResize]="false"
+          [draggable]="false"
+          [resizeable]="false"
+          [headerCheckboxable]="true"
+          [checkboxable]="true"
+        />
+        <ngx-datatable-column name="Name" />
+        <ngx-datatable-column name="Gender" />
+        <ngx-datatable-column name="Company" />
+      </ngx-datatable>
+    </div>
+  `,
+  styles: `
+    .summary-row-actions-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .summary-row-actions-buttons {
+      display: flex;
+      gap: 8px;
+    }
+  `
+})
+export class SummaryRowActionsComponent {
+  protected readonly rows = signal<Employee[]>([]);
+  protected readonly selected = signal<Employee[]>([]);
+
+  private dataService = inject(DataService);
+
+  constructor() {
+    this.dataService.load('company.json').subscribe(data => this.rows.set(data));
+  }
+
+  protected onExport() {
+    alert(`Exporting ${this.selected().length} row(s)`);
+  }
+
+  protected onDelete() {
+    const names = this.selected().map(r => r.name);
+    this.rows.update(rows => rows.filter(r => !names.includes(r.name)));
+    this.selected.set([]);
+  }
+
+  protected onCancel() {
+    this.selected.set([]);
+  }
+}


### PR DESCRIPTION
Add `DatatableSummaryRowDirective` (`[ngx-datatable-summary-row]`) that allows rendering a bulk actions bar in the summary row position. When rows are selected, users can project action controls (e.g. delete, export) that appear as a sticky row at the top of the datatable body.

The directive reuses the existing summary row infrastructure, extending it with a template input that bypasses per-column computation and renders the provided content directly.

Usage:
```html
<ngx-datatable [rows]="rows" selectionType="checkbox" [(selected)]="selected">
  [@if](https://github.com/if) (selected.length) {
    <ng-template ngx-datatable-summary-row>
      <span>{{ selected.length }} selected</span>
      <button (click)="delete()">Delete</button>
    </ng-template>
  }
</ngx-datatable>
```

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
