### PR TITLE
fix(summary-row): don't show checkbox with summary row

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
@@ -56,6 +56,20 @@ describe('DataTableSummaryRowComponent', () => {
     });
   });
 
+  describe('Checkbox', () => {
+    it('should not render checkbox in summary row even if a column is checkboxable', async () => {
+      const checkboxableColumns = toInternalColumn([
+        { prop: 'col1', checkboxable: true },
+        { prop: 'col2' }
+      ]);
+      componentRef.setInput('columns', checkboxableColumns);
+      componentRef.setInput('rows', rows);
+
+      expect(await harness.hasSummaryRow()).toBe(true);
+      expect(await harness.getCheckboxCount()).toBe(0);
+    });
+  });
+
   describe('Computing', () => {
     beforeEach(() => {
       componentRef.setInput('columns', columns);

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
@@ -51,6 +51,7 @@ export class DataTableSummaryRowComponent {
   protected readonly _internalColumns = computed(() => {
     return this.columns().map(col => ({
       ...col,
+      checkboxable: false,
       cellTemplate: col.summaryTemplate
     }));
   });

--- a/projects/ngx-datatable/src/lib/components/body/summary/testing/summary.harness.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/testing/summary.harness.ts
@@ -5,6 +5,7 @@ export class SummaryHarness extends ComponentHarness {
 
   private summaryRowCells = this.locatorForAll('datatable-body-cell');
   private summaryRow = this.locatorForOptional('datatable-body-row');
+  private checkboxes = this.locatorForAll('input[type="checkbox"]');
 
   async getSummaryRowCellText(index: number): Promise<string> {
     const cells = await this.summaryRowCells();
@@ -14,5 +15,10 @@ export class SummaryHarness extends ComponentHarness {
   async hasSummaryRow(): Promise<boolean> {
     const row = await this.summaryRow();
     return !!row;
+  }
+
+  async getCheckboxCount(): Promise<number> {
+    const checkboxes = await this.checkboxes();
+    return checkboxes.length;
   }
 }


### PR DESCRIPTION
checkboxes are only mean't for rows selection and showing it on summary row make no sense.

currently when enabling `selectionType` with `checkbox` all rows along with summary row as well shows checkbox.
showing checkbox on summary row doesn't make any sense.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
