### PR TITLE
build(renovate): use best practices config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,14 +1,17 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "config:recommended",
+    "config:best-practices",
     "group:allNonMajor",
     ":semanticCommits",
     ":semanticCommitTypeAll(chore)",
     ":prHourlyLimitNone",
-    ":prConcurrentLimitNone"
+    ":prConcurrentLimitNone",
+    ":maintainLockFilesMonthly"
   ],
   addLabels: ["dep-bump"],
+  schedule: ["before 7am on Wednesday"],
+  timezone: "Etc/UTC",
   customManagers: [
     {
       customType: "regex",
@@ -72,12 +75,6 @@
         "axe-html-reporter",
         "mcr.microsoft.com/playwright"
       ]
-    },
-    {
-      description: ["Node LTS gitlab-ci update"],
-      matchPackageNames: ["node"],
-      matchDatasources: ["docker"],
-      enabled: true
     }
   ]
 }


### PR DESCRIPTION
This PR syncs the renovate configuration and schedule used in siemens/element. For detailed information refer to https://github.com/siemens/element/pull/1818.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Renovate uses `config:recommended`

**What is the new behavior?**

Renovate uses `config:best-practices`

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The `Node LTS gitlab-ci update` is obsolete and no longer needed (see https://github.com/siemens/element/pull/1054).
