### PR TITLE
Replace IterableDiffer with KeyValueDiffer

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -14,8 +14,8 @@ import {
   HostListener,
   inject,
   input,
-  IterableDiffer,
-  IterableDiffers,
+  KeyValueDiffer,
+  KeyValueDiffers,
   linkedSignal,
   model,
   numberAttribute,
@@ -575,7 +575,7 @@ export class DatatableComponent<TRow extends Row = any>
     return 0;
   });
   readonly rowCount = computed(() => this.calcRowCount());
-  rowDiffer: IterableDiffer<TRow | undefined> = inject(IterableDiffers).find([]).create();
+  rowDiffer: KeyValueDiffer<TRow, TRow> = inject(KeyValueDiffers).find([]).create();
   /** This counter is increased, when the rowDiffer detects a change. This will cause an update of _internalRows. */
   private readonly _rowDiffCount = signal(0);
 
@@ -685,7 +685,7 @@ export class DatatableComponent<TRow extends Row = any>
    * Lifecycle hook that is called when Angular dirty checks a directive.
    */
   ngDoCheck(): void {
-    const rowDiffers = this.rowDiffer.diff(this.rows());
+    const rowDiffers = this.rowDiffer.diff(this.rows() as any);
     if (rowDiffers || this.disableRowCheck()) {
       this._rowDiffCount.update(count => count + 1);
       if (rowDiffers) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

this is a fix from swimlane repo that i needed in this fork (siemens), my app crash after changing from swimlane to siemens due to lack of this fix.

https://github.com/swimlane/ngx-datatable/pull/2240

thanks to [steveblue](https://github.com/steveblue) @steveblue

