### PR TITLE
refactor: change API of `scrollToRow` to accept options object

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
@@ -14,7 +14,7 @@ import {
   signal
 } from '@angular/core';
 
-import { Row, RowDetailContext, RowOrGroup } from '../../types/public.types';
+import { Row, RowDetailContext, RowOrGroup, ScrollToRowOptions } from '../../types/public.types';
 import { DatatableRowDetailDirective } from '../row-detail/row-detail.directive';
 
 @Component({
@@ -75,8 +75,11 @@ export class DataTableRowWrapperComponent<TRow extends Row = any> implements DoC
     }
   }
 
-  scrollIntoView(behavior?: ScrollBehavior): void {
-    this.elementRef.nativeElement.scrollIntoView({ behavior, block: 'start' });
+  scrollIntoView(options?: ScrollToRowOptions): void {
+    this.elementRef.nativeElement.scrollIntoView({
+      behavior: options?.behavior,
+      block: options?.block ?? 'start'
+    });
   }
 
   @HostListener('contextmenu', ['$event'])

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -35,6 +35,7 @@ import {
   Row,
   RowOrGroup,
   ScrollEvent,
+  ScrollToRowOptions,
   SelectionType
 } from '../../types/public.types';
 import { TableColumn } from '../../types/table-column.type';
@@ -562,11 +563,11 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     return rows;
   }
 
-  scrollToIndex(index: number, behavior?: ScrollBehavior): void {
+  scrollToIndex(index: number, options?: ScrollToRowOptions): void {
     if (this.virtualization()) {
-      this.scroller.scrollTo(this.rowHeightsCache().query(index - 1), behavior);
+      this.scroller.scrollTo(this.rowHeightsCache().query(index - 1), options);
     } else {
-      this.rowWrappers()[index]?.scrollIntoView(behavior);
+      this.rowWrappers()[index]?.scrollIntoView(options);
     }
   }
 

--- a/projects/ngx-datatable/src/lib/components/body/client-side-scrolling.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/client-side-scrolling.spec.ts
@@ -69,7 +69,7 @@ describe('Client-side Scrolling – DatatableComponent.scrollToRow', () => {
 
     it('should use instant behavior when specified', () => {
       const scrollToSpy = vi.spyOn(bodyEl, 'scrollTo');
-      datatable.scrollToRow(rowsSig()[9], 'instant');
+      datatable.scrollToRow(rowsSig()[9], { behavior: 'instant' });
       expect(scrollToSpy).toHaveBeenCalledWith({ top: expectedOffset(9), behavior: 'instant' });
     });
   });
@@ -98,7 +98,7 @@ describe('Client-side Scrolling – DatatableComponent.scrollToRow', () => {
     it('should use smooth behavior when specified', () => {
       const rowWrappers = bodyEl.querySelectorAll('datatable-row-wrapper');
       const scrollIntoViewSpy = vi.spyOn(rowWrappers[9], 'scrollIntoView');
-      datatable.scrollToRow(rowsSig()[9], 'smooth');
+      datatable.scrollToRow(rowsSig()[9], { behavior: 'smooth' });
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
     });
   });

--- a/projects/ngx-datatable/src/lib/components/body/scroller.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/scroller.component.ts
@@ -11,6 +11,8 @@ import {
   output
 } from '@angular/core';
 
+import { ScrollToRowOptions } from '../../types/public.types';
+
 export interface ScrollEventInternal {
   direction: string;
   scrollYPos: number;
@@ -73,9 +75,9 @@ export class ScrollerComponent implements OnInit, OnDestroy {
     }
   }
 
-  scrollTo(top: number, behavior?: ScrollBehavior): void {
+  scrollTo(top: number, options?: ScrollToRowOptions): void {
     if (this.parentElement) {
-      this.parentElement.scrollTo({ top, behavior });
+      this.parentElement.scrollTo({ top, behavior: options?.behavior });
     }
   }
 

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -49,6 +49,7 @@ import {
   Row,
   RowOrGroup,
   ScrollEvent,
+  ScrollToRowOptions,
   SelectEvent,
   SelectionType,
   SortEvent,
@@ -1132,7 +1133,7 @@ export class DatatableComponent<TRow extends Row = any>
     this._subscriptions.forEach(subscription => subscription.unsubscribe());
   }
 
-  scrollToRow(row: TRow, behavior?: ScrollBehavior): void {
+  scrollToRow(row: TRow, options?: ScrollToRowOptions): void {
     if (!this.scrollbarV()) {
       throw new Error('Vertical scrolling is not enabled.');
     }
@@ -1157,6 +1158,6 @@ export class DatatableComponent<TRow extends Row = any>
 
     // Here we have ensured, that we have only one page and the row exists.
     // Now we just need to scroll to that row.
-    this._bodyComponent().scrollToIndex(index, behavior);
+    this._bodyComponent().scrollToIndex(index, options);
   }
 }

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -258,6 +258,11 @@ export interface ContextMenuEvenHeader {
 
 export type ContextMenuEvent<TRow> = ContextMenuEventBody<TRow> | ContextMenuEvenHeader;
 
+export interface ScrollToRowOptions {
+  behavior?: ScrollBehavior;
+  block?: Extract<ScrollLogicalPosition, 'start'>;
+}
+
 export type DragEventType =
   | 'drag'
   | 'dragend'

--- a/src/app/basic/virtual.component.ts
+++ b/src/app/basic/virtual.component.ts
@@ -101,7 +101,7 @@ export class VirtualScrollComponent {
   protected scroll(): void {
     const row = this.rows()[this.scrollTarget()];
     if (row) {
-      this.datatable().scrollToRow(row, 'smooth');
+      this.datatable().scrollToRow(row, { behavior: 'smooth' });
     }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`scrollToRow` only accepts a behavior option.

**What is the new behavior?**

`scrollToRow` accepts on object of options. Still does only really support a behavior, but support for `block` will be added.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No, (`scrollToRow` was never released)

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This is a preparation, to allow block targets other than `start`. We may also use this object later to support more options.