### PR TITLE
docs: close unclosed code block in sort output JSDoc comment

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -460,6 +460,7 @@ export class DatatableComponent<TRow extends Row = any>
    * <ngx-datatable [sorts]="mySorts" (sortsChange)="onSort({sorts: $event})"></ngx-datatable>
    * <!-- or -->
    * <ngx-datatable [(sorts)]="mySorts"></ngx-datatable>
+   * ```
    */
   readonly sort = output<SortEvent>();
 


### PR DESCRIPTION
The code block example in the sort output property's JSDoc comment was not properly closed with backticks, which could cause documentation rendering issues. Added closing (```) to properly terminate the code block example.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
