### PR TITLE
feat: support skipping deep change detection for rows

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
@@ -50,6 +50,7 @@ export class DataTableRowWrapperComponent<TRow extends Row = any> implements DoC
 
   readonly expanded = input(false, { transform: booleanAttribute });
   readonly ariaGroupHeaderCheckboxMessage = input.required<string>();
+  readonly checkRowPropertyChanges = input(true, { transform: booleanAttribute });
 
   readonly detailsRowHeight = computed(() => this.detailRowHeightFn()(this.row(), this.rowIndex()));
   readonly context = computed<RowDetailContext<TRow>>(() => {
@@ -69,6 +70,9 @@ export class DataTableRowWrapperComponent<TRow extends Row = any> implements DoC
   private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
   ngDoCheck(): void {
+    if (!this.checkRowPropertyChanges()) {
+      return;
+    }
     const row = this.row();
     if (this.rowDiffer.diff(row)) {
       this.rowDiffedCount.update(count => count + 1);

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -10,6 +10,7 @@ import {
   KeyValueDiffer,
   KeyValueDiffers,
   input,
+  booleanAttribute,
   computed,
   output
 } from '@angular/core';
@@ -88,6 +89,7 @@ export class DataTableBodyRowComponent<TRow extends Row = any> implements DoChec
 
   readonly disabled = input<boolean>();
   readonly cssClasses = input.required<Partial<Required<NgxDatatableConfig>['cssClasses']>>();
+  readonly checkRowPropertyChanges = input(true, { transform: booleanAttribute });
 
   protected readonly cssClass = computed(() => {
     const rowClass = this.rowClass();
@@ -118,6 +120,9 @@ export class DataTableBodyRowComponent<TRow extends Row = any> implements DoChec
     .create();
 
   ngDoCheck(): void {
+    if (!this.checkRowPropertyChanges()) {
+      return;
+    }
     if (this._rowDiffer.diff(this.row())) {
       this.cd.markForCheck();
     }

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -130,6 +130,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
             [expanded]="getRowExpanded(row)"
             [rowIndex]="indexes().first + index"
             [ariaGroupHeaderCheckboxMessage]="ariaGroupHeaderCheckboxMessage()"
+            [checkRowPropertyChanges]="checkRowPropertyChanges()"
             (rowContextmenu)="rowContextmenu.emit($event)"
           >
             <datatable-body-row
@@ -148,6 +149,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
               [draggable]="rowDraggable()"
               [ariaRowCheckboxMessage]="ariaRowCheckboxMessage()"
               [cssClasses]="cssClasses()"
+              [checkRowPropertyChanges]="checkRowPropertyChanges()"
               (treeAction)="onTreeAction(row)"
               (activate)="onActivate($event, index)"
               (drop)="drop($event, row, rowElement)"
@@ -293,6 +295,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   readonly rowDragEvents = input.required<OutputEmitterRef<DragEventData>>();
   readonly disableRowCheck = input<(row: TRow) => boolean | undefined>();
   readonly ariaGroupHeaderCheckboxMessage = input.required<string>();
+  readonly checkRowPropertyChanges = input(true, { transform: booleanAttribute });
 
   readonly pageSize = input.required<number>();
 

--- a/projects/ngx-datatable/src/lib/components/changedetection.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/changedetection.spec.ts
@@ -1,0 +1,108 @@
+import { ChangeDetectorRef, inputBinding, signal, WritableSignal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { TableColumn } from '../types/table-column.type';
+import { DataTableBodyCellComponent } from './body/body-cell.component';
+import { DataTableBodyRowComponent } from './body/body-row.component';
+import { DatatableComponent } from './datatable.component';
+
+interface TestRow {
+  name: string;
+}
+
+describe('DatatableComponent change-detection inputs', () => {
+  let fixture: ComponentFixture<DatatableComponent<TestRow>>;
+  let rowsSig: WritableSignal<TestRow[]>;
+  let checkRowListChanges: WritableSignal<boolean>;
+  let checkRowPropertyChanges: WritableSignal<boolean>;
+
+  const renderedRowCount = () =>
+    fixture.debugElement.queryAll(By.directive(DataTableBodyRowComponent)).length;
+
+  const cellText = (rowIndex: number, columnIndex: number) => {
+    const bodyRow = fixture.debugElement.queryAll(By.directive(DataTableBodyRowComponent))[
+      rowIndex
+    ];
+    const bodyCell = bodyRow.queryAll(By.directive(DataTableBodyCellComponent))[columnIndex];
+    return (bodyCell.nativeElement as HTMLElement).textContent?.trim();
+  };
+
+  beforeEach(async () => {
+    const columnsSig = signal<TableColumn[]>([{ name: 'Name', prop: 'name' }]);
+    rowsSig = signal<TestRow[]>([{ name: 'Ada' }, { name: 'Grace' }]);
+    checkRowListChanges = signal(true);
+    checkRowPropertyChanges = signal(true);
+
+    fixture = TestBed.createComponent(DatatableComponent<TestRow>, {
+      bindings: [
+        inputBinding('columns', columnsSig),
+        inputBinding('rows', rowsSig),
+        inputBinding('checkRowListChanges', checkRowListChanges),
+        inputBinding('checkRowPropertyChanges', checkRowPropertyChanges)
+      ]
+    });
+    await fixture.whenStable();
+  });
+
+  describe('checkRowListChanges', () => {
+    it('renders rows appended in place when enabled (default)', async () => {
+      expect(renderedRowCount()).toBe(2);
+
+      // Mutate the rows array in place – same reference, new item appended.
+      rowsSig().push({ name: 'Hedy' });
+      // The in-place push leaves all signal references untouched, so
+      // nothing dirties the OnPush datatable on its own. Marking it
+      // dirty manually triggers its `ngDoCheck`, which is what runs the
+      // IterableDiffer.
+      fixture.componentRef.injector.get(ChangeDetectorRef).markForCheck();
+      await fixture.whenStable();
+
+      expect(renderedRowCount()).toBe(3);
+    });
+
+    it('does not render rows appended in place when disabled', async () => {
+      checkRowListChanges.set(false);
+      await fixture.whenStable();
+      expect(renderedRowCount()).toBe(2);
+
+      rowsSig().push({ name: 'Hedy' });
+      fixture.componentRef.injector.get(ChangeDetectorRef).markForCheck();
+      await fixture.whenStable();
+
+      // Row count stays at 2: the IterableDiffer is never consulted, so
+      // the in-place push is invisible to the table.
+      expect(renderedRowCount()).toBe(2);
+    });
+  });
+
+  describe('checkRowPropertyChanges', () => {
+    it('renders property mutations on an existing row when enabled (default)', async () => {
+      expect(cellText(0, 0)).toBe('Ada');
+
+      // Mutate a property on the existing row object – same reference.
+      rowsSig()[0].name = 'Ada Lovelace';
+      // Re-emit the rows signal with a new array reference so the table's
+      // body-row is visited during CD; the per-row KeyValueDiffer then
+      // detects the in-place property change and marks the row for update.
+      rowsSig.set(rowsSig().slice());
+      await fixture.whenStable();
+
+      expect(cellText(0, 0)).toBe('Ada Lovelace');
+    });
+
+    it('does not render property mutations on an existing row when disabled', async () => {
+      checkRowPropertyChanges.set(false);
+      await fixture.whenStable();
+      expect(cellText(0, 0)).toBe('Ada');
+
+      rowsSig()[0].name = 'Ada Lovelace';
+      rowsSig.set(rowsSig().slice());
+      await fixture.whenStable();
+
+      // Old cell text is still rendered: the per-row KeyValueDiffer is
+      // never consulted, so the in-place mutation is invisible.
+      expect(cellText(0, 0)).toBe('Ada');
+    });
+  });
+});

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -65,6 +65,7 @@
         messages().ariaGroupHeaderCheckboxMessage ?? 'Select row group'
       "
       [disableRowCheck]="disableRowCheck()"
+      [checkRowPropertyChanges]="checkRowPropertyChanges()"
       [rowDraggable]="rowDraggable()"
       [rowDragEvents]="rowDragEvents"
       [rowDefTemplate]="_rowDefTemplate()"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -420,6 +420,26 @@ export class DatatableComponent<TRow extends Row = any>
   readonly enableClearingSortState = input(false, { transform: booleanAttribute });
 
   /**
+   * Controls whether the datatable runs an {@link IterableDiffer} against the
+   * `rows` input on every change detection cycle to detect additions, removals
+   * and reorderings that happen in-place on the same array reference.
+   *
+   * Enabled by default. Set to `false` as a performance optimization when you
+   * always pass a new `rows` array reference on updates.
+   */
+  readonly checkRowListChanges = input(true, { transform: booleanAttribute });
+
+  /**
+   * Controls whether each rendered row runs a {@link KeyValueDiffer} against
+   * its row object on every change detection cycle to detect in-place property
+   * mutations (e.g. `row.name = 'new'` without replacing the row reference).
+   *
+   * Enabled by default. Set to `false` as a performance optimization when row
+   * objects are treated as immutable.
+   */
+  readonly checkRowPropertyChanges = input(true, { transform: booleanAttribute });
+
+  /**
    * Body was scrolled typically in a `scrollbarV:true` scenario.
    */
   readonly scroll = output<ScrollEvent>();
@@ -687,7 +707,7 @@ export class DatatableComponent<TRow extends Row = any>
    * Lifecycle hook that is called when Angular dirty checks a directive.
    */
   ngDoCheck(): void {
-    const rowDiffers = this.rowDiffer.diff(this.rows());
+    const rowDiffers = this.checkRowListChanges() ? this.rowDiffer.diff(this.rows()) : null;
     if (rowDiffers || this.disableRowCheck()) {
       this._rowDiffCount.update(count => count + 1);
       if (rowDiffers) {
@@ -930,7 +950,7 @@ export class DatatableComponent<TRow extends Row = any>
     }
 
     // otherwise use row length
-    return this.rows()?.length ?? 0;
+    return this._internalRows().length;
   }
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Deep change checking on rows can not be disabled.

**What is the new behavior?**

Deep change checking on rows can be disabled.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

1. The idea is to switch the default with the next major to `false`.
2. This commit also contains a hidden fix the properly recalculate pages if a row was added without creating a new array (but no extra commit as irrelevant).