### PR TITLE
test: use 0 loading to solve flaky e2e tests

### DIFF
--- a/playwright/e2e/sorting.spec.ts
+++ b/playwright/e2e/sorting.spec.ts
@@ -94,7 +94,6 @@ test.describe('sorting', () => {
 
       await expect(companyHeader).toHaveClass(/sort-active/);
       await expect(companyHeader).toHaveClass(/sort-asc/);
-      await expect(loadingIndicator).toBeVisible();
 
       await expect(loadingIndicator).toHaveCount(0);
 
@@ -106,8 +105,6 @@ test.describe('sorting', () => {
 
       await expect(companyHeader).toHaveClass(/sort-active/);
       await expect(companyHeader).toHaveClass(/sort-desc/);
-
-      await expect(loadingIndicator).toBeVisible();
 
       await expect(loadingIndicator).toHaveCount(0);
 

--- a/src/app/paging/scrolling-server.component.ts
+++ b/src/app/paging/scrolling-server.component.ts
@@ -19,7 +19,7 @@ interface PagedData<T> {
 export class MockServerResultsService {
   public getResults(offset: number, limit: number): Observable<PagedData<Employee>> {
     return of(companyData.slice(offset, offset + limit)).pipe(
-      delay(new Date(Date.now() + 1500)),
+      delay(window.navigator.webdriver ? 0 : 1500),
       map(d => ({ data: d }))
     );
   }

--- a/src/app/sorting/sorting-server.component.ts
+++ b/src/app/sorting/sorting-server.component.ts
@@ -56,21 +56,24 @@ export class ServerSortingComponent {
     // event was triggered, start sort sequence
     this.loading.set(true);
     // emulate a server request with a timeout
-    setTimeout(() => {
-      const rows = [...this.rows()];
-      // this is only for demo purposes, normally
-      // your server would return the result for
-      // you and you would just set the rows prop
-      const sort = event[0];
-      type SortProp = 'company' | 'name' | 'gender';
-      rows.sort(
-        (a, b) =>
-          a[sort.prop as SortProp].localeCompare(b[sort.prop as SortProp]) *
-          (sort.dir === 'desc' ? -1 : 1)
-      );
+    setTimeout(
+      () => {
+        const rows = [...this.rows()];
+        // this is only for demo purposes, normally
+        // your server would return the result for
+        // you and you would just set the rows prop
+        const sort = event[0];
+        type SortProp = 'company' | 'name' | 'gender';
+        rows.sort(
+          (a, b) =>
+            a[sort.prop as SortProp].localeCompare(b[sort.prop as SortProp]) *
+            (sort.dir === 'desc' ? -1 : 1)
+        );
 
-      this.rows.set(rows);
-      this.loading.set(false);
-    }, 1000);
+        this.rows.set(rows);
+        this.loading.set(false);
+      },
+      window.navigator.webdriver ? 0 : 1000
+    );
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Flaky E2E tests due to simulated loading time.

**What is the new behavior?**

No flaky e2e as simulated loading time is `0` for e2e.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
