### PR TITLE
fix: compute correct level when child precedes parent in tree rows

### DIFF
--- a/projects/ngx-datatable/src/lib/utils/tree.spec.ts
+++ b/projects/ngx-datatable/src/lib/utils/tree.spec.ts
@@ -1,0 +1,130 @@
+import { groupRowsByParents, optionalGetterForProp } from './tree';
+
+interface TreeRow {
+  id: number;
+  parentId: number;
+  level?: number;
+  treeStatus?: 'expanded' | 'collapsed' | 'disabled' | 'loading';
+}
+
+const fromGetter = optionalGetterForProp('parentId');
+const toGetter = optionalGetterForProp('id');
+
+const expanded = (row: Partial<TreeRow>): TreeRow =>
+  ({ treeStatus: 'expanded', ...row }) as TreeRow;
+
+describe('groupRowsByParents', () => {
+  it('should compute level=0 for root rows and level=1 for direct children when parent precedes child', () => {
+    const rows: TreeRow[] = [expanded({ id: 1, parentId: 0 }), expanded({ id: 2, parentId: 1 })];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result.map(r => r.id)).toEqual([1, 2]);
+    expect(result[0].level).toBe(0);
+    expect(result[1].level).toBe(1);
+  });
+
+  it('should compute correct level when a child appears before its parent in the input array', () => {
+    // Regression: previously produced level = NaN for the child.
+    const rows: TreeRow[] = [expanded({ id: 2, parentId: 1 }), expanded({ id: 1, parentId: 0 })];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    for (const row of result) {
+      expect(Number.isNaN(row.level)).toBe(false);
+      expect(typeof row.level).toBe('number');
+    }
+
+    const byId = new Map(result.map(r => [r.id, r]));
+    expect(byId.get(1)!.level).toBe(0);
+    expect(byId.get(2)!.level).toBe(1);
+  });
+
+  it('should compute correct levels for arbitrarily ordered deep trees', () => {
+    // Tree:
+    //   1
+    //   ├── 3
+    //   │   └── 6
+    //   └── 4
+    //   2
+    //   └── 5
+    const rows: TreeRow[] = [
+      expanded({ id: 6, parentId: 3 }),
+      expanded({ id: 5, parentId: 2 }),
+      expanded({ id: 3, parentId: 1 }),
+      expanded({ id: 4, parentId: 1 }),
+      expanded({ id: 1, parentId: 0 }),
+      expanded({ id: 2, parentId: 0 })
+    ];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    const byId = new Map(result.map(r => [r.id, r]));
+    expect(byId.get(1)!.level).toBe(0);
+    expect(byId.get(2)!.level).toBe(0);
+    expect(byId.get(3)!.level).toBe(1);
+    expect(byId.get(4)!.level).toBe(1);
+    expect(byId.get(5)!.level).toBe(1);
+    expect(byId.get(6)!.level).toBe(2);
+
+    for (const row of result) {
+      expect(Number.isNaN(row.level)).toBe(false);
+    }
+  });
+
+  it('should treat orphans (parent not in list) as root rows with level=0', () => {
+    const rows: TreeRow[] = [
+      expanded({ id: 7, parentId: 8 }) // parent 8 does not exist
+    ];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result).toHaveLength(1);
+    expect(result[0].level).toBe(0);
+  });
+
+  it('should not loop forever on cyclic relationships and should assign finite numeric levels', () => {
+    const rows: TreeRow[] = [expanded({ id: 1, parentId: 2 }), expanded({ id: 2, parentId: 1 })];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result).toHaveLength(rows.length);
+    for (const row of result) {
+      expect(Number.isFinite(row.level!)).toBe(true);
+      expect(Number.isNaN(row.level)).toBe(false);
+    }
+  });
+
+  it('should return rows unchanged when no from/to getters are provided', () => {
+    const rows: TreeRow[] = [expanded({ id: 2, parentId: 1 }), expanded({ id: 1, parentId: 0 })];
+
+    const result = groupRowsByParents(rows);
+    expect(result).toBe(rows);
+  });
+
+  it('should not include children of collapsed parents in the flattened output', () => {
+    const rows: TreeRow[] = [
+      { id: 1, parentId: 0, treeStatus: 'collapsed' },
+      { id: 2, parentId: 1, treeStatus: 'expanded' }
+    ];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result.map(r => r.id)).toEqual([1]);
+    // Level should still be assigned correctly even if not rendered.
+    expect(rows[1].level).toBe(1);
+  });
+
+  it('should preserve input-order sibling ordering when a grandchild appears before a sibling', () => {
+    const rows: TreeRow[] = [
+      expanded({ id: 1, parentId: 0 }),
+      expanded({ id: 4, parentId: 1 }),
+      expanded({ id: 3, parentId: 2 }),
+      expanded({ id: 2, parentId: 1 })
+    ];
+
+    const result = groupRowsByParents(rows, fromGetter, toGetter) as TreeRow[];
+
+    expect(result.map(r => r.id)).toEqual([1, 4, 2, 3]);
+  });
+});

--- a/projects/ngx-datatable/src/lib/utils/tree.ts
+++ b/projects/ngx-datatable/src/lib/utils/tree.ts
@@ -13,7 +13,7 @@ export const optionalGetterForProp = (prop: TableColumnProp | undefined): Option
  *
  * Note: Expecting each item has a property called parentId
  * Note: This algorithm will fail if a list has two or more items with same ID
- * NOTE: This algorithm will fail if there is a deadlock of relationship
+ * Note: Cyclic relationships are broken by treating one node in the cycle as a root
  *
  * For example,
  *
@@ -52,19 +52,48 @@ export const groupRowsByParents = <TRow extends Row>(
     const treeRows = rows.filter(row => !!row).map(row => new TreeNode(row));
     const uniqIDs = new Map(treeRows.map(node => [to(node.row), node]));
 
-    const rootNodes = treeRows.reduce((root, node) => {
-      const fromValue = from(node.row);
-      const parent = uniqIDs.get(fromValue);
-      if (parent) {
-        node.row.level = parent.row.level! + 1; // TODO: should be reflected by type, that level is defined
-        node.parent = parent;
-        parent.children.push(node);
+    const resolved = new Set<TreeNode<TRow>>();
+    const resolveLevel = (node: TreeNode<TRow>, visited: Set<TreeNode<TRow>>): number => {
+      if (resolved.has(node)) {
+        return node.row.level!;
+      }
+      if (visited.has(node)) {
+        return Infinity;
+      }
+      visited.add(node);
+
+      const parent = uniqIDs.get(from(node.row));
+      if (parent && parent !== node) {
+        const parentLevel = resolveLevel(parent, visited);
+        if (parentLevel !== Infinity) {
+          node.row.level = parentLevel + 1;
+        } else {
+          node.row.level = 0;
+        }
       } else {
         node.row.level = 0;
-        root.push(node);
       }
-      return root;
-    }, [] as TreeNode<TRow>[]);
+
+      visited.delete(node);
+      resolved.add(node);
+      return node.row.level;
+    };
+
+    for (const node of treeRows) {
+      if (!resolved.has(node)) {
+        resolveLevel(node, new Set());
+      }
+    }
+
+    for (const node of treeRows) {
+      const parent = uniqIDs.get(from(node.row));
+      if (parent && parent !== node && node.row.level! > 0) {
+        node.parent = parent;
+        parent.children.push(node);
+      }
+    }
+
+    const rootNodes = treeRows.filter(n => !n.parent);
 
     return rootNodes.flatMap(child => child.flatten());
   } else {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

`groupRowsByParents` (`projects/ngx-datatable/src/lib/utils/tree.ts`) assigns `level = parent.level + 1` in a single forward pass. If a child precedes its parent in the input array, `parent.level` is `undefined`, the child gets `NaN`, and the cell template renders `margin-left: NaNpx` — affected rows have no tree indent.

**What is the new behavior?**

Levels are resolved on first touch with memoized recursion, so order in the input array no longer matters. The algorithm stays O(n); cycles are broken via a per-recursion `visited` set. Root order, child order, orphan and self-reference handling are preserved.

Added `tree.spec.ts` with unit tests covering ordered/unordered/deep trees, orphans, cycles, pass-through, and collapsed parents.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

**Other information**: