### PR TITLE
fix: keep prior selection when shift-clicking after ctrl-click

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -248,4 +248,55 @@ describe('DataTableBodyComponent', () => {
       expect(component.getGroupExpanded(group)).toBe(true);
     });
   });
+
+  describe('selectRow', () => {
+    const rows = [
+      { id: 1, name: 'Ethel' },
+      { id: 2, name: 'Claudine' },
+      { id: 3, name: 'Beryl' },
+      { id: 4, name: 'Wilder' },
+      { id: 5, name: 'Georgina' }
+    ];
+
+    beforeEach(() => {
+      fixture.componentRef.setInput('rows', rows);
+      fixture.componentRef.setInput('rowCount', rows.length);
+      fixture.componentRef.setInput('pageSize', rows.length);
+      fixture.componentRef.setInput('offset', 0);
+      fixture.componentRef.setInput('selectionType', 'multi');
+      fixture.componentRef.setInput('selected', []);
+    });
+
+    it('should keep prior ctrl-selected rows when shift-clicking a range', () => {
+      // Regression for https://github.com/siemens/ngx-datatable/issues/582
+      // 1. Click Georgina (idx 4)
+      component.selectRow(new MouseEvent('click'), 4, rows[4]);
+      expect(component.selected()).toEqual([rows[4]]);
+
+      // 2. Ctrl-click Beryl (idx 2) - extends selection, becomes new anchor
+      component.selectRow(new MouseEvent('click', { ctrlKey: true }), 2, rows[2]);
+      expect(component.selected()).toEqual([rows[4], rows[2]]);
+
+      // 3. Shift-click Ethel (idx 0) - range from last anchor (Beryl, idx 2) to Ethel (idx 0)
+      component.selectRow(new MouseEvent('click', { shiftKey: true }), 0, rows[0]);
+
+      const selected = component.selected();
+      // Georgina must still be selected (the bug)
+      expect(selected).toContain(rows[4]);
+      // Range Beryl..Ethel must be selected
+      expect(selected).toContain(rows[2]);
+      expect(selected).toContain(rows[1]);
+      expect(selected).toContain(rows[0]);
+      // No duplicates (Beryl was already selected before shift-click)
+      expect(selected.length).toBe(new Set(selected).size);
+    });
+
+    it('should not throw when shift is the very first click', () => {
+      expect(() =>
+        component.selectRow(new MouseEvent('click', { shiftKey: true }), 2, rows[2])
+      ).not.toThrow();
+      // First-ever shift-click without a prior anchor selects just the clicked row.
+      expect(component.selected()).toEqual([rows[2]]);
+    });
+  });
 });

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -866,8 +866,14 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
 
     // TODO: this code needs cleanup. Casting it to KeyboardEvent is not correct as it could also be other types.
     if (multi || chkbox || multiClick) {
-      if ((event as KeyboardEvent).shiftKey) {
-        selected = selectRowsBetween([], this.rows(), index, this.prevIndex!);
+      if ((event as KeyboardEvent).shiftKey && this.prevIndex !== undefined) {
+        const rangeSelection = selectRowsBetween(this.rows(), index, this.prevIndex);
+        selected = [...this.selected()];
+        for (const rangeRow of rangeSelection) {
+          if (this.getRowSelectedIdx(rangeRow, selected) < 0) {
+            selected.push(rangeRow);
+          }
+        }
       } else if (
         (event as KeyboardEvent).key === 'a' &&
         ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey)

--- a/projects/ngx-datatable/src/lib/utils/selection.ts
+++ b/projects/ngx-datatable/src/lib/utils/selection.ts
@@ -11,12 +11,12 @@ export const selectRows = <TRow>(selected: TRow[], row: TRow, comparefn: any) =>
 };
 
 export const selectRowsBetween = <TRow>(
-  selected: TRow[],
   rows: (TRow | undefined)[],
   index: number,
   prevIndex: number
 ): TRow[] => {
   const reverse = index < prevIndex;
+  const rangeRows: TRow[] = [];
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
@@ -37,13 +37,11 @@ export const selectRowsBetween = <TRow>(
     }
 
     if ((reverse && lesser) || (!reverse && greater)) {
-      // if in the positive range to be added to `selected`, and
-      // not already in the selected array, add it
       if (i >= range.start && i <= range.end && row) {
-        selected.push(row);
+        rangeRows.push(row);
       }
     }
   }
 
-  return selected;
+  return rangeRows;
 };


### PR DESCRIPTION
Closes #582. 

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Shift-clicking after a Ctrl-click discards previously selected rows because the range selection replaces the selection with `[]`.

**What is the new behavior?**

Shift-click extends the existing selection with the range from the last clicked row, preserving prior Ctrl-selections. Duplicates are skipped.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

**Other information**:

Added a unit test in `body.component.spec.ts` covering the issue's repro steps.