### PR TITLE
fix: wait for DOM updates before scrolling to expanded tree row

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/client-side-scrolling.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/client-side-scrolling.spec.ts
@@ -274,7 +274,7 @@ describe('Client-side Scrolling – DatatableComponent.scrollToRow', () => {
 
     it('should call expandToRow for a non-visible child row', async () => {
       datatable.scrollToRow(treeRows[3]);
-      await fixture.whenStable();
+      await vi.waitFor(() => expect(bodyEl.scrollTop).toBeCloseTo(expectedOffset(2)));
 
       // expandToRow should expand the ancestors needed to reveal the target leaf row,
       // but must not flip the leaf itself away from 'disabled'.
@@ -292,6 +292,42 @@ describe('Client-side Scrolling – DatatableComponent.scrollToRow', () => {
       expect(() => datatable.scrollToRow(treeRows[0])).toThrowError(
         'Vertical scrolling is not enabled.'
       );
+    });
+
+    it('should scroll past the original scrollHeight after expanding a parent with many children', async () => {
+      // Build a tree where expanding Row 1 reveals 30 new children. Before expansion,
+      // the visible row count is small (5 roots) and the scroll container therefore has
+      // a scrollHeight equal to ~5 rows. After expansion the rendered DOM grows to
+      // ~35 rows, so the scroll container's scrollHeight must be large enough to reach
+      // the deeply nested target row.
+      const manyChildren: TreeRow[] = Array.from({ length: 30 }, (_, i) => ({
+        id: 100 + i,
+        parentId: 1,
+        name: `Child ${i}`,
+        treeStatus: 'disabled'
+      }));
+      const largeTree: TreeRow[] = [
+        { id: 1, parentId: null, name: 'Row 1', treeStatus: 'collapsed' },
+        ...manyChildren,
+        { id: 2, parentId: null, name: 'Row 2', treeStatus: 'disabled' },
+        { id: 3, parentId: null, name: 'Row 3', treeStatus: 'disabled' },
+        { id: 4, parentId: null, name: 'Row 4', treeStatus: 'disabled' },
+        { id: 5, parentId: null, name: 'Row 5', treeStatus: 'disabled' }
+      ];
+      rowsSig.set(largeTree);
+      await fixture.whenStable();
+
+      // Constrain the viewport so a scrollTop > 0 is required to reveal the target row.
+      bodyEl.style.height = '200px';
+      await fixture.whenStable();
+
+      // Pick the last child of Row 1 – it is not visible yet (Row 1 is collapsed) and
+      // its rendered position is well beyond the pre-expansion scrollHeight.
+      const target = manyChildren[manyChildren.length - 1];
+      datatable.scrollToRow(target, { block: 'start' });
+
+      // Tree order after expansion: Row 1, Child 0..29, Row 2..5 → target index = 30.
+      await vi.waitFor(() => expect(bodyEl.scrollTop).toBeCloseTo(expectedOffset(30)));
     });
   });
 });

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -1201,7 +1201,7 @@ export class DatatableComponent<TRow extends Row = any>
       optionalGetterForProp(this.treeToRelation())
     );
     this._rowDiffCount.update(v => v + 1);
-    // We need a microTask here to let Angular update the DOM
-    queueMicrotask(() => this.scrollToRowTree(row, options, true));
+    // We need a setTimeout to wait until the DOM was updated
+    setTimeout(() => this.scrollToRowTree(row, options, true));
   }
 }

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -1207,7 +1207,7 @@ export class DatatableComponent<TRow extends Row = any>
       optionalGetterForProp(this.treeToRelation())
     );
     this._rowDiffCount.update(v => v + 1);
-    // We need a microTask here to let Angular update the DOM
-    queueMicrotask(() => this.scrollToRowTree(row, options, true));
+    // We need a setTimeout to wait until the DOM was updated
+    setTimeout(() => this.scrollToRowTree(row, options, true));
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

When `scrollToRow` is called on a tree row whose ancestors are still collapsed, the datatable expands the ancestors and then schedules the recursive scroll call as a microtask via `queueMicrotask`. Microtasks run before Angular's zoneless change detection has flushed the newly visible rows to the DOM, so the scroll container's `scrollHeight` is still the pre-expansion value. The browser clamps `scrollTop` to the old maximum and the target row is not actually scrolled into view, especially when the tree grows enough that the target lies beyond the previous scrollable area.

**What is the new behavior?**

The recursive scroll call is deferred via `setTimeout` instead of `queueMicrotask`. This lets Angular's change detection cycle run and update the DOM (including the scroller's height) before the scroll position is computed and applied, so the browser no longer clamps `scrollTop` and the target row ends up at the requested position.

A new unit test in `client-side-scrolling.spec.ts` reproduces the failure mode: it expands a parent with 30 children inside a constrained viewport and asserts that the resulting `scrollTop` matches the freshly rendered target row's offset. The test fails with `queueMicrotask` and passes with `setTimeout`. The existing `should call expandToRow for a non-visible child row` test was updated to use `vi.waitFor` so it correctly awaits the deferred scroll.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

**Other information**:

None.