### PR TITLE
fix: fill viewport with ghost loader rows on initial load

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
@@ -578,6 +578,113 @@ describe('DatatableComponent With Custom Templates', () => {
   });
 });
 
+describe('DatatableComponent With Ghost Loading', () => {
+  @Component({
+    imports: [DatatableComponent],
+    template: `
+      <ngx-datatable
+        columnMode="force"
+        [rows]="rows()"
+        [columns]="columns()"
+        [scrollbarV]="scrollbarV()"
+        [ghostLoadingIndicator]="ghostLoadingIndicator()"
+        [rowHeight]="rowHeight()"
+        [headerHeight]="headerHeight()"
+      />
+    `,
+    host: {
+      '[style.inline-size.px]': 'size()',
+      '[style.block-size.px]': 'height()'
+    }
+  })
+  class TestFixtureWithGhostLoadingComponent {
+    readonly columns = signal<TableColumn[]>([{ prop: 'name' }]);
+    readonly rows = signal<Record<string, any>[]>([]);
+    readonly scrollbarV = signal(true);
+    readonly ghostLoadingIndicator = signal(false);
+    readonly rowHeight = signal(50);
+    readonly headerHeight = signal(50);
+    readonly size = signal(400);
+    readonly height = signal(600);
+  }
+
+  let fixture: ComponentFixture<TestFixtureWithGhostLoadingComponent>;
+  let component: TestFixtureWithGhostLoadingComponent;
+  let datatable: DatatableComponent;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestFixtureWithGhostLoadingComponent);
+    component = fixture.componentInstance;
+    datatable = fixture.debugElement.query(By.directive(DatatableComponent)).componentInstance;
+  });
+
+  it('should push enough undefined rows to fill pageSize when ghost loading with no data', async () => {
+    component.ghostLoadingIndicator.set(true);
+    component.scrollbarV.set(true);
+    component.rows.set([]);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const pageSize = datatable.pageSize();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(Math.max(pageSize, 1));
+  });
+
+  it('should push only one undefined row when data already fills the viewport', async () => {
+    const rows = Array.from({ length: 20 }, (_, i) => ({ name: `Row ${i}` }));
+    component.rows.set(rows);
+    await fixture.whenStable();
+
+    component.ghostLoadingIndicator.set(true);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(1);
+    expect(internalRows.length).toBe(rows.length + 1);
+  });
+
+  it('should push enough undefined rows to fill remaining viewport when partial data is loaded', async () => {
+    component.ghostLoadingIndicator.set(true);
+    component.scrollbarV.set(true);
+    await fixture.whenStable();
+
+    const pageSize = datatable.pageSize();
+    const partialRows = Array.from({ length: 3 }, (_, i) => ({ name: `Row ${i}` }));
+    component.rows.set(partialRows);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(Math.max(pageSize - partialRows.length, 1));
+    expect(internalRows.length).toBe(partialRows.length + undefinedCount);
+  });
+
+  it('should not add undefined rows when ghostLoadingIndicator is false', async () => {
+    component.ghostLoadingIndicator.set(false);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(0);
+  });
+
+  it('should not add undefined rows when scrollbarV is false', async () => {
+    component.ghostLoadingIndicator.set(true);
+    component.scrollbarV.set(false);
+    await fixture.whenStable();
+
+    const internalRows = datatable._internalRows();
+    const undefinedCount = internalRows.filter(r => r === undefined).length;
+
+    expect(undefinedCount).toBe(0);
+  });
+});
+
 describe('DatatableComponent With Frozen columns', () => {
   @Component({
     imports: [DatatableComponent, DataTableColumnDirective],

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -581,6 +581,10 @@ export class DatatableComponent<TRow extends Row = any>
   element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
   readonly _innerWidth = computed(() => this.dimensions().width);
   readonly pageSize = computed(() => this.calcPageSize());
+  private readonly viewportRowCount = computed(() => {
+    const size = Math.ceil(this.bodyHeight() / (this.rowHeight() as number));
+    return Math.max(size, 0);
+  });
   readonly _isFixedHeader = computed(() => {
     const headerHeight: number | string = this.headerHeight();
     return typeof headerHeight === 'string' ? (headerHeight as string) !== 'auto' : true;
@@ -620,8 +624,10 @@ export class DatatableComponent<TRow extends Row = any>
     }
 
     if (this.ghostLoadingIndicator() && this.scrollbarV() && !this.externalPaging()) {
-      // in case where we don't have predefined total page length
-      rows.push(undefined); // undefined row will render ghost cell row at the end of the page
+      const ghostRowCount = Math.max(this.viewportRowCount() - rows.length, 1);
+      for (let i = 0; i < ghostRowCount; i++) {
+        rows.push(undefined);
+      }
     }
 
     return rows;
@@ -935,12 +941,8 @@ export class DatatableComponent<TRow extends Row = any>
    * Recalculates the sizes of the page
    */
   calcPageSize(): number {
-    // Keep the page size constant even if the row has been expanded.
-    // This is because an expanded row is still considered to be a child of
-    // the original row.  Hence calculation would use rowHeight only.
     if (this.scrollbarV() && this.virtualization()) {
-      const size = Math.ceil(this.bodyHeight() / (this.rowHeight() as number));
-      return Math.max(size, 0);
+      return this.viewportRowCount();
     }
 
     // if limit is passed, we are paging

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -585,6 +585,10 @@ export class DatatableComponent<TRow extends Row = any>
   element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
   readonly _innerWidth = computed(() => this.dimensions().width);
   readonly pageSize = computed(() => this.calcPageSize());
+  private readonly viewportRowCount = computed(() => {
+    const size = Math.ceil(this.bodyHeight() / (this.rowHeight() as number));
+    return Math.max(size, 0);
+  });
   readonly _isFixedHeader = computed(() => {
     const headerHeight: number | string = this.headerHeight();
     return typeof headerHeight === 'string' ? (headerHeight as string) !== 'auto' : true;
@@ -624,8 +628,10 @@ export class DatatableComponent<TRow extends Row = any>
     }
 
     if (this.ghostLoadingIndicator() && this.scrollbarV() && !this.externalPaging()) {
-      // in case where we don't have predefined total page length
-      rows.push(undefined); // undefined row will render ghost cell row at the end of the page
+      const ghostRowCount = Math.max(this.viewportRowCount() - rows.length, 1);
+      for (let i = 0; i < ghostRowCount; i++) {
+        rows.push(undefined);
+      }
     }
 
     return rows;
@@ -939,12 +945,8 @@ export class DatatableComponent<TRow extends Row = any>
    * Recalculates the sizes of the page
    */
   calcPageSize(): number {
-    // Keep the page size constant even if the row has been expanded.
-    // This is because an expanded row is still considered to be a child of
-    // the original row.  Hence calculation would use rowHeight only.
     if (this.scrollbarV() && this.virtualization()) {
-      const size = Math.ceil(this.bodyHeight() / (this.rowHeight() as number));
-      return Math.max(size, 0);
+      return this.viewportRowCount();
     }
 
     // if limit is passed, we are paging


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

When using server-side scrolling with `ghostLoadingIndicator`, only a single `undefined` row was pushed into `_internalRows`, resulting in just one or two ghost skeleton rows being visible during initial load instead of filling the entire viewport.

**What is the new behavior?**

Now it pushes enough `undefined` rows to fill the viewport (`pageSize - rows.length`, minimum 1), so the ghost loader fills the entire body area before data arrives. When data already fills the viewport, only one `undefined` row is added as a bottom loading indicator.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

**Other information:**

Affects the `Scrolling server-side` example.

Added unit tests verifying:

- Ghost rows fill viewport when loading with no data
- Only one ghost row added as bottom indicator when data fills viewport
- Ghost rows fill remaining space when partial data is loaded
- No ghost rows added when `ghostLoadingIndicator` is false
- No ghost rows added when `scrollbarV` is false