### PR TITLE
docs: clarify how to replace the `sort` event

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -483,7 +483,7 @@ export class DatatableComponent<TRow extends Row = any>
    * <ngx-datatable [(sorts)]="mySorts"></ngx-datatable>
    * ```
    *
-   * When using `(sort)/(sortsChange)` and `(page)` together (typically server-side paging),
+   * When using `(sort)`/`(sortsChange)` and `(page)` together (typically for server-side paging),
    * subscribe only to `(page)` and read {@link PageEvent.sorts} from the event payload instead.
    * `(page)` emits on both page changes and sort changes.
    */

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -482,6 +482,10 @@ export class DatatableComponent<TRow extends Row = any>
    * <!-- or -->
    * <ngx-datatable [(sorts)]="mySorts"></ngx-datatable>
    * ```
+   *
+   * When using `(sort)/(sortsChange)` and `(page)` together (typically server-side paging),
+   * subscribe only to `(page)` and read {@link PageEvent.sorts} from the event payload instead.
+   * `(page)` emits on both page changes and sort changes.
    */
   readonly sort = output<SortEvent>();
 

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -485,7 +485,7 @@ export class DatatableComponent<TRow extends Row = any>
    *
    * When using `(sort)`/`(sortsChange)` and `(page)` together (typically for server-side paging),
    * subscribe only to `(page)` and read {@link PageEvent.sorts} from the event payload instead.
-   * `(page)` emits on both page changes and sort changes.
+   * `(page)` emits on both page and sort changes.
    */
   readonly sort = output<SortEvent>();
 


### PR DESCRIPTION
Closes #682

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: docs

**What is the current behavior?** (You can also link to an open issue here)

No hint that the `page` event can be a replacement for `sort`.

**What is the new behavior?**

The deprecation note states that `page` event should be used for server-side paging.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

@fh1ch should we also update the changelog?