### PR TITLE
fix: center empty-content slot vertically and horizontally

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.scss
@@ -15,6 +15,18 @@ datatable-scroller {
 
   :host-context(ngx-datatable.fixed-row) & {
     white-space: nowrap;
+
+    &:has([empty-content]) {
+      white-space: normal;
+    }
+  }
+
+  &:has([empty-content]) {
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
   }
 }
 

--- a/src/app/basic/empty-template.component.ts
+++ b/src/app/basic/empty-template.component.ts
@@ -20,6 +20,8 @@ import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
       <ngx-datatable
         class="material"
         columnMode="force"
+        style="height: 500px;"
+        [scrollbarV]="true"
         [rows]="[]"
         [columns]="columns"
         [headerHeight]="50"


### PR DESCRIPTION
Apply flex centering on datatable-scroller when it contains empty-content to ensure vertical and horizontal centering within the body.

**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The empty-content slot only uses computed sizes and does not do any vertical or horizontal alignment.

**What is the new behavior?**

The empty-content slot does vertical and horizontal alignment of the content. 

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
