### PR TITLE
feat(summary-row): support providing custom animation class

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -107,6 +107,8 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
             [rows]="rows"
             [columns]="columns"
             [template]="summaryRowTemplate()"
+            [animate.enter]="summaryRowAnimateEnter()"
+            [animate.leave]="summaryRowAnimateLeave()"
           />
         }
         <ng-template
@@ -242,6 +244,8 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
           [rows]="rows"
           [columns]="columns"
           [template]="summaryRowTemplate()"
+          [animate.enter]="summaryRowAnimateEnter()"
+          [animate.leave]="summaryRowAnimateLeave()"
         />
       }
     }
@@ -295,6 +299,8 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   readonly summaryPosition = input.required<string>();
   readonly summaryHeight = input.required<number>();
   readonly summaryRowTemplate = input<TemplateRef<void>>();
+  readonly summaryRowAnimateEnter = input<string>();
+  readonly summaryRowAnimateLeave = input<string>();
   readonly rowDraggable = input<boolean>();
   readonly rowDragEvents = input.required<OutputEmitterRef<DragEventData>>();
   readonly disableRowCheck = input<(row: TRow) => boolean | undefined>();

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -60,6 +60,8 @@
       [summaryHeight]="summaryHeight()"
       [summaryPosition]="summaryPosition()"
       [summaryRowTemplate]="summaryRowDirective()?.template"
+      [summaryRowAnimateEnter]="summaryRowAnimateEnter()"
+      [summaryRowAnimateLeave]="summaryRowAnimateLeave()"
       [verticalScrollVisible]="verticalScrollVisible"
       [ariaRowCheckboxMessage]="messages().ariaRowCheckboxMessage ?? 'Select row'"
       [ariaGroupHeaderCheckboxMessage]="

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -398,6 +398,18 @@ export class DatatableComponent<TRow extends Row = any>
   readonly summaryPosition = input('top');
 
   /**
+   * CSS class to apply when the summary row enters (appears).
+   * Use this to customize the enter animation.
+   */
+  readonly summaryRowAnimateEnter = input<string>();
+
+  /**
+   * CSS class to apply when the summary row leaves (disappears).
+   * Use this to customize the leave animation.
+   */
+  readonly summaryRowAnimateLeave = input<string>();
+
+  /**
    * A function you can use to check whether you want
    * to disable a row. Example:
    *


### PR DESCRIPTION
added `summaryRowAnimateEnter` and `summaryRowAnimateLeave` input which can be used to provide custom class for angular's `[animate.enter]` and `[animate.leave]` transitions on summary row.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
