### PR TITLE
feat: new `fetchRows` event

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ColumnMode, SortPropDir } from '../types/public.types';
+import { ColumnMode, FetchRowsEvent, SortEvent, SortPropDir } from '../types/public.types';
 import { TableColumn } from '../types/table-column.type';
 import { DataTableBodyCellComponent } from './body/body-cell.component';
 import { DataTableBodyRowComponent } from './body/body-row.component';
@@ -353,6 +353,32 @@ describe('DatatableComponent', () => {
     expect(datatableComponent.offset()).toBe(0);
   });
 
+  it('should emit fetchRows when sorting by a column', async () => {
+    const initialRows = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const columns = [{ prop: 'id' }];
+
+    component.rows.set(initialRows);
+    component.columns.set(columns);
+    await fixture.whenStable();
+
+    const datatable: DatatableComponent = fixture.debugElement.query(
+      By.directive(DatatableComponent)
+    ).componentInstance;
+
+    const fetchRowsSpy = vi.spyOn(datatable.fetchRows, 'emit');
+
+    sortBy({ column: 1 }, fixture);
+    await fixture.whenStable();
+
+    const lastEmit = fetchRowsSpy.mock.calls.at(-1)?.[0] as FetchRowsEvent;
+
+    expect(lastEmit).toEqual({
+      startIndex: 0,
+      endIndex: 3,
+      sorts: [{ prop: 'id', dir: 'asc' }]
+    });
+  });
+
   it('should support array data', async () => {
     const initialRows = [['Hello', 123]];
 
@@ -575,6 +601,124 @@ describe('DatatableComponent With Custom Templates', () => {
     expect(textContent({ row: 1, column: 2 }, fixture)).toContain('35');
     expect(textContent({ row: 2, column: 2 }, fixture)).toContain('50');
     expect(textContent({ row: 3, column: 2 }, fixture)).toContain('60');
+  });
+});
+
+describe('DatatableComponent With External Paging', () => {
+  @Component({
+    imports: [DatatableComponent],
+    template: `
+      <ngx-datatable
+        [columns]="columns()"
+        [rows]="rows()"
+        [externalPaging]="externalPaging()"
+        [scrollbarV]="scrollbarV()"
+        [virtualization]="virtualization()"
+        [limit]="limit()"
+        [count]="count()"
+        (fetchRows)="onFetchRows($event)"
+      />
+    `,
+    host: {
+      '[style.inline-size.px]': 'size()',
+      '[style.block-size.px]': 'height()'
+    }
+  })
+  class TestFixtureWithExternalPagingComponent {
+    readonly columns = signal<TableColumn[]>([{ prop: 'name' }]);
+    readonly rows = signal<Record<string, any>[]>([]);
+    readonly externalPaging = signal(true);
+    readonly scrollbarV = signal(true);
+    readonly virtualization = signal(true);
+    readonly limit = signal<number | undefined>(10);
+    readonly count = signal(100);
+    readonly size = signal(400);
+    readonly height = signal(600);
+
+    lastFetchRowsEvent?: FetchRowsEvent;
+
+    onFetchRows(event: FetchRowsEvent) {
+      this.lastFetchRowsEvent = event;
+    }
+  }
+
+  let fixture: ComponentFixture<TestFixtureWithExternalPagingComponent>;
+  let component: TestFixtureWithExternalPagingComponent;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestFixtureWithExternalPagingComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should emit fetchRows on initialization with external paging and scrollbarV', async () => {
+    component.rows.set(Array.from({ length: 100 }, (_, i) => ({ name: `Row ${i}` })));
+    component.virtualization.set(false);
+
+    vi.useFakeTimers();
+    fixture.detectChanges();
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+
+    expect(component.lastFetchRowsEvent).toEqual({
+      startIndex: 0,
+      endIndex: 10,
+      sorts: []
+    });
+  });
+
+  it('should emit fetchRows with correct row indexes based on offset', async () => {
+    component.rows.set(Array.from({ length: 30 }, (_, i) => ({ id: i })));
+    component.columns.set([{ prop: 'id' }]);
+    component.limit.set(10);
+    component.virtualization.set(false);
+
+    vi.useFakeTimers();
+    fixture.detectChanges();
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+
+    const datatable = fixture.debugElement.query(By.directive(DatatableComponent))
+      .componentInstance as DatatableComponent;
+    const fetchRowsSpy = vi.spyOn(datatable.fetchRows, 'emit');
+
+    datatable.onFooterPage({ page: 3 });
+    await fixture.whenStable();
+
+    expect(fetchRowsSpy.mock.calls.at(-1)?.[0]).toEqual({
+      startIndex: 20,
+      endIndex: 30,
+      sorts: []
+    });
+  });
+
+  it('should emit fetchRows with row count when no limit is set', async () => {
+    component.rows.set(Array.from({ length: 15 }, (_, i) => ({ id: i })));
+    component.columns.set([{ prop: 'id' }]);
+    component.limit.set(undefined);
+    component.virtualization.set(false);
+
+    vi.useFakeTimers();
+    fixture.detectChanges();
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+
+    const datatable = fixture.debugElement.query(By.directive(DatatableComponent))
+      .componentInstance as DatatableComponent;
+    const fetchRowsSpy = vi.spyOn(datatable.fetchRows, 'emit');
+
+    datatable.onColumnSort({
+      column: { prop: 'id' },
+      prevValue: undefined,
+      newValue: 'desc',
+      sorts: [{ prop: 'id', dir: 'desc' }]
+    });
+    await fixture.whenStable();
+
+    expect(fetchRowsSpy.mock.calls.at(-1)?.[0]).toEqual({
+      startIndex: 0,
+      endIndex: 15,
+      sorts: [{ prop: 'id', dir: 'desc' }]
+    });
   });
 });
 

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -42,6 +42,7 @@ import {
   ColumnResizeEvent,
   ContextMenuEvent,
   DragEventData,
+  FetchRowsEvent,
   Group,
   PageEvent,
   PagerPageEvent,
@@ -239,7 +240,16 @@ export class DatatableComponent<TRow extends Row = any>
    * The current offset ( page - 1 ) shown.
    * Default value: `0`
    */
-  readonly offset = model<number>(0);
+    readonly offset = model<number>(0);
+
+  /**
+   * Row-based offset for external paging.
+   * When provided, overrides `offset` (page-based) by converting rows to page number.
+   * Represents the starting row index (0-based) of the first visible row.
+   *
+   * Default value: `null`
+   */
+   readonly rowsOffset = input<number | null>(null);
 
   /**
    * Show the linear loading bar.
@@ -492,8 +502,23 @@ export class DatatableComponent<TRow extends Row = any>
 
   /**
    * The table was paged either triggered by the pager or the body scroll.
+   *
+   * @deprecated Use `fetchRows` instead.
+   * Application code must be adjusted to fetch rows based on the requested index
+   * instead of fetching a specific page.
+   *
+   * The `page` events nature using the page as a foundation has severe restrictions:
+   * - The table cannot fetch additional buffer rows to enable smoother virtual scrolling
+   * - The page currently includes half visible rows to avoid blanks, which breaks paging with pagination
+   *   since half visible rows never become fully visible. See #146
    */
   readonly page = output<PageEvent>();
+
+  /**
+   * Emitted when the table needs new rows for external paging/sorting.
+   * Provides row indexes that should be fetched.
+   */
+  readonly fetchRows = output<FetchRowsEvent>();
 
   /**
    * Columns were re-ordered.
@@ -687,12 +712,12 @@ export class DatatableComponent<TRow extends Row = any>
    * Computed signal that returns the corrected offset value.
    * It ensures the offset is within valid bounds based on rowCount and pageSize.
    */
-  readonly correctedOffset = computed(() => {
-    const offset = this.offset();
-    const rowCount = this.rowCount();
-    const pageSize = this.pageSize();
-    return Math.max(Math.min(offset, Math.ceil(rowCount / pageSize) - 1), 0);
-  });
+    readonly correctedOffset = computed(() => {
+      const offset = this.offset();
+      const rowCount = this.rowCount();
+      const pageSize = this.pageSize();
+      return Math.max(Math.min(offset, Math.ceil(rowCount / pageSize) - 1), 0);
+    });
 
   _subscriptions: Subscription[] = [];
   _defaultColumnWidth = this.configuration?.defaultColumnWidth ?? 150;
@@ -705,7 +730,7 @@ export class DatatableComponent<TRow extends Row = any>
   protected verticalScrollVisible = false;
   private readonly dimensions = signal<Pick<DOMRect, 'width' | 'height'>>({ height: 0, width: 0 });
 
-  constructor() {
+   constructor() {
     // TODO: This should be a computed signal.
     // Effect to handle recalculate when limit or count changes
     effect(() => {
@@ -717,6 +742,16 @@ export class DatatableComponent<TRow extends Row = any>
     });
 
     effect(() => this.recalculateColumns());
+
+    // Sync rowsOffset (row index) to offset (page number)
+    // This ensures pager displays correctly when rowsOffset is used
+    effect(() => {
+      const rowsOffset = this.rowsOffset();
+      if (rowsOffset != null && rowsOffset >= 0) {
+        const pageSize = this.pageSize();
+        untracked(() => this.offset.set(Math.floor(rowsOffset / pageSize)));
+      }
+    });
   }
 
   /*
@@ -751,13 +786,22 @@ export class DatatableComponent<TRow extends Row = any>
     requestAnimationFrame(() => {
       this.recalculate();
 
-      // emit page for virtual server-side kickoff
+      // Emit page for virtual server-side kickoff
       if (this.externalPaging() && this.scrollbarV()) {
         this.page.emit({
           count: this.count(),
           pageSize: this.pageSize(),
           limit: this.limit(),
           offset: 0,
+          sorts: this.sorts()
+        });
+      }
+
+      // Emit fetchRows for external paging kickoff
+      if (this.externalPaging()) {
+        this.fetchRows.emit({
+          startIndex: 0,
+          endIndex: this.pageSize(),
           sorts: this.sorts()
         });
       }
@@ -900,11 +944,19 @@ export class DatatableComponent<TRow extends Row = any>
     this.offset.set(offset);
 
     if (!isNaN(this.correctedOffset())) {
+      const pageSize = this.pageSize();
+      const correctedOffset = this.correctedOffset();
       this.page.emit({
         count: this.count(),
-        pageSize: this.pageSize(),
+        pageSize,
         limit: this.limit(),
-        offset: this.correctedOffset(),
+        offset: correctedOffset,
+        sorts: this.sorts()
+      });
+      const startIndex = correctedOffset * pageSize;
+      this.fetchRows.emit({
+        startIndex,
+        endIndex: startIndex + pageSize,
         sorts: this.sorts()
       });
     }
@@ -931,11 +983,19 @@ export class DatatableComponent<TRow extends Row = any>
     this.offset.set(event.page - 1);
     this._bodyComponent().updateOffsetY(this.correctedOffset());
 
+    const pageSize = this.pageSize();
+    const correctedOffset = this.correctedOffset();
     this.page.emit({
       count: this.count(),
-      pageSize: this.pageSize(),
+      pageSize,
       limit: this.limit(),
-      offset: this.correctedOffset(),
+      offset: correctedOffset,
+      sorts: this.sorts()
+    });
+    const startIndex = correctedOffset * pageSize;
+    this.fetchRows.emit({
+      startIndex,
+      endIndex: startIndex + pageSize,
       sorts: this.sorts()
     });
 
@@ -1086,11 +1146,17 @@ export class DatatableComponent<TRow extends Row = any>
     this.offset.set(0);
     this._bodyComponent().updateOffsetY(this.correctedOffset());
     // Emit the page object with updated offset value
+    const pageSize = this.pageSize();
     this.page.emit({
       count: this.count(),
-      pageSize: this.pageSize(),
+      pageSize,
       limit: this.limit(),
       offset: this.correctedOffset(),
+      sorts: this.sorts()
+    });
+    this.fetchRows.emit({
+      startIndex: 0,
+      endIndex: pageSize,
       sorts: this.sorts()
     });
     this.sort.emit(event);

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -184,6 +184,12 @@ export interface PagerPageEvent {
   page: number;
 }
 
+export interface FetchRowsEvent {
+  startIndex: number;
+  endIndex: number;
+  sorts: SortPropDir[];
+}
+
 export interface ColumnResizeEvent {
   column: TableColumn;
   prevValue: number;

--- a/src/app/paging/mock-server-results-service.ts
+++ b/src/app/paging/mock-server-results-service.ts
@@ -4,8 +4,11 @@ import { delay, map } from 'rxjs/operators';
 
 import companyData from '../../../src/assets/data/company.json';
 import { Employee } from '../data.model';
-import { Page } from './model/page';
-import { PagedData } from './model/paged-data';
+
+export interface FetchResult<T> {
+  data: T[];
+  totalElements: number;
+}
 
 /**
  * A server used to mock a paged data result from a server
@@ -14,32 +17,33 @@ import { PagedData } from './model/paged-data';
 export class MockServerResultsService {
   /**
    * A method that mocks a paged server response
-   * @param page The selected page
+   * @param startIndex The start index of rows to fetch
+   * @param endIndex The end index of rows to fetch
    * @returns An observable containing the employee data
    */
-  public getResults(page: Page): Observable<PagedData<Employee>> {
+  public getResults(startIndex: number, endIndex: number): Observable<FetchResult<Employee>> {
     return (
       of(companyData)
-        .pipe(map(d => this.getPagedData(page)))
+        .pipe(map(() => this.getData(startIndex, endIndex)))
         // 1 ms in e2e requires the app to recalculate, but it is too fast for e2e to notice.
         .pipe(delay(window.navigator.webdriver ? 1 : 1500 * Math.random()))
     );
   }
 
   /**
-   * Package companyData into a PagedData object based on the selected Page
-   * @param page The page data used to get the selected data from companyData
-   * @returns An array of the selected data and page
+   * Package companyData into a FetchResult object based on row indexes
+   * @param startIndex The starting row index
+   * @param endIndex The ending row index
+   * @returns An array of the selected data and total element count
    */
-  private getPagedData(page: Page): PagedData<Employee> {
+  private getData(startIndex: number, endIndex: number): FetchResult<Employee> {
     const data: Employee[] = [];
-    page.totalElements = companyData.length;
-    page.totalPages = page.totalElements / page.size;
-    const start = page.pageNumber * page.size;
-    const end = Math.min(start + page.size, page.totalElements);
+    const totalElements = companyData.length;
+    const start = Math.max(0, startIndex);
+    const end = Math.min(endIndex, totalElements);
     for (let i = start; i < end; i++) {
       data.push(companyData[i]);
     }
-    return { page, data };
+    return { data, totalElements };
   }
 }

--- a/src/app/paging/scrolling-no-virtual.component.ts
+++ b/src/app/paging/scrolling-no-virtual.component.ts
@@ -1,9 +1,8 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
-import { DatatableComponent } from '@siemens/ngx-datatable';
+import { Component, inject, signal } from '@angular/core';
+import { DatatableComponent, FetchRowsEvent } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
 import { MockServerResultsService } from './mock-server-results-service';
-import { Page } from './model/page';
 
 @Component({
   selector: 'scrolling-no-virtual-demo',
@@ -21,57 +20,46 @@ import { Page } from './model/page';
           </a>
         </small>
       </h3>
-      @let rows = this.rows();
-      @let page = this.page();
-      @let isLoading = this.isLoading();
       <ngx-datatable
         class="material"
         rowHeight="auto"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows()"
         [columns]="[{ name: 'Name' }, { name: 'Gender' }, { name: 'Company' }]"
         [headerHeight]="50"
         [footerHeight]="50"
         [scrollbarV]="true"
         [virtualization]="false"
         [externalPaging]="true"
-        [count]="page.totalElements"
-        [offset]="page.pageNumber"
-        [limit]="page.size"
-        [ghostLoadingIndicator]="isLoading > 0"
-        (page)="setPage($event.offset)"
+        [count]="totalElements()"
+        [rowsOffset]="rowsOffset()"
+        [limit]="pageSize()"
+        [ghostLoadingIndicator]="isLoading() > 0"
+        (fetchRows)="onFetchRows($event)"
       />
     </div>
   `,
   providers: [MockServerResultsService]
 })
-export class ScrollingNoVirtualComponent implements OnInit {
-  readonly page = signal<Page>({
-    pageNumber: 0,
-    size: 20,
-    totalElements: 0,
-    totalPages: 0
-  });
+export class ScrollingNoVirtualComponent {
+  readonly totalElements = signal(0);
+  readonly rowsOffset = signal(0);
+  readonly pageSize = signal(20);
   readonly rows = signal<Employee[]>([]);
-
   readonly isLoading = signal(0);
   private serverResultsService = inject(MockServerResultsService);
 
-  ngOnInit() {
-    this.setPage(0);
-  }
-
   /**
-   * Populate the table with new data based on the page number
-   * @param page The page to select
+   * Populate the table with new data based on row indexes
+   * @param event The fetchRows event containing start and end indexes
    */
-  setPage(page: number) {
-    this.page.update(currentPage => ({ ...currentPage, pageNumber: page }));
+  onFetchRows(event: FetchRowsEvent) {
     this.isLoading.update(v => v + 1);
-    this.serverResultsService.getResults(this.page()).subscribe(pagedData => {
+    this.rowsOffset.set(event.startIndex);
+    this.serverResultsService.getResults(event.startIndex, event.endIndex).subscribe(result => {
       this.isLoading.update(v => v - 1);
-      this.page.set(pagedData.page);
-      this.rows.set(pagedData.data);
+      this.totalElements.set(result.totalElements);
+      this.rows.set(result.data);
     });
   }
 }

--- a/src/app/paging/server-side-paging.component.ts
+++ b/src/app/paging/server-side-paging.component.ts
@@ -1,9 +1,8 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
-import { DatatableComponent } from '@siemens/ngx-datatable';
+import { Component, inject, signal } from '@angular/core';
+import { DatatableComponent, FetchRowsEvent } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
 import { MockServerResultsService } from './mock-server-results-service';
-import { Page } from './model/page';
 
 @Component({
   selector: 'server-side-paging-demo',
@@ -21,7 +20,6 @@ import { Page } from './model/page';
           </a>
         </small>
       </h3>
-      @let page = this.page();
       <ngx-datatable
         class="material"
         rowHeight="auto"
@@ -31,41 +29,34 @@ import { Page } from './model/page';
         [headerHeight]="50"
         [footerHeight]="50"
         [externalPaging]="true"
-        [count]="page.totalElements"
-        [offset]="page.pageNumber"
-        [limit]="page.size"
+        [count]="totalElements()"
+        [rowsOffset]="rowsOffset()"
+        [limit]="pageSize()"
         [loadingIndicator]="loading()"
-        (page)="setPage($event.offset)"
+        (fetchRows)="onFetchRows($event)"
       />
     </div>
   `,
   providers: [MockServerResultsService]
 })
-export class ServerSidePagingComponent implements OnInit {
-  readonly page = signal<Page>({
-    pageNumber: 0,
-    size: 20,
-    totalElements: 0,
-    totalPages: 0
-  });
+export class ServerSidePagingComponent {
+  readonly totalElements = signal(0);
+  readonly rowsOffset = signal(0);
+  readonly pageSize = signal(20);
   readonly rows = signal<Employee[]>([]);
   readonly loading = signal(false);
   private serverResultsService = inject(MockServerResultsService);
 
-  ngOnInit() {
-    this.setPage(0);
-  }
-
   /**
-   * Populate the table with new data based on the page number
-   * @param page The page to select
+   * Populate the table with new data based on row indexes
+   * @param event The fetchRows event containing start and end indexes
    */
-  setPage(page: number) {
-    this.page.update(currentPage => ({ ...currentPage, pageNumber: page }));
+  onFetchRows(event: FetchRowsEvent) {
     this.loading.set(true);
-    this.serverResultsService.getResults(this.page()).subscribe(pagedData => {
-      this.page.set(pagedData.page);
-      this.rows.set(pagedData.data);
+    this.rowsOffset.set(event.startIndex);
+    this.serverResultsService.getResults(event.startIndex, event.endIndex).subscribe(result => {
+      this.totalElements.set(result.totalElements);
+      this.rows.set(result.data);
       this.loading.set(false);
     });
   }

--- a/src/app/paging/virtual-server-side.component.ts
+++ b/src/app/paging/virtual-server-side.component.ts
@@ -1,9 +1,8 @@
 import { Component, inject, signal } from '@angular/core';
-import { DatatableComponent, PageEvent } from '@siemens/ngx-datatable';
+import { DatatableComponent, FetchRowsEvent } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
 import { MockServerResultsService } from './mock-server-results-service';
-import { Page } from './model/page';
 
 @Component({
   selector: 'virtual-server-side-demo',
@@ -42,8 +41,8 @@ import { Page } from './model/page';
         [externalPaging]="true"
         [externalSorting]="true"
         [count]="totalElements"
-        [offset]="pageNumber"
-        (page)="setPage($event)"
+        [rowsOffset]="rowsOffset()"
+        (fetchRows)="onFetchRows($event)"
       >
         <div loading-indicator class="custom-loading-indicator">loading...</div>
       </ngx-datatable>
@@ -54,69 +53,46 @@ import { Page } from './model/page';
 })
 export class VirtualServerSideComponent {
   readonly totalElements = signal(0);
-  pageNumber = 0;
+  readonly rowsOffset = signal(0);
   readonly rows = signal<Employee[] | undefined>(undefined);
-  cache: Record<string, boolean> = {};
-  cachePageSize = 0;
+  cache: Set<string> = new Set();
+  cachedChunkSize = 0;
 
   readonly isLoading = signal(0);
 
   private serverResultsService = inject(MockServerResultsService);
 
-  setPage(pageInfo: PageEvent) {
-    // Current page number is determined by last call to setPage
-    // This is the page the UI is currently displaying
-    // The current page is based on the UI pagesize and scroll position
-    // Pagesize can change depending on browser size
-    this.pageNumber = pageInfo.offset;
+  onFetchRows(event: FetchRowsEvent) {
+    this.rowsOffset.set(event.startIndex);
 
-    // Calculate row offset in the UI using pageInfo
-    // This is the scroll position in rows
-    const rowOffset = pageInfo.offset * pageInfo.pageSize;
+    const chunkSize = event.endIndex - event.startIndex;
+    const cacheKey = `${event.startIndex}-${event.endIndex}`;
 
-    const page: Page = {
-      pageNumber: Math.floor(rowOffset / pageInfo.pageSize),
-      size: pageInfo.pageSize,
-      totalElements: 0,
-      totalPages: 0
-    };
-
-    // We keep a index of server loaded pages so we don't load same data twice
-    // This is based on the server page not the UI
-    if (this.cachePageSize !== page.size) {
-      this.cachePageSize = page.size;
-      this.cache = {};
+    // We keep an index of fetched chunks so we don't load same data twice
+    if (this.cachedChunkSize !== chunkSize) {
+      this.cachedChunkSize = chunkSize;
+      this.cache.clear();
     }
-    if (this.cache[page.pageNumber]) {
+    if (this.cache.has(cacheKey)) {
       return;
     }
-    this.cache[page.pageNumber] = true;
+    this.cache.add(cacheKey);
 
-    // Counter of pending API calls
     this.isLoading.update(v => v + 1);
 
-    this.serverResultsService.getResults(page).subscribe(pagedData => {
-      // Update total count
-      this.totalElements.set(pagedData.page.totalElements);
+    this.serverResultsService.getResults(event.startIndex, event.endIndex).subscribe(result => {
+      this.totalElements.set(result.totalElements);
 
-      // Create array to store data if missing
-      // The array should have the correct number of with "holes" for missing data
       const currentRows = this.rows() ?? new Array<Employee>(this.totalElements() || 0);
 
-      // Calc starting row offset
-      // This is the position to insert the new data
-      const start = pagedData.page.pageNumber * pagedData.page.size;
-
-      // Copy existing data
       const rows = [...currentRows];
 
-      // Insert new rows into correct position
-      rows.splice(start, pagedData.page.size, ...pagedData.data);
+      for (let i = 0; i < result.data.length; i++) {
+        rows[event.startIndex + i] = result.data[i];
+      }
 
-      // Set rows to our new rows for display
       this.rows.set(rows);
 
-      // Decrement the counter of pending API calls
       this.isLoading.update(v => v - 1);
     });
   }

--- a/src/app/summary/server-side-paging-summary.component.ts
+++ b/src/app/summary/server-side-paging-summary.component.ts
@@ -1,9 +1,8 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
-import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
+import { Component, inject, signal } from '@angular/core';
+import { DatatableComponent, FetchRowsEvent, TableColumn } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
 import { MockServerResultsService } from '../paging/mock-server-results-service';
-import { Page } from '../paging/model/page';
 
 @Component({
   selector: 'server-side-paging-summary-demo',
@@ -20,7 +19,6 @@ import { Page } from '../paging/model/page';
           </a>
         </small>
       </h3>
-      @let page = this.page();
       <ngx-datatable
         class="material"
         rowHeight="auto"
@@ -32,22 +30,19 @@ import { Page } from '../paging/model/page';
         [summaryHeight]="55"
         [footerHeight]="50"
         [externalPaging]="true"
-        [count]="page.totalElements"
-        [offset]="page.pageNumber"
-        [limit]="page.size"
-        (page)="setPage($event.offset)"
+        [count]="totalElements()"
+        [rowsOffset]="rowsOffset()"
+        [limit]="pageSize()"
+        (fetchRows)="onFetchRows($event)"
       />
     </div>
   `,
   providers: [MockServerResultsService]
 })
-export class ServerSidePagingSummaryComponent implements OnInit {
-  readonly page = signal<Page>({
-    pageNumber: 0,
-    size: 20,
-    totalPages: 0,
-    totalElements: 0
-  });
+export class ServerSidePagingSummaryComponent {
+  readonly totalElements = signal(0);
+  readonly rowsOffset = signal(0);
+  readonly pageSize = signal(20);
   readonly rows = signal<Employee[]>([]);
 
   columns: TableColumn[] = [
@@ -59,19 +54,15 @@ export class ServerSidePagingSummaryComponent implements OnInit {
 
   private serverResultsService = inject(MockServerResultsService);
 
-  ngOnInit() {
-    this.setPage(0);
-  }
-
   /**
-   * Populate the table with new data based on the page number
-   * @param page The page to select
+   * Populate the table with new data based on row indexes
+   * @param event The fetchRows event containing start and end indexes
    */
-  setPage(page: number) {
-    this.page.update(currentPage => ({ ...currentPage, pageNumber: page }));
-    this.serverResultsService.getResults(this.page()).subscribe(pagedData => {
-      this.page.set(pagedData.page);
-      this.rows.set(pagedData.data);
+  onFetchRows(event: FetchRowsEvent) {
+    this.rowsOffset.set(event.startIndex);
+    this.serverResultsService.getResults(event.startIndex, event.endIndex).subscribe(result => {
+      this.totalElements.set(result.totalElements);
+      this.rows.set(result.data);
     });
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
`page` event is used for external paging/sorting.

**What is the new behavior?**

`fetchRows` event is used for external paging/sorting.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The key difference is, that the `page` event requests always an entire page data using the page size of the table.

This has two major flaws:

- the table cannot fetch additional buffer rows to enable smoother virtual scrolling
- the page currently includes half visible rows, to avoid blanks. This breaks paging with a pagination, since half visible rows never become fully visible. See #146

This new event allows us to modify the ranges better and change the page behavior in the next major release.

DEPRECATED:
`DatatableComponent.page` event is deprecated in favor of `fetchRows`.

Application code must be adjusted to fetch rows based on the requested index instead of fetching a specific page.

The `page` events nature using the page as a foundation has severe restrictions:
- The table cannot fetch additional buffer rows to enable smoother virtual scrolling
- The page currently includes half visible rows to avoid blanks, which breaks paging with pagination since half visible rows never become fully visible. See #146
