### PR TITLE
docs(examples): use async pipe instead of manual subscribe

### DIFF
--- a/src/app/basic/context-menu.component.ts
+++ b/src/app/basic/context-menu.component.ts
@@ -1,3 +1,4 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { ContextMenuEvent, DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
 
@@ -6,7 +7,7 @@ import { DataService } from '../data.service';
 
 @Component({
   selector: 'context-menu-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -46,7 +47,7 @@ import { DataService } from '../data.service';
         class="material"
         rowHeight="auto"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [columns]="columns"
         [headerHeight]="50"
         [footerHeight]="50"
@@ -56,21 +57,13 @@ import { DataService } from '../data.service';
   `
 })
 export class ContextMenuComponent {
-  rows: Employee[] = [];
+  protected readonly rows = inject(DataService).load('company.json');
 
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Gender' }, { name: 'Company' }];
 
   rawEvent: any;
   contextmenuRow: any;
   contextmenuColumn: any;
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows = data;
-    });
-  }
 
   onTableContextMenu(contextMenuEvent: ContextMenuEvent<Employee>) {
     this.rawEvent = contextMenuEvent.event;

--- a/src/app/basic/css-classes.component.ts
+++ b/src/app/basic/css-classes.component.ts
@@ -1,12 +1,14 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { DataTableColumnDirective, DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'css-classes-demo',
-  imports: [DatatableComponent, DataTableColumnDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -23,7 +25,7 @@ import { DataService } from '../data.service';
       <ngx-datatable
         class="material"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [headerHeight]="50"
         [rowHeight]="50"
         [rowClass]="getRowClass"
@@ -37,16 +39,10 @@ import { DataService } from '../data.service';
   `
 })
 export class CssClassesComponent {
-  rows: FullEmployee[] = [];
+  protected readonly rows = inject(DataService)
+    .load('100k.json')
+    .pipe(map(data => data.slice(0, 50)));
   expanded = {};
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('100k.json').subscribe(data => {
-      this.rows = data.splice(0, 50);
-    });
-  }
 
   getRowClass(row: FullEmployee) {
     return {

--- a/src/app/basic/dynamic-row-height.component.ts
+++ b/src/app/basic/dynamic-row-height.component.ts
@@ -1,12 +1,14 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { DataTableColumnDirective, DatatableComponent } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
 import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'dynamic-row-height-demo',
-  imports: [DatatableComponent, DataTableColumnDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -23,7 +25,7 @@ import { DataService } from '../data.service';
       <ngx-datatable
         class="material"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [headerHeight]="50"
         [footerHeight]="50"
         [rowHeight]="getRowHeight"
@@ -37,19 +39,15 @@ import { DataService } from '../data.service';
   `
 })
 export class DynamicRowHeightComponent {
-  rows: (FullEmployee & { height: number })[] = [];
+  protected readonly rows = inject(DataService)
+    .load('100k.json')
+    .pipe(
+      map(data =>
+        data.slice(0, 100).map(d => ({ ...d, height: Math.floor(Math.random() * 80) + 50 }))
+      )
+    );
   expanded = {};
   timeout: any;
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('100k.json').subscribe(data => {
-      this.rows = data
-        .splice(0, 100)
-        .map(d => ({ ...d, height: Math.floor(Math.random() * 80) + 50 }));
-    });
-  }
 
   getRowHeight(row: FullEmployee & { height: number }) {
     if (!row) {

--- a/src/app/basic/fixed-row-height.component.ts
+++ b/src/app/basic/fixed-row-height.component.ts
@@ -1,12 +1,12 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'fixed-row-height-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -23,7 +23,7 @@ import { DataService } from '../data.service';
       <ngx-datatable
         class="material striped"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [columns]="columns"
         [headerHeight]="50"
         [footerHeight]="50"
@@ -33,14 +33,6 @@ import { DataService } from '../data.service';
   `
 })
 export class FixedRowHeightComponent {
-  rows: Employee[] = [];
+  protected readonly rows = inject(DataService).load('company.json');
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender' }];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows = data;
-    });
-  }
 }

--- a/src/app/basic/footer-template.component.ts
+++ b/src/app/basic/footer-template.component.ts
@@ -1,3 +1,4 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import {
   DatatableComponent,
@@ -6,8 +7,8 @@ import {
   TableColumn,
   DatatablePagerComponent
 } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
@@ -16,7 +17,8 @@ import { DataService } from '../data.service';
     DatatableComponent,
     DatatableFooterDirective,
     DataTableFooterTemplateDirective,
-    DatatablePagerComponent
+    DatatablePagerComponent,
+    AsyncPipe
   ],
   template: `
     <div>
@@ -35,7 +37,7 @@ import { DataService } from '../data.service';
         class="material"
         rowHeight="auto"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [columns]="columns"
         [footerHeight]="100"
         [headerHeight]="50"
@@ -65,15 +67,9 @@ import { DataService } from '../data.service';
   `
 })
 export class FooterTemplateComponent {
-  rows: Employee[] = [];
+  protected readonly rows = inject(DataService)
+    .load('company.json')
+    .pipe(map(data => data.slice(0, 5)));
 
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Gender' }, { name: 'Company' }];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows = data.splice(0, 5);
-    });
-  }
 }

--- a/src/app/basic/full-screen.component.ts
+++ b/src/app/basic/full-screen.component.ts
@@ -1,12 +1,12 @@
-import { Component, inject, signal } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import { DataTableColumnDirective, DatatableComponent } from '@siemens/ngx-datatable';
 
-import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'full-screen-demo',
-  imports: [DatatableComponent, DataTableColumnDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -29,7 +29,7 @@ import { DataService } from '../data.service';
         [rowHeight]="50"
         [scrollbarV]="true"
         [scrollbarH]="true"
-        [rows]="rows()"
+        [rows]="rows | async"
       >
         <ngx-datatable-column name="Id" [width]="80" />
         <ngx-datatable-column name="Name" [width]="300" />
@@ -42,11 +42,5 @@ import { DataService } from '../data.service';
   `
 })
 export class FullScreenComponent {
-  readonly rows = signal<FullEmployee[]>([]);
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('100k.json').subscribe(data => this.rows.set(data));
-  }
+  protected readonly rows = inject(DataService).load('100k.json');
 }

--- a/src/app/basic/hidden-on-load.component.ts
+++ b/src/app/basic/hidden-on-load.component.ts
@@ -1,12 +1,12 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { DataTableColumnDirective, DatatableComponent } from '@siemens/ngx-datatable';
 
-import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'hidden-on-load-demo',
-  imports: [DatatableComponent, DataTableColumnDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -22,6 +22,7 @@ import { DataService } from '../data.service';
       </h3>
 
       <div style="width:75%;margin:0 auto">
+        @let rows = this.rows | async;
         <div>
           <button type="button" (click)="tab1 = true; tab2 = false; tab3 = false">Nothing</button>
           <button type="button" (click)="tab2 = true; tab1 = false; tab3 = false">Hidden</button>
@@ -72,17 +73,9 @@ import { DataService } from '../data.service';
   `
 })
 export class HiddenOnLoadComponent {
-  rows: FullEmployee[] = [];
+  protected readonly rows = inject(DataService).load('100k.json');
 
   tab1 = true;
   tab2 = false;
   tab3 = false;
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('100k.json').subscribe(data => {
-      this.rows = data;
-    });
-  }
 }

--- a/src/app/basic/horz-vert-scrolling.component.ts
+++ b/src/app/basic/horz-vert-scrolling.component.ts
@@ -1,12 +1,12 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { DataTableColumnDirective, DatatableComponent } from '@siemens/ngx-datatable';
 
-import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'horz-vert-scrolling-demo',
-  imports: [DatatableComponent, DataTableColumnDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -23,7 +23,7 @@ import { DataService } from '../data.service';
       <ngx-datatable
         class="material"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [headerHeight]="50"
         [footerHeight]="0"
         [rowHeight]="50"
@@ -40,13 +40,5 @@ import { DataService } from '../data.service';
   `
 })
 export class HorzVertScrollingComponent {
-  rows: FullEmployee[] = [];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('100k.json').subscribe(data => {
-      this.rows = data;
-    });
-  }
+  protected readonly rows = inject(DataService).load('100k.json');
 }

--- a/src/app/basic/responsive.component.ts
+++ b/src/app/basic/responsive.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, signal, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject, ViewChild, ViewEncapsulation } from '@angular/core';
 import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
@@ -21,7 +22,8 @@ import { DataService } from '../data.service';
     DatatableRowDetailTemplateDirective,
     DataTableColumnDirective,
     DataTableColumnCellDirective,
-    DataTableColumnHeaderDirective
+    DataTableColumnHeaderDirective,
+    AsyncPipe
   ],
   template: `
     <div>
@@ -36,7 +38,6 @@ import { DataService } from '../data.service';
           </a>
         </small>
       </h3>
-      @let rows = this.rows();
       <ngx-datatable
         #myTable
         class="material expandable"
@@ -45,7 +46,7 @@ import { DataService } from '../data.service';
         [footerHeight]="50"
         [rowHeight]="50"
         [scrollbarV]="true"
-        [rows]="rows"
+        [rows]="rows | async"
         (page)="onPage($event)"
       >
         <!-- Row Detail Template -->
@@ -136,15 +137,9 @@ import { DataService } from '../data.service';
 export class ResponsiveComponent {
   @ViewChild('myTable') table!: DatatableComponent<FullEmployee>;
 
-  readonly rows = signal<FullEmployee[]>([]);
+  readonly rows = inject(DataService).load('100k.json');
   expanded: any = {};
   timeout: any;
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('100k.json').subscribe(data => this.rows.set(data));
-  }
 
   onPage(event: PageEvent) {
     clearTimeout(this.timeout);

--- a/src/app/basic/row-detail.component.ts
+++ b/src/app/basic/row-detail.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, signal, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject, ViewChild, ViewEncapsulation } from '@angular/core';
 import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
@@ -19,7 +20,8 @@ import { DataService } from '../data.service';
     DatatableRowDetailDirective,
     DatatableRowDetailTemplateDirective,
     DataTableColumnDirective,
-    DataTableColumnCellDirective
+    DataTableColumnCellDirective,
+    AsyncPipe
   ],
   template: `
     <div>
@@ -39,7 +41,6 @@ import { DataService } from '../data.service';
           <a href="javascript:void(0)" (click)="table.rowDetail!.collapseAllRows()">Collapse All</a>
         </small>
       </h3>
-      @let rows = this.rows();
       <ngx-datatable
         #myTable
         class="material expandable"
@@ -48,7 +49,7 @@ import { DataService } from '../data.service';
         [footerHeight]="50"
         [rowHeight]="50"
         [scrollbarV]="true"
-        [rows]="rows"
+        [rows]="rows | async"
         (page)="onPage($event)"
       >
         <!-- Row Detail Template -->
@@ -110,15 +111,9 @@ import { DataService } from '../data.service';
 export class RowDetailComponent {
   @ViewChild('myTable') table!: DatatableComponent<FullEmployee>;
 
-  readonly rows = signal<FullEmployee[]>([]);
+  readonly rows = inject(DataService).load('100k.json');
   expanded: any = {};
   timeout: any;
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('100k.json').subscribe(data => this.rows.set(data));
-  }
 
   onPage(event: PageEvent) {
     clearTimeout(this.timeout);

--- a/src/app/columns/column-pinning.component.ts
+++ b/src/app/columns/column-pinning.component.ts
@@ -1,12 +1,12 @@
-import { Component, inject, signal } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import { DataTableColumnDirective, DatatableComponent } from '@siemens/ngx-datatable';
 
-import { FullEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'column-pinning-demo',
-  imports: [DatatableComponent, DataTableColumnDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -28,7 +28,7 @@ import { DataService } from '../data.service';
         [rowHeight]="50"
         [scrollbarV]="true"
         [scrollbarH]="true"
-        [rows]="rows()"
+        [rows]="rows | async"
       >
         <ngx-datatable-column name="Name" [width]="300" [frozenLeft]="true" />
         <ngx-datatable-column name="Gender" />
@@ -45,11 +45,5 @@ import { DataService } from '../data.service';
   `
 })
 export class ColumnPinningComponent {
-  readonly rows = signal<FullEmployee[]>([]);
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('100k.json').subscribe(data => this.rows.set(data));
-  }
+  protected readonly rows = inject(DataService).load('100k.json');
 }

--- a/src/app/columns/fixed-column.component.ts
+++ b/src/app/columns/fixed-column.component.ts
@@ -1,16 +1,17 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
   DatatableComponent
 } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'fixed-column-demo',
-  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -28,7 +29,7 @@ import { DataService } from '../data.service';
         class="material"
         rowHeight="auto"
         columnMode="standard"
-        [rows]="rows"
+        [rows]="rows | async"
         [headerHeight]="50"
         [footerHeight]="50"
       >
@@ -52,13 +53,7 @@ import { DataService } from '../data.service';
   `
 })
 export class FixedColumnComponent {
-  rows: Employee[] = [];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows = data.splice(0, 5);
-    });
-  }
+  protected readonly rows = inject(DataService)
+    .load('company.json')
+    .pipe(map(data => data.slice(0, 5)));
 }

--- a/src/app/columns/flex-column.component.ts
+++ b/src/app/columns/flex-column.component.ts
@@ -1,16 +1,17 @@
-import { Component, inject, signal } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
   DatatableComponent
 } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'flex-column-demo',
-  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -24,14 +25,13 @@ import { DataService } from '../data.service';
           </a>
         </small>
       </h3>
-      @let rows = this.rows();
       <ngx-datatable
         class="material"
         rowHeight="auto"
         columnMode="flex"
         [headerHeight]="50"
         [footerHeight]="50"
-        [rows]="rows"
+        [rows]="rows | async"
       >
         <ngx-datatable-column name="Name" [flexGrow]="3">
           <ng-template let-value="value" ngx-datatable-cell-template>
@@ -53,11 +53,7 @@ import { DataService } from '../data.service';
   `
 })
 export class FlexColumnComponent {
-  readonly rows = signal<Employee[]>([]);
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => this.rows.set(data.splice(0, 5)));
-  }
+  protected readonly rows = inject(DataService)
+    .load('company.json')
+    .pipe(map(data => data.slice(0, 5)));
 }

--- a/src/app/columns/force-column.component.ts
+++ b/src/app/columns/force-column.component.ts
@@ -1,16 +1,17 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
   DatatableComponent
 } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'force-column-demo',
-  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -30,7 +31,7 @@ import { DataService } from '../data.service';
         columnMode="force"
         [headerHeight]="50"
         [footerHeight]="50"
-        [rows]="rows"
+        [rows]="rows | async"
       >
         <ngx-datatable-column name="Name" [width]="100">
           <ng-template let-value="value" ngx-datatable-cell-template>
@@ -52,13 +53,7 @@ import { DataService } from '../data.service';
   `
 })
 export class ForceColumnComponent {
-  rows: Employee[] = [];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows = data.splice(0, 5);
-    });
-  }
+  protected readonly rows = inject(DataService)
+    .load('company.json')
+    .pipe(map(data => data.slice(0, 5)));
 }

--- a/src/app/paging/client-side-paging.component.ts
+++ b/src/app/paging/client-side-paging.component.ts
@@ -1,12 +1,12 @@
-import { Component, inject, signal } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import { DatatableComponent } from '@siemens/ngx-datatable';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'client-side-paging-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -20,12 +20,11 @@ import { DataService } from '../data.service';
           </a>
         </small>
       </h3>
-      @let rows = this.rows();
       <ngx-datatable
         class="material"
         rowHeight="auto"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [columns]="[{ name: 'Name' }, { name: 'Gender' }, { name: 'Company' }]"
         [headerHeight]="50"
         [footerHeight]="50"
@@ -35,11 +34,5 @@ import { DataService } from '../data.service';
   `
 })
 export class ClientSidePagingComponent {
-  readonly rows = signal<Employee[]>([]);
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => this.rows.set(data));
-  }
+  protected readonly rows = inject(DataService).load('company.json');
 }

--- a/src/app/selection/cell-selection.component.ts
+++ b/src/app/selection/cell-selection.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, signal } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   DatatableComponent,
@@ -11,7 +12,7 @@ import { DataService } from '../data.service';
 
 @Component({
   selector: 'cell-selection-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -25,12 +26,11 @@ import { DataService } from '../data.service';
           </a>
         </small>
       </h3>
-      @let rows = this.rows();
       <ngx-datatable
         class="material selection-cell"
         columnMode="force"
         selectionType="cell"
-        [rows]="rows"
+        [rows]="rows | async"
         [columns]="columns"
         [headerHeight]="50"
         [footerHeight]="50"
@@ -43,17 +43,9 @@ import { DataService } from '../data.service';
   `
 })
 export class CellSelectionComponent {
-  readonly rows = signal<Employee[]>([]);
+  readonly rows = inject(DataService).load('company.json');
   selected: Employee[] = [];
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender' }];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows.set(data);
-    });
-  }
 
   onSelect(event: SelectEvent<Employee>) {
     // eslint-disable-next-line no-console

--- a/src/app/selection/disable-selection-callback.component.ts
+++ b/src/app/selection/disable-selection-callback.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, signal } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   DatatableComponent,
@@ -11,7 +12,7 @@ import { DataService } from '../data.service';
 
 @Component({
   selector: 'disable-selection-callback-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -26,13 +27,12 @@ import { DataService } from '../data.service';
         </small>
       </h3>
       <div style="float:left;width:75%">
-        @let rows = this.rows();
         <ngx-datatable
           class="material selection-row"
           rowHeight="auto"
           columnMode="force"
           selectionType="multi"
-          [rows]="rows"
+          [rows]="rows | async"
           [columns]="columns"
           [headerHeight]="50"
           [footerHeight]="50"
@@ -60,17 +60,11 @@ import { DataService } from '../data.service';
   `
 })
 export class DisableSelectionCallbackComponent {
-  readonly rows = signal<Employee[]>([]);
+  readonly rows = inject(DataService).load('company.json');
 
   selected: Employee[] = [];
 
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender' }];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => this.rows.set(data));
-  }
 
   onSelect({ selected }: SelectEvent<Employee>) {
     this.selected.splice(0, this.selected.length);

--- a/src/app/selection/multi-click-row-selection.component.ts
+++ b/src/app/selection/multi-click-row-selection.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, signal } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import {
   ActivateEvent,
   DatatableComponent,
@@ -11,7 +12,7 @@ import { DataService } from '../data.service';
 
 @Component({
   selector: 'multi-click-row-selection-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -30,13 +31,12 @@ import { DataService } from '../data.service';
           <p>This demonstrates multi selection table, where any click event causes a selection.</p>
         </div>
 
-        @let rows = this.rows();
         <ngx-datatable
           class="material selection-row"
           rowHeight="auto"
           columnMode="force"
           selectionType="multiClick"
-          [rows]="rows"
+          [rows]="rows | async"
           [columns]="columns"
           [headerHeight]="50"
           [footerHeight]="50"
@@ -63,17 +63,11 @@ import { DataService } from '../data.service';
   `
 })
 export class MultiClickRowSelectionComponent {
-  readonly rows = signal<Employee[]>([]);
+  readonly rows = inject(DataService).load('company.json');
 
   selected: Employee[] = [];
 
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender' }];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => this.rows.set(data));
-  }
 
   onSelect({ selected }: SelectEvent<Employee>) {
     this.selected.splice(0, this.selected.length);

--- a/src/app/selection/multi-row-selection.component.ts
+++ b/src/app/selection/multi-row-selection.component.ts
@@ -1,3 +1,4 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject, signal } from '@angular/core';
 import { ActivateEvent, DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
 
@@ -6,7 +7,7 @@ import { DataService } from '../data.service';
 
 @Component({
   selector: 'multi-row-selection-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -33,7 +34,7 @@ import { DataService } from '../data.service';
           rowHeight="auto"
           columnMode="force"
           selectionType="multi"
-          [rows]="rows()"
+          [rows]="rows | async"
           [columns]="columns"
           [headerHeight]="50"
           [footerHeight]="50"
@@ -59,17 +60,11 @@ import { DataService } from '../data.service';
   `
 })
 export class MultiRowSelectionComponent {
-  readonly rows = signal<Employee[]>([]);
+  readonly rows = inject(DataService).load('company.json');
 
   readonly selected = signal<Employee[]>([]);
 
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender' }];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => this.rows.set(data));
-  }
 
   onActivate(event: ActivateEvent<Employee>) {
     // eslint-disable-next-line no-console

--- a/src/app/sorting/client-side-sorting.component.ts
+++ b/src/app/sorting/client-side-sorting.component.ts
@@ -1,12 +1,12 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'client-side-sorting-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -24,7 +24,7 @@ import { DataService } from '../data.service';
         class="material"
         columnMode="force"
         sortType="multi"
-        [rows]="rows"
+        [rows]="rows | async"
         [columns]="columns"
         [headerHeight]="50"
         [footerHeight]="50"
@@ -35,15 +35,7 @@ import { DataService } from '../data.service';
   `
 })
 export class ClientSideSortingComponent {
-  rows: Employee[] = [];
+  protected readonly rows = inject(DataService).load('company.json');
 
   columns: TableColumn[] = [{ name: 'Company' }, { name: 'Name' }, { name: 'Gender' }];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows = data;
-    });
-  }
 }

--- a/src/app/sorting/comparator.component.ts
+++ b/src/app/sorting/comparator.component.ts
@@ -1,12 +1,13 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'comparator-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -24,7 +25,7 @@ import { DataService } from '../data.service';
         class="material"
         rowHeight="auto"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [columns]="columns"
         [headerHeight]="50"
         [footerHeight]="50"
@@ -33,21 +34,15 @@ import { DataService } from '../data.service';
   `
 })
 export class ComparatorComponent {
-  rows: Employee[] = [];
+  protected readonly rows = inject(DataService)
+    .load('company.json')
+    .pipe(map(data => data.slice(0, 20)));
 
   columns: TableColumn[] = [
     { name: 'Company', comparator: this.companyComparator.bind(this) },
     { name: 'Name', sortable: false },
     { name: 'Gender', sortable: false }
   ];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows = data.splice(0, 20);
-    });
-  }
 
   companyComparator(propA: string, propB: string) {
     // Just a simple sort function comparisoins

--- a/src/app/sorting/default-sort.component.ts
+++ b/src/app/sorting/default-sort.component.ts
@@ -1,16 +1,16 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
   DatatableComponent
 } from '@siemens/ngx-datatable';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'default-sort-demo',
-  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -27,7 +27,7 @@ import { DataService } from '../data.service';
       <ngx-datatable
         class="material"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [headerHeight]="50"
         [footerHeight]="50"
         [rowHeight]="50"
@@ -52,14 +52,6 @@ import { DataService } from '../data.service';
     </div>
   `
 })
-export class DefaultSortComponent implements OnInit {
-  rows: Employee[] = [];
-
-  private dataService = inject(DataService);
-
-  ngOnInit() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows = data;
-    });
-  }
+export class DefaultSortComponent {
+  protected readonly rows = inject(DataService).load('company.json');
 }

--- a/src/app/summary/simple-summary.component.ts
+++ b/src/app/summary/simple-summary.component.ts
@@ -1,12 +1,13 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'simple-summary-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -46,14 +47,16 @@ import { DataService } from '../data.service';
         [columns]="columns"
         [headerHeight]="50"
         [summaryHeight]="55"
-        [rows]="rows"
+        [rows]="rows | async"
       />
     </div>
   `,
   styleUrl: './simple-summary.component.scss'
 })
 export class SimpleSummaryComponent {
-  rows: Employee[] = [];
+  protected readonly rows = inject(DataService)
+    .load('company.json')
+    .pipe(map(data => data.slice(0, 5)));
 
   columns: TableColumn[] = [
     { prop: 'name' },
@@ -63,14 +66,6 @@ export class SimpleSummaryComponent {
 
   enableSummary = true;
   summaryPosition = 'top';
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => {
-      this.rows = data.splice(0, 5);
-    });
-  }
 
   onPositionSelectChange($event: Event) {
     const target = $event.target as HTMLSelectElement;

--- a/src/app/templates/inline-template.component.ts
+++ b/src/app/templates/inline-template.component.ts
@@ -1,12 +1,13 @@
-import { Component, inject, signal } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
   DataTableColumnHeaderDirective,
   DatatableComponent
 } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
@@ -15,7 +16,8 @@ import { DataService } from '../data.service';
     DatatableComponent,
     DataTableColumnDirective,
     DataTableColumnHeaderDirective,
-    DataTableColumnCellDirective
+    DataTableColumnCellDirective,
+    AsyncPipe
   ],
   template: `
     <div>
@@ -30,12 +32,11 @@ import { DataService } from '../data.service';
           </a>
         </small>
       </h3>
-      @let rows = this.rows();
       <ngx-datatable
         class="material"
         rowHeight="auto"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [headerHeight]="50"
         [footerHeight]="50"
       >
@@ -68,12 +69,8 @@ import { DataService } from '../data.service';
   `
 })
 export class InlineTemplateComponent {
-  readonly rows = signal<Employee[]>([]);
+  protected readonly rows = inject(DataService)
+    .load('company.json')
+    .pipe(map(data => data.slice(0, 5)));
   joke = 'knock knock';
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => this.rows.set(data.splice(0, 5)));
-  }
 }

--- a/src/app/templates/template-ref.component.ts
+++ b/src/app/templates/template-ref.component.ts
@@ -1,12 +1,13 @@
-import { Component, inject, OnInit, signal, TemplateRef, ViewChild } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, inject, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
+import { map } from 'rxjs';
 
-import { Employee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'template-ref-demo',
-  imports: [DatatableComponent],
+  imports: [DatatableComponent, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -20,12 +21,11 @@ import { DataService } from '../data.service';
           </a>
         </small>
       </h3>
-      @let rows = this.rows();
       <ngx-datatable
         class="material"
         rowHeight="auto"
         columnMode="force"
-        [rows]="rows"
+        [rows]="rows | async"
         [columns]="columns"
         [headerHeight]="50"
         [footerHeight]="50"
@@ -50,14 +50,10 @@ export class TemplateRefComponent implements OnInit {
   @ViewChild('editTmpl', { static: true }) editTmpl!: TemplateRef<any>;
   @ViewChild('hdrTpl', { static: true }) hdrTpl!: TemplateRef<any>;
 
-  readonly rows = signal<Employee[]>([]);
+  readonly rows = inject(DataService)
+    .load('company.json')
+    .pipe(map(data => data.slice(0, 5)));
   columns: TableColumn[] = [];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company.json').subscribe(data => this.rows.set(data.splice(0, 5)));
-  }
 
   ngOnInit() {
     this.columns = [

--- a/src/app/tree/client-side-tree.component.ts
+++ b/src/app/tree/client-side-tree.component.ts
@@ -1,3 +1,4 @@
+import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import {
   DataTableColumnCellDirective,
@@ -5,12 +6,11 @@ import {
   DatatableComponent
 } from '@siemens/ngx-datatable';
 
-import { TreeEmployee } from '../data.model';
 import { DataService } from '../data.service';
 
 @Component({
   selector: 'client-side-tree-demo',
-  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective],
+  imports: [DatatableComponent, DataTableColumnDirective, DataTableColumnCellDirective, AsyncPipe],
   template: `
     <div>
       <h3>
@@ -32,7 +32,7 @@ import { DataService } from '../data.service';
         treeToRelation="name"
         [headerHeight]="50"
         [footerHeight]="50"
-        [rows]="rows"
+        [rows]="rows | async"
         (treeAction)="onTreeAction($event)"
       >
         <ngx-datatable-column name="Name" [flexGrow]="3" [isTreeColumn]="true">
@@ -56,13 +56,7 @@ import { DataService } from '../data.service';
   styles: ['.icon {height: 10px; width: 10px; }', '.disabled {opacity: 0.5; }']
 })
 export class ClientSideTreeComponent {
-  rows: TreeEmployee[] = [];
-
-  private dataService = inject(DataService);
-
-  constructor() {
-    this.dataService.load('company_tree.json').subscribe(data => (this.rows = data));
-  }
+  protected readonly rows = inject(DataService).load('company_tree.json');
 
   onTreeAction(event: any) {
     const row = event.row;


### PR DESCRIPTION
## Summary

Refactors the demo example components to use the `| async` pipe instead of manually subscribing in TypeScript. Each converted component now exposes a `rows` observable (via `inject(DataService).load(...)`) that the template consumes with `[rows]="rows | async"`.

## Changes

- Replaced manual `.subscribe()` + `signal`/`OnInit` boilerplate with `AsyncPipe` in 26 example components.
- Simple transforms now use `map(...)` from rxjs (e.g. `.pipe(map(data => data.slice(0, n)))`) instead of mutating arrays in subscribe callbacks.
- Removed now-unused `private dataService` fields and constructors.
- `hidden-on-load` shares a single subscription across its two tables via `@let rows = this.rows | async;`.

Components that read/mutate `rows` in TypeScript or have load-time side effects (loading indicators, deriving `selected`, etc.) were intentionally left untouched.

## Verification

- `ng build` passes (only the pre-existing NG8102 warning in `body.component.ts`).
- `eslint` and `prettier --check` clean.