### PR TITLE
docs(examples): use signals so rows render under zoneless change detection

### DIFF
--- a/src/app/basic/filtering.component.ts
+++ b/src/app/basic/filtering.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ViewChild } from '@angular/core';
+import { Component, inject, signal, ViewChild } from '@angular/core';
 import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
@@ -35,13 +35,13 @@ import { DataService } from '../data.service';
         [headerHeight]="50"
         [footerHeight]="50"
         [limit]="10"
-        [rows]="rows"
+        [rows]="rows()"
       />
     </div>
   `
 })
 export class FilteringComponent {
-  rows: Employee[] = [];
+  readonly rows = signal<Employee[]>([]);
 
   temp: Employee[] = [];
 
@@ -56,7 +56,7 @@ export class FilteringComponent {
       this.temp = [...data];
 
       // push our inital complete list
-      this.rows = data;
+      this.rows.set(data);
     });
   }
 
@@ -64,9 +64,11 @@ export class FilteringComponent {
     const val = (event.target as HTMLInputElement).value.toLowerCase();
 
     // filter our data and update the rows
-    this.rows = this.temp.filter(d => {
-      return d.name.toLowerCase().includes(val) || !val;
-    });
+    this.rows.set(
+      this.temp.filter(d => {
+        return d.name.toLowerCase().includes(val) || !val;
+      })
+    );
     // Whenever the filter changes, always go back to the first page
     this.table.offset.set(0);
   }

--- a/src/app/basic/row-grouping.component.ts
+++ b/src/app/basic/row-grouping.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ViewChild } from '@angular/core';
+import { Component, inject, signal, ViewChild } from '@angular/core';
 import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
@@ -40,7 +40,7 @@ import { DataService } from '../data.service';
         groupRowsBy="age"
         columnMode="force"
         selectionType="checkbox"
-        [rows]="rows"
+        [rows]="rows()"
         [scrollbarH]="true"
         [headerHeight]="50"
         [footerHeight]="50"
@@ -160,13 +160,13 @@ export class RowGroupingComponent {
   @ViewChild('myTable') table!: DatatableComponent<GroupedEmployee>;
 
   editing: Record<string, boolean> = {};
-  rows: GroupedEmployee[] = [];
+  readonly rows = signal<GroupedEmployee[]>([]);
 
   private dataService = inject(DataService);
 
   constructor() {
     this.dataService.load('forRowGrouping.json').subscribe(data => {
-      this.rows = data;
+      this.rows.set(data);
     });
   }
 
@@ -275,8 +275,15 @@ export class RowGroupingComponent {
 
   updateValue(event: Event, cell: 'comment', rowIndex: number) {
     this.editing[rowIndex + '-' + cell] = false;
-    this.rows[rowIndex][cell] = (event.target as HTMLInputElement).value;
-    this.rows = [...this.rows];
+    const value = (event.target as HTMLInputElement).value;
+    this.rows.update(currentRows => {
+      const updated = [...currentRows];
+      updated[rowIndex] = {
+        ...updated[rowIndex],
+        [cell]: value
+      };
+      return updated;
+    });
   }
 
   toggleExpandGroup(group: Group<GroupedEmployee>) {

--- a/src/app/summary/custom-template-summary.component.ts
+++ b/src/app/summary/custom-template-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component, computed, inject, OnInit, signal, TemplateRef, ViewChild } from '@angular/core';
 import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
@@ -27,11 +27,11 @@ import { DataService } from '../data.service';
         [columns]="columns"
         [headerHeight]="50"
         [summaryHeight]="55"
-        [rows]="rows"
+        [rows]="rows()"
       />
       <ng-template #nameSummaryCell let-row="row" let-value="value">
         <div class="name-container">
-          @for (name of getNames(); track name) {
+          @for (name of names(); track name) {
             <div class="chip">
               <span class="chip-content">{{ name }}</span>
             </div>
@@ -43,7 +43,13 @@ import { DataService } from '../data.service';
   styleUrl: './custom-template-summary.component.scss'
 })
 export class CustomTemplateSummaryComponent implements OnInit {
-  rows: Employee[] = [];
+  readonly rows = signal<Employee[]>([]);
+
+  readonly names = computed(() =>
+    this.rows()
+      .map(row => row.name)
+      .map(fullName => fullName.split(' ')[1])
+  );
 
   @ViewChild('nameSummaryCell') nameSummaryCell!: TemplateRef<any>;
 
@@ -53,7 +59,7 @@ export class CustomTemplateSummaryComponent implements OnInit {
 
   constructor() {
     this.dataService.load('company.json').subscribe(data => {
-      this.rows = data.splice(0, 5);
+      this.rows.set(data.splice(0, 5));
     });
   }
 
@@ -67,10 +73,6 @@ export class CustomTemplateSummaryComponent implements OnInit {
       { name: 'Gender', summaryFunc: cells => this.summaryForGender(cells) },
       { prop: 'age', summaryFunc: cells => this.avgAge(cells) }
     ];
-  }
-
-  getNames(): string[] {
-    return this.rows.map(row => row.name).map(fullName => fullName.split(' ')[1]);
   }
 
   private summaryForGender(cells: string[]) {

--- a/src/app/summary/inline-html-summary.component.ts
+++ b/src/app/summary/inline-html-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { DataTableColumnDirective, DatatableComponent } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
@@ -27,7 +27,7 @@ import { DataService } from '../data.service';
         [summaryPosition]="summaryPosition"
         [summaryHeight]="100"
         [headerHeight]="50"
-        [rows]="rows"
+        [rows]="rows()"
       >
         <ngx-datatable-column prop="name" [summaryTemplate]="nameSummaryCell" />
         <ngx-datatable-column name="Gender" [summaryFunc]="summaryForGender" />
@@ -35,7 +35,7 @@ import { DataService } from '../data.service';
       </ngx-datatable>
       <ng-template #nameSummaryCell>
         <div class="name-container">
-          @for (name of getNames(); track name) {
+          @for (name of names(); track name) {
             <div class="chip">
               <span class="chip-content">{{ name }}</span>
             </div>
@@ -46,7 +46,13 @@ import { DataService } from '../data.service';
   `
 })
 export class InlineHtmlSummaryComponent {
-  rows: Employee[] = [];
+  readonly rows = signal<Employee[]>([]);
+
+  readonly names = computed(() =>
+    this.rows()
+      .map(row => row.name)
+      .map(fullName => fullName.split(' ')[1])
+  );
 
   enableSummary = true;
   summaryPosition = 'top';
@@ -55,12 +61,8 @@ export class InlineHtmlSummaryComponent {
 
   constructor() {
     this.dataService.load('company.json').subscribe(data => {
-      this.rows = data.splice(0, 5);
+      this.rows.set(data.splice(0, 5));
     });
-  }
-
-  getNames(): string[] {
-    return this.rows.map(row => row.name).map(fullName => fullName.split(' ')[1]);
   }
 
   summaryForGender(cells: string[]) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Documentation/example fix

**What is the current behavior?** (You can also link to an open issue here)

Several demo examples fail to render their data under zoneless change detection (`provideZonelessChangeDetection()`). Assigning a plain class property inside an `HttpClient.subscribe()` callback no longer triggers change detection, so the affected tables show "No data to display". This also causes the corresponding e2e (Playwright) tests to fail.

A previous commit converted most examples away from manual `subscribe()` + plain property assignment, but four were missed:

- `filtering.component.ts`
- `row-grouping.component.ts`
- `custom-template-summary.component.ts`
- `inline-html-summary.component.ts`

**What is the new behavior?**

The `rows` of the four remaining examples are converted to signals (matching the existing `summary-row-actions` pattern), so the data renders correctly under zoneless change detection. All 33 e2e (Playwright) tests pass.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: This only touches example/demo components; no library code is changed.
