### PR TITLE
chore(ci): add OpenCode PR review workflow with deepseek

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,29 @@
+name: OpenCode Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@5d0f86606ac30690f79f0a6a9f41a1f49fe95d0b
+        env:
+          SIEMENS_API_KEY: ${{ secrets.SIEMENS_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: siemens/deepseek-v4-flash
+          use_github_token: true
+          prompt: |
+            Review this pull request.
+            Provide feedback as line-specific comments on the relevant code lines (using the review comment API).
+            Do NOT make any commits or changes. Only review and comment on specific lines.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "siemens": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "code.siemens.com",
+      "options": {
+        "baseURL": "https://api.siemens.com/llm/v1",
+        "apiKey": "{env:SIEMENS_API_KEY}"
+      },
+      "models": {
+        "deepseek-v4-flash": {
+          "limit": {
+            "context": 1048576,
+            "output": 1048576
+          },
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] CI related changes

**What is the new behavior?**

Adds automated code reviews based on opencode + the Siemens DeepSeek instance, modeled after #714 (which uses Qwen).

- Introduces `opencode.json` configuring the Siemens OpenAI-compatible provider and the `deepseek-v4-flash` model.
- Adds a GitHub Actions workflow that runs OpenCode on `pull_request` events and posts line-specific review comments.

**Does this PR introduce a breaking change?**

- [x] No