### PR TITLE
ci(stale): use correct label configuration

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,5 +18,5 @@ jobs:
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           stale-pr-message: 'This pr is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-pr-message: 'This pr was closed because it has been stalled for 7 days with no activity.'
-          any-of-labels: 'Need More Info,Needs Demo'
+          any-of-issue-labels: 'awaiting-feedback'
           operations-per-run: 300


### PR DESCRIPTION
See https://github.com/actions/stale#any-of-issue-labels.

With the current label configuration, this GitHub Actions workflow was basically a no-op. With the new config, we only mark issues `stale` if we wait for feedback (`await-feedback`) as an issue left open is otherwise treated as `acknowledged`. PRs should in general be marked as stale of open (not marked as draft) and not changed (e.g. rebased, commented on) if left open for longer than 60 days.

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The `stale` GitHub Action workflow didn't do anything.

**What is the new behavior?**

Issues and PRs are treated as stale according to our actual workflow.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
