### PR TITLE
refactor: lay out columns with a shared css-grid template

### DIFF
--- a/playwright/snapshots/e2e/selection.spec.ts-snapshots/multi-row-selection--using-shift-chromium-linux.png
+++ b/playwright/snapshots/e2e/selection.spec.ts-snapshots/multi-row-selection--using-shift-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f20bfbc3c0238ccee35322974a82456d69dea1027b919b9a8de2a7488d1a9bad
-size 43620
+oid sha256:0f21fbca5363821fa73a398d93047fa551a3e03824c9569db805e06f54c4931b
+size 43603

--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.spec.ts
@@ -59,20 +59,6 @@ describe('DataTableBodyCellComponent', () => {
     expect(cellText).toEqual('Hello');
   });
 
-  it('should have min width when column has minWidth', async () => {
-    const columns = toInternalColumn([{ name: 'Min Width Column', prop: 0, minWidth: 500 }]);
-    component.setInput('column', columns[0]);
-
-    expect(await harness.bodyCellWidth()).toBe(500);
-  });
-
-  it('should honour maxWidth when provided', async () => {
-    const columns = toInternalColumn([{ name: 'Min Width Column', prop: 0, maxWidth: 10 }]);
-    component.setInput('column', columns[0]);
-
-    expect(await harness.bodyCellWidth()).toBe(10);
-  });
-
   describe('checkboxable', () => {
     beforeEach(() => {
       component.setInput('row', { id: 1 });

--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -90,10 +90,6 @@ import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../util
     '[class]': 'columnCssClasses()',
     '[class.active]': 'isFocused() && !disabled()',
     '[class.row-disabled]': 'disabled()',
-    '[style.width.px]': 'column().width()',
-    '[style.minWidth.px]': 'column().minWidth',
-    '[style.maxWidth.px]': 'column().maxWidth',
-    '[style.height]': 'height()',
     '(focus)': 'onFocus()',
     '(blur)': 'onBlur()',
     '(click)': 'onClick($event)',
@@ -147,14 +143,6 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
       value: this.value(),
       rowHeight: this.rowHeight()
     });
-  });
-
-  protected readonly height = computed(() => {
-    const height = this.rowHeight();
-    if (isNaN(height)) {
-      return height;
-    }
-    return height + 'px';
   });
 
   protected readonly sanitizedValue = computed(() => {

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.scss
@@ -1,7 +1,9 @@
 @use '../shared';
 
 :host {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--ngx-datatable-grid-template-columns);
+  grid-template-rows: minmax(0, 1fr);
   outline: none;
 
   :host-context(ngx-datatable.fixed-row) & {
@@ -10,7 +12,9 @@
 }
 
 .datatable-row-group {
-  display: flex;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-template-rows: subgrid;
   position: relative;
 }
 

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.spec.ts
@@ -1,9 +1,10 @@
-import { Component, signal } from '@angular/core';
+import { Component, computed, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
 import { RowIndex } from '../../types/internal.types';
+import { columnsByPinArr, gridColumnTemplate } from '../../utils/column';
 import { toInternalColumn } from '../../utils/column-helper';
 import { DataTableBodyRowComponent } from './body-row.component';
 
@@ -11,20 +12,23 @@ describe('DataTableBodyRowComponent', () => {
   @Component({
     imports: [DataTableBodyRowComponent],
     template: `
-      <datatable-body-row
-        ariaRowCheckboxMessage=""
-        [cssClasses]="{}"
-        [rowHeight]="40"
-        [rowIndex]="rowIndex()"
-        [row]="row()"
-        [columns]="columns()"
-      />
+      <div [style.--ngx-datatable-grid-template-columns]="gridTemplate()">
+        <datatable-body-row
+          ariaRowCheckboxMessage=""
+          [cssClasses]="{}"
+          [rowHeight]="40"
+          [rowIndex]="rowIndex()"
+          [row]="row()"
+          [columns]="columns()"
+        />
+      </div>
     `
   })
   class TestHostComponent {
     readonly rowIndex = signal<RowIndex>({ index: 0 });
     readonly row = signal<any>({ prop: 'value' });
     readonly columns = signal(toInternalColumn([{ prop: 'prop' }]));
+    readonly gridTemplate = computed(() => gridColumnTemplate(columnsByPinArr(this.columns())));
   }
 
   let fixture: ComponentFixture<TestHostComponent>;
@@ -58,5 +62,21 @@ describe('DataTableBodyRowComponent', () => {
     component.rowIndex.set({ index: 666, indexInGroup: 3 });
     await fixture.whenStable();
     expect(element.classList).toContain('datatable-row-odd');
+  });
+
+  it('should enforce column minWidth via the shared grid track', async () => {
+    component.columns.set(toInternalColumn([{ prop: 'prop', width: 50, minWidth: 500 }]));
+    await fixture.whenStable();
+    const cell = fixture.debugElement.query(By.css('datatable-body-cell'))
+      .nativeElement as HTMLElement;
+    expect(cell.offsetWidth).toBe(500);
+  });
+
+  it('should enforce column maxWidth via the shared grid track', async () => {
+    component.columns.set(toInternalColumn([{ prop: 'prop', width: 50, maxWidth: 10 }]));
+    await fixture.whenStable();
+    const cell = fixture.debugElement.query(By.css('datatable-body-cell'))
+      .nativeElement as HTMLElement;
+    expect(cell.offsetWidth).toBe(10);
   });
 });

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -31,7 +31,7 @@ import { DataTableBodyCellComponent } from './body-cell.component';
         <div
           class="datatable-row-group"
           [class]="'datatable-row-' + colGroup.type"
-          [style.width.px]="_columnGroupWidths()[colGroup.type]"
+          [style.grid-column]="'span ' + colGroup.columns.length"
           [class.row-disabled]="disabled()"
         >
           @for (column of colGroup.columns; track column.$$id; let ii = $index) {

--- a/projects/ngx-datatable/src/lib/components/body/testing/body-cell.harness.ts
+++ b/projects/ngx-datatable/src/lib/components/body/testing/body-cell.harness.ts
@@ -45,10 +45,4 @@ export class BodyCellHarness extends ComponentHarness {
       await button.click();
     }
   }
-
-  async bodyCellWidth(): Promise<number> {
-    const cell = await this.host();
-    const width = await cell?.getProperty('offsetWidth');
-    return width ? Number(width) : 0;
-  }
 }

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -3,13 +3,9 @@
     datatableScrollContainer
     role="table"
     class="datatable-grid"
+    [style.--ngx-datatable-grid-template-columns]="_gridTemplateColumns()"
     [style.scroll-padding-block-start.px]="_isFixedHeader() ? headerHeight() : null"
   >
-    <!-- TODO: remove the explicit width.
-          This is a temporary solution which is needed to keep the current behavior if columns exceed their width.
-          This happens if padding + content is bigger than the defined width.
-          See the checkbox examples.
-    -->
     @if (headerHeight()) {
       <datatable-header
         role="rowgroup"
@@ -29,7 +25,6 @@
         [verticalScrollVisible]="verticalScrollVisible"
         [enableClearingSortState]="enableClearingSortState()"
         [ariaHeaderCheckboxMessage]="messages().ariaHeaderCheckboxMessage ?? 'Select all rows'"
-        [style.width.px]="totalColumnGroupWidths()"
         (sort)="onColumnSort($event)"
         (resize)="onColumnResize($event)"
         (resizing)="onColumnResizing($event)"
@@ -80,7 +75,6 @@
       [rowDragEvents]="rowDragEvents"
       [rowDefTemplate]="_rowDefTemplate()"
       [cssClasses]="cssClasses()"
-      [style.width.px]="totalColumnGroupWidths()"
       [(selected)]="selected"
       (page)="onBodyPage($event)"
       (activate)="activate.emit($event)"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -59,7 +59,12 @@ import {
   TreeStatus
 } from '../types/public.types';
 import { TableColumn } from '../types/table-column.type';
-import { columnGroupWidths, columnsByPin } from '../utils/column';
+import {
+  columnGroupWidths,
+  columnsByPin,
+  columnsByPinArr,
+  gridColumnTemplate
+} from '../utils/column';
 import { toInternalColumn, toPublicColumn } from '../utils/column-helper';
 import { adjustColumnWidths, forceFillColumnWidths } from '../utils/math';
 import { numberOrUndefinedAttribute } from '../utils/number-or-undefined-attribute';
@@ -687,6 +692,16 @@ export class DatatableComponent<TRow extends Row = any>
         : (this.columns() ?? []),
       this._defaultColumnWidth
     )
+  );
+
+  /**
+   * The shared `grid-template-columns` definition for the combined css-grid.
+   * It is exposed once as a custom property on the scroll container so the
+   * header and every body row align to the same column tracks via `var()`,
+   * instead of each row binding its own (identical) template string.
+   */
+  readonly _gridTemplateColumns = computed(() =>
+    gridColumnTemplate(columnsByPinArr(this._internalColumns()))
   );
 
   /**

--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -92,10 +92,7 @@ import { nextSortDir } from '../../utils/sort';
     '[class.resizeable]': 'showResizeHandle()',
     '[class.sort-active]': 'sortDir()',
     '[class.sort-asc]': 'sortDir() === "asc"',
-    '[class.sort-desc]': 'sortDir() === "desc"',
-    '[style.minWidth.px]': 'column().minWidth',
-    '[style.maxWidth.px]': 'column().maxWidth',
-    '[style.width.px]': 'column().width()'
+    '[class.sort-desc]': 'sortDir() === "desc"'
   }
 })
 export class DataTableHeaderCellComponent implements OnInit, OnDestroy {

--- a/projects/ngx-datatable/src/lib/components/header/header.component.scss
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.scss
@@ -9,8 +9,8 @@
 }
 
 .datatable-header-inner {
-  display: flex;
-  min-inline-size: max-content;
+  display: grid;
+  grid-template-columns: var(--ngx-datatable-grid-template-columns);
 
   :host-context(ngx-datatable.fixed-header) & {
     white-space: nowrap;
@@ -18,7 +18,8 @@
 }
 
 .datatable-row-group {
-  display: flex;
+  display: grid;
+  grid-template-columns: subgrid;
 }
 
 @include shared.pinned-columns();

--- a/projects/ngx-datatable/src/lib/components/header/header.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { vi } from 'vitest';
 
+import { columnsByPinArr, gridColumnTemplate } from '../../utils/column';
 import { toInternalColumn } from '../../utils/column-helper';
 import { DataTableHeaderComponent } from './header.component';
 import { HeaderHarness } from './testing/header.harness';
@@ -12,6 +13,14 @@ describe('DataTableHeaderComponent', () => {
   let fixture: ComponentFixture<DataTableHeaderComponent>;
   let componentRef: ComponentRef<DataTableHeaderComponent>;
   let harness: HeaderHarness;
+
+  const applyMockGridTemplate = (): void => {
+    fixture.nativeElement.style.width = 'max-content';
+    fixture.nativeElement.style.setProperty(
+      '--ngx-datatable-grid-template-columns',
+      gridColumnTemplate(columnsByPinArr(componentRef.instance.columns()))
+    );
+  };
 
   beforeEach(async () => {
     fixture = TestBed.createComponent(DataTableHeaderComponent);
@@ -50,6 +59,7 @@ describe('DataTableHeaderComponent', () => {
         { prop: 'col2', name: 'Column 2', width: 200 }
       ])
     );
+    applyMockGridTemplate();
     // there is setTimeout in columns setter so we need to wait for it
     vi.advanceTimersByTime(0);
     expect(await harness.getHeaderRowWidth()).toBeCloseTo(500);
@@ -89,6 +99,7 @@ describe('DataTableHeaderComponent', () => {
       const { column, newValue } = event;
       column.width.set(newValue);
       componentRef.setInput('columns', [...componentRef.instance.columns()]);
+      applyMockGridTemplate();
     });
 
     const initialWidth = await harness.getColumnWidth(0);

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -42,7 +42,11 @@ import { DataTableHeaderCellComponent } from './header-cell.component';
     >
       @for (colGroup of _columnsByPin(); track colGroup.type) {
         @if (colGroup.columns.length) {
-          <div class="datatable-row-group" [class]="'datatable-row-' + colGroup.type">
+          <div
+            class="datatable-row-group"
+            [class]="'datatable-row-' + colGroup.type"
+            [style.grid-column]="'span ' + colGroup.columns.length"
+          >
             @for (column of colGroup.columns; track column.$$id) {
               <datatable-header-cell
                 role="columnheader"

--- a/projects/ngx-datatable/src/lib/components/shared.scss
+++ b/projects/ngx-datatable/src/lib/components/shared.scss
@@ -16,6 +16,7 @@
 
 @mixin cell-styles() {
   overflow-x: hidden;
+  min-inline-size: 0;
   vertical-align: top;
   display: inline-block;
   line-height: 1.625;

--- a/projects/ngx-datatable/src/lib/utils/column.ts
+++ b/projects/ngx-datatable/src/lib/utils/column.ts
@@ -52,6 +52,38 @@ export const columnTotalWidth = (columns?: TableColumnInternal[]) => {
   return columns?.reduce((total, column) => total + column.width(), 0) ?? 0;
 };
 
+/**
+ * Builds the `grid-template-columns` value for the combined css-grid.
+ * Produces one track per column, sized by the column's current width, in the
+ * pinned render order (left, center, right). Header and body rows share this
+ * single definition so every cell aligns to the same column tracks.
+ *
+ * `minWidth`/`maxWidth` are baked into the track via `clamp()`/`min()`/`max()`
+ * so the constraints are enforced once on the shared grid instead of per cell.
+ */
+export const gridColumnTemplate = (cols: PinnedColumns[]): string => {
+  return cols
+    .flatMap(group => group.columns)
+    .map(column => gridColumnTrack(column))
+    .join(' ');
+};
+
+const gridColumnTrack = (column: TableColumnInternal): string => {
+  const width = `${column.width()}px`;
+  const min = column.minWidth ? `${column.minWidth}px` : undefined;
+  const max = column.maxWidth ? `${column.maxWidth}px` : undefined;
+  if (min && max) {
+    return `clamp(${min}, ${width}, ${max})`;
+  }
+  if (min) {
+    return `max(${min}, ${width})`;
+  }
+  if (max) {
+    return `min(${max}, ${width})`;
+  }
+  return width;
+};
+
 export const columnsByPinArr = (val: TableColumnInternal[]): PinnedColumns[] => {
   const colsByPin = columnsByPin(val);
   return [


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Layout refactor (flexbox → CSS grid) that carries a breaking column-sizing behavior change (and fixes a row-hover border glitch).

**What is the current behavior?**

Header and body rows are laid out with flexbox, and each cell sets its own inline `width`/`min-width`/`max-width` (and `height`). Because cells cannot shrink below their content, a column could grow beyond its configured `width` to fit content, pushing later columns. The fixed cell height also overflowed the row's bottom border (border-box), so the border was painted over on hover.

**What is the new behavior?**

Header and body cells are positioned by a single `grid-template-columns` definition, exposed as the `--ngx-datatable-grid-template-columns` custom property on the scroll container and consumed by every header/row grid (with subgrid pin groups). `minWidth`/`maxWidth` are baked into each track via `clamp()`/`min()`/`max()`. Cells no longer set their own inline width/height; they stretch to the grid row track, so the row's bottom border is preserved on hover.

**Main changes:**

- Add `gridColumnTemplate`/`gridColumnTrack` (`utils/column.ts`) building one track per column in `left, center, right` order.
- Compute `_gridTemplateColumns` once in `DatatableComponent` and bind it as the custom property on `.datatable-grid`.
- Lay out header-inner and body rows as `display: grid`; pin groups use `grid-column: span N` + `grid-template-columns/-rows: subgrid`.
- Remove per-cell width/height host bindings and the now-dead `_styleByGroup`/`calcStylesByGroup` + `NgStyle` usage in the header.
- Update unit specs/harness and regenerate the affected VRT baselines.

Verified: `npx ng test ngx-datatable-lib --watch=false` (191 passed, 1 skipped), `npx ng lint ngx-datatable-lib` (clean), `npx ng build ngx-datatable-lib` (clean), `npx playwright test` (33 passed, snapshots updated).

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

Columns are now held at their configured `width` and no longer grow to fit cell content: Overflowing content is clipped rather than widening the column (and pushing later columns) as it did before. Migration: Give columns that need more room an explicit `width`/`minWidth` (e.g. narrow checkbox columns).

**Other information**:

Column widths are driven internally by the `--ngx-datatable-grid-template-columns` custom property instead of flexbox + per-cell inline widths; custom styles that relied on the old flexbox structure or per-cell inline widths may need updating.