### PR TITLE
test: add flex mode column resize integration tests

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.spec.ts
@@ -416,6 +416,72 @@ describe('DatatableComponent', () => {
     await fixture.whenStable();
     expect(cellSizes()).toEqual([75, 125, 50, 50]);
   });
+
+  it('should distribute initial column widths by flexGrow in flex mode', async () => {
+    component.columns.set([
+      { prop: 'A', width: 100, flexGrow: 1 },
+      { prop: 'B', width: 100, flexGrow: 2 },
+      { prop: 'C', width: 100, flexGrow: 1 }
+    ]);
+    component.columnMode.set('flex');
+    await fixture.whenStable();
+    const headerCells = fixture.debugElement.queryAll(By.directive(DataTableHeaderCellComponent));
+    const cellSizes = () => headerCells.map(cell => cell.nativeElement.clientWidth);
+
+    // 400px split across flexGrow [1, 2, 1] => 100 / 200 / 100
+    expect(cellSizes()).toEqual([100, 200, 100]);
+  });
+
+  it('should redistribute remaining width across the other flex columns after a column resize', async () => {
+    component.columns.set([
+      { prop: 'A', width: 100, flexGrow: 1 },
+      { prop: 'B', width: 100, flexGrow: 2 },
+      { prop: 'C', width: 100, flexGrow: 1 }
+    ]);
+    component.columnMode.set('flex');
+    await fixture.whenStable();
+    const headerCells = fixture.debugElement.queryAll(By.directive(DataTableHeaderCellComponent));
+    const cellSizes = () => headerCells.map(cell => cell.nativeElement.clientWidth);
+
+    expect(cellSizes()).toEqual([100, 200, 100]);
+
+    // Resize the second column to 160. The resized column is pinned to its new
+    // width and the remaining 240px is split across A/C by flexGrow (1:1).
+    headerCells[1].triggerEventHandler('resize', {
+      width: 160,
+      column: headerCells[1].componentInstance.column()
+    });
+    await fixture.whenStable();
+    expect(cellSizes()).toEqual([120, 160, 120]);
+  });
+
+  it('should keep a manually resized column fixed while rescaling the rest on window resize in flex mode', async () => {
+    component.columns.set([
+      { prop: 'A', width: 100, flexGrow: 1 },
+      { prop: 'B', width: 100, flexGrow: 2 },
+      { prop: 'C', width: 100, flexGrow: 1 }
+    ]);
+    component.columnMode.set('flex');
+    await fixture.whenStable();
+    const headerCells = fixture.debugElement.queryAll(By.directive(DataTableHeaderCellComponent));
+    const cellSizes = () => headerCells.map(cell => cell.nativeElement.clientWidth);
+
+    headerCells[1].triggerEventHandler('resize', {
+      width: 160,
+      column: headerCells[1].componentInstance.column()
+    });
+    await fixture.whenStable();
+    expect(cellSizes()).toEqual([120, 160, 120]);
+
+    // Shrink the table to 280px. Unlike force mode, the manually resized
+    // column stays at 160px and only the flex columns rescale: the remaining
+    // 120px is split across A/C by flexGrow (1:1).
+    component.size.set(280);
+    await fixture.whenStable();
+    fixture.debugElement.query(By.directive(DatatableComponent)).componentInstance.recalculate();
+    await fixture.whenStable();
+    expect(cellSizes()).toEqual([60, 160, 60]);
+  });
 });
 
 describe('DatatableComponent with Tree', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Test coverage only (adds unit tests, no production code changes)

**What is the current behavior?** (You can also link to an open issue here)

Column resizing in **flex** mode is only covered at the `adjustColumnWidths` math-function level. Force mode has a full integration test in `datatable.component.spec.ts`, but there is no equivalent integration test that drives a real resize event through a `columnMode = 'flex'` table.

**What is the new behavior?**

Adds integration-level unit tests for flex-mode column resizing in `datatable.component.spec.ts`, mirroring the existing force-mode test. The new tests drive the real event flow (`resize` event → `onColumnResize` → `recalculateColumns` → `adjustColumnWidths`) and assert on rendered `clientWidth`:

- **Initial flex distribution** — 400px split across `flexGrow [1, 2, 1]` → `[100, 200, 100]`.
- **Redistribution after a column resize** — resizing column B to 160px pins it and splits the remaining 240px across A/C → `[120, 160, 120]`.
- **Window resize after a manual resize** — captures the key flex-vs-force difference: the manually resized column stays fixed (`canAutoResize: false`) while the flex columns rescale → shrinking to 280px gives `[60, 160, 60]`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

- `ng test ngx-datatable-lib --watch=false` → 194 passed (1 pre-existing skip)
- `prettier --check` passes