### PR TITLE
refactor: drop redundant widths

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.ts
@@ -17,11 +17,7 @@ import { DatatableGroupHeaderDirective } from './body-group-header.directive';
   template: `
     @let groupHeader = this.groupHeader();
     @if (groupHeader && groupHeader.template()) {
-      <div
-        class="datatable-group-header"
-        [style.height.px]="groupHeaderRowHeight()"
-        [style.width.px]="innerWidth()"
-      >
+      <div class="datatable-group-header" [style.height.px]="groupHeaderRowHeight()">
         <div class="datatable-group-cell">
           @if (groupHeader.checkboxable()) {
             <div>
@@ -55,7 +51,6 @@ import { DatatableGroupHeaderDirective } from './body-group-header.directive';
   }
 })
 export class DataTableGroupWrapperComponent<TRow extends Row = any> {
-  readonly innerWidth = input.required<number>();
   readonly groupHeader = input.required<DatatableGroupHeaderDirective | undefined>();
   readonly groupHeaderRowHeight = input.required<number>();
   readonly group = input.required<Group<TRow>>();

--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
@@ -36,7 +36,6 @@ import { DatatableRowDetailDirective } from '../row-detail/row-detail.directive'
   }
 })
 export class DataTableRowWrapperComponent<TRow extends Row = any> implements DoCheck {
-  readonly innerWidth = input.required<number>();
   readonly rowDetail = input<DatatableRowDetailDirective>();
   readonly detailRowHeightFn = input.required<(row?: TRow, index?: number) => number>();
   readonly row = input.required<TRow>();

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -1,17 +1,16 @@
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   DoCheck,
   ElementRef,
-  HostBinding,
   HostListener,
   inject,
+  input,
   KeyValueDiffer,
   KeyValueDiffers,
-  input,
-  booleanAttribute,
-  computed,
   output
 } from '@angular/core';
 
@@ -97,11 +96,6 @@ export class DataTableBodyRowComponent<TRow extends Row = any> implements DoChec
   });
 
   readonly rowHeight = input.required<number>();
-
-  @HostBinding('style.width.px')
-  get columnsTotalWidths(): number {
-    return this._columnGroupWidths().total;
-  }
 
   readonly activate = output<ActivateEvent<TRow>>();
   readonly treeAction = output<void>();

--- a/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -39,7 +39,6 @@ describe('DataTableBodyComponent', () => {
     });
     fixture = TestBed.createComponent(DataTableBodyComponent);
     fixture.componentRef.setInput('rowDragEvents', new EventEmitter<any>());
-    fixture.componentRef.setInput('innerWidth', 400);
     fixture.componentRef.setInput('rowIdentity', (row: any) => row);
     fixture.componentRef.setInput('summaryPosition', 'top');
     fixture.componentRef.setInput('summaryHeight', 50);

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -39,7 +39,6 @@ import {
   SelectionType
 } from '../../types/public.types';
 import { TableColumn } from '../../types/table-column.type';
-import { columnGroupWidths, columnsByPin } from '../../utils/column';
 import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../utils/keys';
 import { RowHeightCache } from '../../utils/row-height-cache';
 import { selectRows, selectRowsBetween } from '../../utils/selection';
@@ -77,7 +76,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
     }
     @let scrollbarV = this.scrollbarV();
     @let columns = this.columns();
-    @let columnGroupWidths = this.columnGroupWidths();
     @let bodyHeight = this._bodyHeight();
     @let rows = this.rows();
     @let rowCount = this.rowCount();
@@ -95,15 +93,12 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
         [scrollbarV]="scrollbarV"
         [scrollbarH]="scrollbarH()"
         [scrollHeight]="scrollHeight()"
-        [scrollWidth]="columnGroupWidths.total"
-        [class.horizontal-overflow]="innerWidth() < columnGroupWidths.total"
         (scroll)="onBodyScroll($event)"
       >
         @if ((summaryRow() || summaryRowTemplate()) && summaryPosition() === 'top') {
           <datatable-summary-row
             [class.sticky]="summaryRowTemplate()"
             [rowHeight]="summaryHeight()"
-            [innerWidth]="innerWidth()"
             [rows]="rows"
             [columns]="columns"
             [template]="summaryRowTemplate()"
@@ -124,7 +119,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
                 ? true
                 : null
             "
-            [innerWidth]="innerWidth()"
             [rowDetail]="rowDetail()"
             [detailRowHeightFn]="detailRowHeightFn()"
             [row]="row"
@@ -205,8 +199,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
                       ? true
                       : null
                   "
-                  [innerWidth]="innerWidth()"
-                  [style.width]="groupedRows() ? columnGroupWidths.total : undefined"
                   [groupHeader]="groupHeader()"
                   [groupHeaderRowHeight]="getGroupHeaderRowHeight(group, i)"
                   [disabled]="disabled"
@@ -238,7 +230,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
       @if ((summaryRow() || summaryRowTemplate()) && summaryPosition() === 'bottom') {
         <datatable-summary-row
           [rowHeight]="summaryHeight()"
-          [innerWidth]="innerWidth()"
           [rows]="rows"
           [columns]="columns"
           [template]="summaryRowTemplate()"
@@ -250,7 +241,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
         [scrollbarV]="scrollbarV"
         [scrollbarH]="scrollbarH()"
         [scrollHeight]="scrollHeight()"
-        [style.width]="scrollbarH() ? columnGroupWidths?.total + 'px' : '100%'"
         (scroll)="onBodyScroll($event)"
       >
         <ng-content select="[empty-content]" />
@@ -287,7 +277,6 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   // TODO: Find a better way to handle default expansion state with signal input
   // eslint-disable-next-line @angular-eslint/prefer-signals
   @Input() groupExpansionDefault?: boolean;
-  readonly innerWidth = input.required<number>();
   readonly virtualization = input<boolean>();
   readonly summaryRow = input<boolean>();
   readonly summaryPosition = input.required<string>();
@@ -361,10 +350,6 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   readonly rowHeightsCache = computed(() => this.computeRowHeightsCache());
   readonly offsetY = signal(0);
   readonly indexes = computed(() => this.computeIndexes());
-  readonly columnGroupWidths = computed(() => {
-    const colsByPin = columnsByPin(this.columns());
-    return columnGroupWidths(colsByPin, this.columns());
-  });
   rowTrackingFn: TrackByFunction<RowOrGroup<TRow> | undefined>;
   destroyRef = inject(DestroyRef);
   readonly rowExpansions = signal<TRow[]>([]);

--- a/projects/ngx-datatable/src/lib/components/body/scroller.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/scroller.component.ts
@@ -24,8 +24,7 @@ export interface ScrollEventInternal {
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'datatable-scroll',
-    '[style.height.px]': 'scrollHeight()',
-    '[style.width.px]': 'scrollWidth()'
+    '[style.height.px]': 'scrollHeight()'
   }
 })
 export class ScrollerComponent implements OnInit, OnDestroy {
@@ -38,7 +37,6 @@ export class ScrollerComponent implements OnInit, OnDestroy {
     transform: booleanAttribute
   });
   readonly scrollHeight = input<number>();
-  readonly scrollWidth = input<number>();
 
   readonly scroll = output<ScrollEventInternal>();
 

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
@@ -30,7 +30,6 @@ describe('DataTableSummaryRowComponent', () => {
     fixture.componentRef.setInput('columns', columns);
     fixture.componentRef.setInput('rows', rows);
     fixture.componentRef.setInput('rowHeight', 30);
-    fixture.componentRef.setInput('innerWidth', 100);
 
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SummaryHarness);
     componentRef = fixture.componentRef;
@@ -159,13 +158,7 @@ describe('DataTableSummaryRowComponent', () => {
 @Component({
   imports: [DataTableSummaryRowComponent],
   template: `
-    <datatable-summary-row
-      [rows]="rows"
-      [columns]="columns"
-      [rowHeight]="30"
-      [innerWidth]="100"
-      [template]="tpl()"
-    />
+    <datatable-summary-row [rows]="rows" [columns]="columns" [rowHeight]="30" [template]="tpl()" />
     <ng-template #summaryTpl>
       <span class="custom-content">Custom summary content</span>
     </ng-template>

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
@@ -57,7 +57,6 @@ export class DataTableSummaryRowComponent {
   readonly columns = input.required<TableColumnInternal[]>();
 
   readonly rowHeight = input.required<number>();
-  readonly innerWidth = input.required<number>();
   readonly template = input<TemplateRef<void>>();
 
   protected readonly _internalColumns = computed(() => {

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -5,13 +5,17 @@
     class="datatable-grid"
     [style.scroll-padding-block-start.px]="_isFixedHeader() ? headerHeight() : null"
   >
+    <!-- TODO: remove the explicit width.
+          This is a temporary solution which is needed to keep the current behavior if columns exceed their width.
+          This happens if padding + content is bigger than the defined width.
+          See the checkbox examples.
+    -->
     @if (headerHeight()) {
       <datatable-header
         role="rowgroup"
         [sorts]="sorts()"
         [sortType]="sortType()"
         [scrollbarH]="scrollbarH()"
-        [innerWidth]="_innerWidth()"
         [dealsWithGroup]="_internalGroupedRows() !== undefined"
         [columns]="_internalColumns()"
         [headerHeight]="headerHeight()"
@@ -25,6 +29,7 @@
         [verticalScrollVisible]="verticalScrollVisible"
         [enableClearingSortState]="enableClearingSortState()"
         [ariaHeaderCheckboxMessage]="messages().ariaHeaderCheckboxMessage ?? 'Select all rows'"
+        [style.width.px]="totalColumnGroupWidths()"
         (sort)="onColumnSort($event)"
         (resize)="onColumnResize($event)"
         (resizing)="onColumnResizing($event)"
@@ -54,7 +59,6 @@
       [offsetX]="_offsetX"
       [rowDetail]="rowDetail"
       [groupHeader]="groupHeader"
-      [innerWidth]="_innerWidth()"
       [bodyHeight]="bodyHeight()"
       [selectionType]="selectionType()"
       [rowIdentity]="rowIdentity()"
@@ -76,6 +80,7 @@
       [rowDragEvents]="rowDragEvents"
       [rowDefTemplate]="_rowDefTemplate()"
       [cssClasses]="cssClasses()"
+      [style.width.px]="totalColumnGroupWidths()"
       [(selected)]="selected"
       (page)="onBodyPage($event)"
       (activate)="activate.emit($event)"

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -59,6 +59,7 @@ import {
   TreeStatus
 } from '../types/public.types';
 import { TableColumn } from '../types/table-column.type';
+import { columnGroupWidths, columnsByPin } from '../utils/column';
 import { toInternalColumn, toPublicColumn } from '../utils/column-helper';
 import { adjustColumnWidths, forceFillColumnWidths } from '../utils/math';
 import { numberOrUndefinedAttribute } from '../utils/number-or-undefined-attribute';
@@ -108,7 +109,8 @@ import { DatatableRowDetailDirective } from './row-detail/row-detail.directive';
     '[class.cell-selection]': 'selectionType() === "cell"',
     '[class.single-selection]': 'selectionType() === "single"',
     '[class.multi-selection]': 'selectionType() === "multi"',
-    '[class.multi-click-selection]': 'selectionType() === "multiClick"'
+    '[class.multi-click-selection]': 'selectionType() === "multiClick"',
+    '[class.horizontal-overflow]': '_innerWidth() < totalColumnGroupWidths()'
   }
 })
 export class DatatableComponent<TRow extends Row = any>
@@ -696,6 +698,11 @@ export class DatatableComponent<TRow extends Row = any>
     const rowCount = this.rowCount();
     const pageSize = this.pageSize();
     return Math.max(Math.min(offset, Math.ceil(rowCount / pageSize) - 1), 0);
+  });
+
+  readonly totalColumnGroupWidths = computed(() => {
+    const colsByPin = columnsByPin(this._internalColumns());
+    return columnGroupWidths(colsByPin, this._internalColumns()).total;
   });
 
   _subscriptions: Subscription[] = [];

--- a/projects/ngx-datatable/src/lib/components/header/header.component.scss
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.scss
@@ -10,6 +10,7 @@
 
 .datatable-header-inner {
   display: flex;
+  min-inline-size: max-content;
 
   :host-context(ngx-datatable.fixed-header) & {
     white-space: nowrap;

--- a/projects/ngx-datatable/src/lib/components/header/header.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.spec.ts
@@ -16,7 +16,6 @@ describe('DataTableHeaderComponent', () => {
   beforeEach(async () => {
     fixture = TestBed.createComponent(DataTableHeaderComponent);
     fixture.componentRef.setInput('columns', []);
-    fixture.componentRef.setInput('innerWidth', 200);
     fixture.componentRef.setInput('sorts', []);
     fixture.componentRef.setInput('sortType', 'single');
     fixture.componentRef.setInput('headerHeight', 50);
@@ -248,26 +247,5 @@ describe('DataTableHeaderComponent', () => {
     expect(await harness.getColumnName(0)).toBe('Column 2');
     expect(await harness.getColumnName(1)).toBe('Column 1');
     expect(await harness.getColumnName(2)).toBe('Column 3');
-  });
-
-  it('should not apply translateX to center group (scroll sync via native scrollLeft)', async () => {
-    componentRef.setInput(
-      'columns',
-      toInternalColumn([
-        { prop: 'col1', name: 'Column 1', width: 100, frozenLeft: true },
-        { prop: 'col2', name: 'Column 2', width: 200 },
-        { prop: 'col3', name: 'Column 3', width: 150 },
-        { prop: 'col4', name: 'Column 4', width: 200, frozenRight: true }
-      ])
-    );
-
-    const leftGroupStyle = await harness.getTransformStyle('left');
-    expect(leftGroupStyle).toBe('width: 100px;');
-
-    const centerGroupStyle = await harness.getTransformStyle('center');
-    expect(centerGroupStyle).toBe('width: 350px;');
-
-    const rightGroupStyle = await harness.getTransformStyle('right');
-    expect(rightGroupStyle).toBe('width: 200px;');
   });
 });

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -1,11 +1,10 @@
-import { NgStyle } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
-  TemplateRef,
-  input,
   computed,
-  output
+  input,
+  output,
+  TemplateRef
 } from '@angular/core';
 
 import { DatatableDraggableDirective } from '../../directives/datatable-draggable.directive';
@@ -26,31 +25,24 @@ import {
   SortPropDir,
   SortType
 } from '../../types/public.types';
-import { columnGroupWidths, columnsByPin, columnsByPinArr } from '../../utils/column';
+import { columnsByPinArr } from '../../utils/column';
 import { toPublicColumn } from '../../utils/column-helper';
 import { DataTableHeaderCellComponent } from './header-cell.component';
 
 @Component({
   selector: 'datatable-header',
-  imports: [OrderableDirective, NgStyle, DataTableHeaderCellComponent, DatatableDraggableDirective],
+  imports: [OrderableDirective, DataTableHeaderCellComponent, DatatableDraggableDirective],
   template: `
-    @let _columnGroupWidths = this._columnGroupWidths();
     <div
       role="row"
       orderable
       class="datatable-header-inner"
-      [class.horizontal-overflow]="innerWidth() < _columnGroupWidths.total"
-      [style.width.px]="_columnGroupWidths.total"
       (reorder)="onColumnReordered($event)"
       (targetChanged)="onTargetChanged($event)"
     >
       @for (colGroup of _columnsByPin(); track colGroup.type) {
         @if (colGroup.columns.length) {
-          <div
-            class="datatable-row-group"
-            [class]="'datatable-row-' + colGroup.type"
-            [ngStyle]="_styleByGroup()[colGroup.type]"
-          >
+          <div class="datatable-row-group" [class]="'datatable-row-' + colGroup.type">
             @for (column of colGroup.columns; track column.$$id) {
               <datatable-header-cell
                 role="columnheader"
@@ -100,7 +92,6 @@ export class DataTableHeaderComponent {
   readonly dealsWithGroup = input<boolean>();
   readonly targetMarkerTemplate = input<TemplateRef<unknown>>();
   readonly enableClearingSortState = input(false);
-  readonly innerWidth = input.required<number>();
   readonly sorts = input.required<SortPropDir[]>();
   readonly sortType = input.required<SortType>();
   readonly allRowsSelected = input<boolean>();
@@ -124,17 +115,6 @@ export class DataTableHeaderComponent {
 
   readonly _columnsByPin = computed(() => {
     return columnsByPinArr(this.columns());
-  });
-  readonly _columnGroupWidths = computed(() => {
-    const colsByPin = columnsByPin(this.columns());
-    return columnGroupWidths(colsByPin, this.columns());
-  });
-  readonly _styleByGroup = computed(() => {
-    return {
-      left: this.calcStylesByGroup('left'),
-      center: this.calcStylesByGroup('center'),
-      right: this.calcStylesByGroup('right')
-    };
   });
 
   onColumnResized({ width, column }: { width: number; column: TableColumnInternal }): void {
@@ -244,13 +224,5 @@ export class DataTableHeaderComponent {
     }
 
     return sorts;
-  }
-
-  calcStylesByGroup(group: 'center' | 'right' | 'left'): NgStyle['ngStyle'] {
-    const widths = this._columnGroupWidths();
-
-    return {
-      width: `${widths[group]}px`
-    };
   }
 }

--- a/projects/ngx-datatable/src/lib/themes/material.scss
+++ b/projects/ngx-datatable/src/lib/themes/material.scss
@@ -209,9 +209,9 @@ $datatable-ghost-cell-animation-duration: 10s;
   /**
 	 * Global Row Styles
 	 */
-  .datatable-header,
-  .datatable-body {
-    .horizontal-overflow {
+  &.horizontal-overflow {
+    .datatable-header,
+    .datatable-body {
       .datatable-row-left {
         background-color: $ngx-datatable-background;
         background-position: 100% 0;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently, the width of the table (which is measured on the outside width) is re applied on all inner elements.

**What is the new behavior?**

This commit removes all those reassignments.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

The class `horizontal-overflow` is now applied on the `ngx-datatable` element. It was previously applied separately within the header and body.

The class indicates that a horizontal scrollbar is visible.

**Other information**:

This PR currently has a workaround which will be solved in a follow-up.
