### PR TITLE
docs(examples): widen checkbox column to prevent overflow

### DIFF
--- a/playwright/snapshots/e2e/selection.spec.ts-snapshots/checkbox-selection--checkbox-selection-all-checked-chromium-linux.png
+++ b/playwright/snapshots/e2e/selection.spec.ts-snapshots/checkbox-selection--checkbox-selection-all-checked-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f521cc052bd6f72712408077ffdf76a2c789925b972b65d82dfebff34d0232c
-size 42950
+oid sha256:0547ace9625b5238602eecdb79be67fa685b134cf0fd807a187edd873f3c3dd0
+size 43611

--- a/playwright/snapshots/e2e/selection.spec.ts-snapshots/checkbox-selection--checkbox-selection-uncheck-chromium-linux.png
+++ b/playwright/snapshots/e2e/selection.spec.ts-snapshots/checkbox-selection--checkbox-selection-uncheck-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9bf20664684f733bb0796ace6bc9197dce403c4c1ff1fce4ed1ce56d40f9d22
-size 39164
+oid sha256:3c7196a6924456ae7991c01b65bfd053bdcaf21857d0b00d3501bf90430c96cd
+size 39738

--- a/playwright/snapshots/e2e/selection.spec.ts-snapshots/multi-click-and-checkbox-selection--backward-navigation-shift-tab-space-chromium-linux.png
+++ b/playwright/snapshots/e2e/selection.spec.ts-snapshots/multi-click-and-checkbox-selection--backward-navigation-shift-tab-space-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef6a96659126b76cc61c9acde0ebe49a8d1df714c43ac1b8ad676e43933f759b
-size 40022
+oid sha256:449544b9f26868d4ddeb46caa7bce438c01c33ca1f76c358f67e1007fd7d359b
+size 40455

--- a/playwright/snapshots/e2e/selection.spec.ts-snapshots/multi-click-and-checkbox-selection--navigation-using-tab-and-space-chromium-linux.png
+++ b/playwright/snapshots/e2e/selection.spec.ts-snapshots/multi-click-and-checkbox-selection--navigation-using-tab-and-space-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3fc2430a50557cc0564589286ae7806f654ceddb9a8244d274013c3fad43d8a9
-size 42111
+oid sha256:7e8c3bcf3a7169b8a711c940bfea7445ec1d3dce93b22456b8be2484b995b1f7
+size 42543

--- a/playwright/snapshots/e2e/summary-row.spec.ts-snapshots/summary-row-actions--summary-row-actions-chromium-linux.png
+++ b/playwright/snapshots/e2e/summary-row.spec.ts-snapshots/summary-row-actions--summary-row-actions-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a288fd998c5d382390cc872d4fb87b5521624e459b9c353ff11159d5b0a782b0
-size 47102
+oid sha256:bf5764ca1bb68f5dda3a5c2b05c160574211b4ae972f3c28c5d0b655be00e6c5
+size 47514

--- a/src/app/selection/checkbox-selection.component.ts
+++ b/src/app/selection/checkbox-selection.component.ts
@@ -49,7 +49,7 @@ import { DataService } from '../data.service';
           (select)="onSelect($event)"
         >
           <ngx-datatable-column
-            [width]="30"
+            [width]="40"
             [sortable]="false"
             [canAutoResize]="false"
             [draggable]="false"

--- a/src/app/selection/custom-checkbox-selection.component.ts
+++ b/src/app/selection/custom-checkbox-selection.component.ts
@@ -54,7 +54,7 @@ import { DataService } from '../data.service';
           (select)="onSelect($event)"
         >
           <ngx-datatable-column
-            [width]="30"
+            [width]="40"
             [sortable]="false"
             [canAutoResize]="false"
             [draggable]="false"

--- a/src/app/selection/multi-click-and-checkbox-selection.component.ts
+++ b/src/app/selection/multi-click-and-checkbox-selection.component.ts
@@ -50,7 +50,7 @@ import { DataService } from '../data.service';
           (select)="onSelect($event)"
         >
           <ngx-datatable-column
-            [width]="30"
+            [width]="40"
             [sortable]="false"
             [canAutoResize]="false"
             [draggable]="false"

--- a/src/app/summary/summary-row-actions.component.ts
+++ b/src/app/summary/summary-row-actions.component.ts
@@ -50,7 +50,7 @@ import { DataService } from '../data.service';
           </ng-template>
         }
         <ngx-datatable-column
-          [width]="30"
+          [width]="40"
           [sortable]="false"
           [canAutoResize]="false"
           [draggable]="false"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Documentation/example fix

**What is the current behavior?**

The checkbox column in the selection and summary-row examples is set to `width: 30`, but renders at `~38px`. Because cells use `box-sizing: border-box` and the theme applies `1.2rem` horizontal padding, the cell cannot be narrower than its padding, so the column exceeds its configured size.

**What is the new behavior?**

The checkbox column width is set to `40` in the affected examples, which is above the padding floor, so the column keeps its size and stays flat.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

**Other information**:

Only affects example components and their VRT snapshots.