### PR TITLE
refactor: remove deprecated `sort` output

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -479,28 +479,6 @@ export class DatatableComponent<TRow extends Row = any>
   readonly select = output<SelectEvent<TRow>>();
 
   /**
-   * Column sort was invoked.
-   * @deprecated Use two-way binding on `sorts` instead.
-   *
-   * Before:
-   * ```html
-   * <ngx-datatable [sorts]="mySorts" (sort)="onSort($event)"></ngx-datatable>
-   * ```
-   *
-   * After:
-   * ```html
-   * <ngx-datatable [sorts]="mySorts" (sortsChange)="onSort({sorts: $event})"></ngx-datatable>
-   * <!-- or -->
-   * <ngx-datatable [(sorts)]="mySorts"></ngx-datatable>
-   * ```
-   *
-   * When using `(sort)`/`(sortsChange)` and `(page)` together (typically for server-side paging),
-   * subscribe only to `(page)` and read {@link PageEvent.sorts} from the event payload instead.
-   * `(page)` emits on both page and sort changes.
-   */
-  readonly sort = output<SortEvent>();
-
-  /**
    * The table was paged either triggered by the pager or the body scroll.
    */
   readonly page = output<PageEvent>();
@@ -1090,7 +1068,6 @@ export class DatatableComponent<TRow extends Row = any>
       offset: this.correctedOffset(),
       sorts: this.sorts()
     });
-    this.sort.emit(event);
   }
 
   /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`sort`  is deprecated.


**What is the new behavior?**

`sort`  is removed.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

The DatatableComponent `(sort)` output has been removed. Use `(sortsChange)` or two-way `[(sorts)]` binding instead. For server-side paging, subscribe to `(page)` and read `PageEvent.sorts`; page emits for both page and sort changes.

Before:
```html
<ngx-datatable [sorts]="mySorts" (sort)="onSort($event)"></ngx-datatable>
```

After:
```html
<ngx-datatable [sorts]="mySorts" (sortsChange)="onSort({sorts: $event})"></ngx-datatable>
<!-- or -->
<ngx-datatable [(sorts)]="mySorts"></ngx-datatable>
```

**Other information**:
