### PR TITLE
refactor: remove deprecated select output

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -79,7 +79,6 @@
       (page)="onBodyPage($event)"
       (activate)="activate.emit($event)"
       (rowContextmenu)="onRowContextmenu($event)"
-      (selectedChange)="onBodySelect($event)"
       (scroll)="onBodyScroll($event)"
       (treeAction)="onTreeAction($event)"
     >

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -51,7 +51,6 @@ import {
   RowOrGroup,
   ScrollEvent,
   ScrollToRowOptions,
-  SelectEvent,
   SelectionType,
   SortEvent,
   SortPropDir,
@@ -459,24 +458,6 @@ export class DatatableComponent<TRow extends Row = any>
    * A cell or row was focused via keyboard or mouse click.
    */
   readonly activate = output<ActivateEvent<TRow>>();
-
-  /**
-   * A cell or row was selected.
-   * @deprecated Use two-way binding on `selected` instead.
-   *
-   * Before:
-   * ```html
-   * <ngx-datatable [selected]="mySelection" (select)="onSelect($event)"></ngx-datatable>
-   * ```
-   *
-   * After:
-   * ```html
-   * <ngx-datatable [selected]="mySelection" (selectedChange)="onSelect({selected: $event})"></ngx-datatable>
-   * <!-- or -->
-   * <ngx-datatable [(selected)]="mySelection"></ngx-datatable>
-   * ```
-   */
-  readonly select = output<SelectEvent<TRow>>();
 
   /**
    * The table was paged either triggered by the pager or the body scroll.
@@ -916,9 +897,6 @@ export class DatatableComponent<TRow extends Row = any>
 
     if (this.selectAllRowsOnPage()) {
       this.selected.set([]);
-      this.select.emit({
-        selected: this.selected()
-      });
     }
   }
 
@@ -1050,9 +1028,6 @@ export class DatatableComponent<TRow extends Row = any>
     // clean selected rows
     if (this.selectAllRowsOnPage()) {
       this.selected.set([]);
-      this.select.emit({
-        selected: this.selected()
-      });
     }
 
     this.sorts.set(event.sorts);
@@ -1108,17 +1083,6 @@ export class DatatableComponent<TRow extends Row = any>
         this.selected.set([]);
       }
     }
-
-    this.select.emit({
-      selected: this.selected()
-    });
-  }
-
-  /**
-   * A row was selected from body
-   */
-  onBodySelect(selected: TRow[]): void {
-    this.select.emit({ selected });
   }
 
   /**

--- a/projects/ngx-datatable/src/lib/types/public.types.ts
+++ b/projects/ngx-datatable/src/lib/types/public.types.ts
@@ -239,11 +239,6 @@ export const SelectionType = {
 
 export type SelectionType = (typeof SelectionType)[keyof typeof SelectionType];
 
-/** @deprecated. Use two-way binding instead. See {@link DatatableComponent.select} */
-export interface SelectEvent<TRow> {
-  selected: TRow[];
-}
-
 export interface ContextMenuEventBody<TRow> {
   event: MouseEvent;
   type: 'body';

--- a/src/app/selection/cell-selection.component.ts
+++ b/src/app/selection/cell-selection.component.ts
@@ -1,11 +1,6 @@
 import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import {
-  ActivateEvent,
-  DatatableComponent,
-  SelectEvent,
-  TableColumn
-} from '@siemens/ngx-datatable';
+import { ActivateEvent, DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
@@ -36,7 +31,7 @@ import { DataService } from '../data.service';
         [footerHeight]="50"
         [rowHeight]="50"
         [selected]="selected"
-        (select)="onSelect($event)"
+        (selectedChange)="onSelect($event)"
         (activate)="onActivate($event)"
       />
     </div>
@@ -47,7 +42,7 @@ export class CellSelectionComponent {
   selected: Employee[] = [];
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender' }];
 
-  onSelect(event: SelectEvent<Employee>) {
+  onSelect(event: Employee[]) {
     // eslint-disable-next-line no-console
     console.log('Event: select', event, this.selected);
   }

--- a/src/app/selection/checkbox-selection.component.ts
+++ b/src/app/selection/checkbox-selection.component.ts
@@ -2,8 +2,7 @@ import { Component, inject, signal } from '@angular/core';
 import {
   ActivateEvent,
   DataTableColumnDirective,
-  DatatableComponent,
-  SelectEvent
+  DatatableComponent
 } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
@@ -46,7 +45,7 @@ import { DataService } from '../data.service';
           [selectAllRowsOnPage]="false"
           [displayCheck]="displayCheck"
           (activate)="onActivate($event)"
-          (select)="onSelect($event)"
+          (selectedChange)="onSelect($event)"
         >
           <ngx-datatable-column
             [width]="40"
@@ -89,7 +88,7 @@ export class CheckboxSelectionComponent {
     this.dataService.load('company.json').subscribe(data => this.rows.set(data));
   }
 
-  onSelect({ selected }: SelectEvent<Employee>) {
+  onSelect(selected: Employee[]) {
     this.selected.splice(0, this.selected.length);
     this.selected.push(...selected);
   }

--- a/src/app/selection/custom-checkbox-selection.component.ts
+++ b/src/app/selection/custom-checkbox-selection.component.ts
@@ -4,8 +4,7 @@ import {
   DataTableColumnCellDirective,
   DataTableColumnDirective,
   DataTableColumnHeaderDirective,
-  DatatableComponent,
-  SelectEvent
+  DatatableComponent
 } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
@@ -51,7 +50,7 @@ import { DataService } from '../data.service';
           [limit]="5"
           [selected]="selected"
           (activate)="onActivate($event)"
-          (select)="onSelect($event)"
+          (selectedChange)="onSelect($event)"
         >
           <ngx-datatable-column
             [width]="40"
@@ -108,7 +107,7 @@ export class CustomCheckboxSelectionComponent {
     this.dataService.load('company.json').subscribe(data => this.rows.set(data));
   }
 
-  onSelect({ selected }: SelectEvent<Employee>) {
+  onSelect(selected: Employee[]) {
     this.selected.splice(0, this.selected.length);
     this.selected.push(...selected);
   }

--- a/src/app/selection/disable-selection-callback.component.ts
+++ b/src/app/selection/disable-selection-callback.component.ts
@@ -1,11 +1,6 @@
 import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import {
-  ActivateEvent,
-  DatatableComponent,
-  SelectEvent,
-  TableColumn
-} from '@siemens/ngx-datatable';
+import { ActivateEvent, DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
@@ -40,7 +35,7 @@ import { DataService } from '../data.service';
           [selectCheck]="checkSelectable"
           [selected]="selected"
           (activate)="onActivate($event)"
-          (select)="onSelect($event)"
+          (selectedChange)="onSelect($event)"
         />
       </div>
 
@@ -66,7 +61,7 @@ export class DisableSelectionCallbackComponent {
 
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender' }];
 
-  onSelect({ selected }: SelectEvent<Employee>) {
+  onSelect(selected: Employee[]) {
     this.selected.splice(0, this.selected.length);
     this.selected.push(...selected);
   }

--- a/src/app/selection/multi-click-and-checkbox-selection.component.ts
+++ b/src/app/selection/multi-click-and-checkbox-selection.component.ts
@@ -2,8 +2,7 @@ import { Component, inject, signal } from '@angular/core';
 import {
   ActivateEvent,
   DataTableColumnDirective,
-  DatatableComponent,
-  SelectEvent
+  DatatableComponent
 } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
@@ -47,7 +46,7 @@ import { DataService } from '../data.service';
           [displayCheck]="allowSelection"
           [selectCheck]="allowSelection"
           (activate)="onActivate($event)"
-          (select)="onSelect($event)"
+          (selectedChange)="onSelect($event)"
         >
           <ngx-datatable-column
             [width]="40"
@@ -90,7 +89,7 @@ export class MultiClickAndCheckboxSelectionComponent {
     this.dataService.load('company.json').subscribe(data => this.rows.set(data));
   }
 
-  onSelect({ selected }: SelectEvent<Employee>) {
+  onSelect(selected: Employee[]) {
     this.selected.splice(0, this.selected.length);
     this.selected.push(...selected);
   }

--- a/src/app/selection/multi-click-row-selection.component.ts
+++ b/src/app/selection/multi-click-row-selection.component.ts
@@ -1,11 +1,6 @@
 import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import {
-  ActivateEvent,
-  DatatableComponent,
-  SelectEvent,
-  TableColumn
-} from '@siemens/ngx-datatable';
+import { ActivateEvent, DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
 import { DataService } from '../data.service';
@@ -43,7 +38,7 @@ import { DataService } from '../data.service';
           [limit]="5"
           [selected]="selected"
           (activate)="onActivate($event)"
-          (select)="onSelect($event)"
+          (selectedChange)="onSelect($event)"
         />
       </div>
 
@@ -69,7 +64,7 @@ export class MultiClickRowSelectionComponent {
 
   columns: TableColumn[] = [{ prop: 'name' }, { name: 'Company' }, { name: 'Gender' }];
 
-  onSelect({ selected }: SelectEvent<Employee>) {
+  onSelect(selected: Employee[]) {
     this.selected.splice(0, this.selected.length);
     this.selected.push(...selected);
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`select` is deprecated.

**What is the new behavior?**

`select` is removed.

**Does this PR introduce a breaking change?** (check one with "x")

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

The DatatableComponent `(select)` output has been removed.

Use `(selectedChange)` with the selected array, or two-way `[(selected)]` binding instead.

Before:
```html
<ngx-datatable [selected]="mySelection" (select)="onSelect($event)"></ngx-datatable>
```

After:
```html
<ngx-datatable [selected]="mySelection" (selectedChange)="onSelect({selected: $event})"></ngx-datatable>
<!-- or -->
<ngx-datatable [(selected)]="mySelection"></ngx-datatable>
```


**Other information**:
