### PR TITLE
chore(deps): remove angular animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "ngx-datatable",
       "version": "26.2.1",
       "dependencies": {
-        "@angular/animations": "22.0.7",
         "@angular/cdk": "22.0.5",
         "@angular/common": "22.0.7",
         "@angular/compiler": "22.0.7",
@@ -511,22 +510,6 @@
         "@typescript-eslint/utils": "^8.0.0",
         "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-22.0.7.tgz",
-      "integrity": "sha512-Q9PS2SYyvY4/K90GGy4+F0X7X7YmEfzKOw3eGgJ+6MnpVFo2kII2WK/bI5spr3PWNrn/TvNNNqP//c8BNX2Lbg==",
-      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "22.0.7"
       }
     },
     "node_modules/@angular/build": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "22.0.7",
     "@angular/cdk": "22.0.5",
     "@angular/common": "22.0.7",
     "@angular/compiler": "22.0.7",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The root project declares `@angular/animations` despite having no imports or animation-provider usage.

**What is the new behavior?**

The unused `@angular/animations` dependency and its root lockfile entry are removed.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Verified with `npm run build:lib:prod`.