### PR TITLE
refactor: avoid API Extractor self import

### DIFF
--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -29,7 +29,12 @@ import {
 import { Subscription } from 'rxjs';
 
 import { ScrollContainerDirective } from '../directives/scroll-container.directive';
-import { NGX_DATATABLE_CONFIG, NgxDatatableConfig } from '../ngx-datatable.config';
+import {
+  NGX_DATATABLE_CONFIG,
+  NgxDatatableConfig,
+  NgxDatatableCssClasses,
+  NgxDatatableMessages
+} from '../ngx-datatable.config';
 import { ScrollbarHelper } from '../services/scrollbar-helper.service';
 import {
   ColumnResizeEventInternal,
@@ -300,7 +305,7 @@ export class DatatableComponent<TRow extends Row = any>
   /**
    * Css class overrides
    */
-  readonly cssClasses = input<Partial<Required<NgxDatatableConfig>['cssClasses']>>(
+  readonly cssClasses = input<Partial<NgxDatatableCssClasses>>(
     this.configuration?.cssClasses ?? {}
   );
 
@@ -324,9 +329,7 @@ export class DatatableComponent<TRow extends Row = any>
    * }
    * ```
    */
-  readonly messages = input<Partial<Required<NgxDatatableConfig>['messages']>>(
-    this.configuration?.messages ?? {}
-  );
+  readonly messages = input<Partial<NgxDatatableMessages>>(this.configuration?.messages ?? {});
 
   /**
    * A function which is called with the row and should return either:


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`DatatableComponent` derives its public `cssClasses` and `messages` input types through `NgxDatatableConfig`. Angular then emits a self-import of `@siemens/ngx-datatable` in the declaration bundle. Under the workspace TypeScript path mapping, that import resolves to `public-api.ts` and pulls normal source files into API Extractor analysis.

**What is the new behavior?**

The inputs directly reference `NgxDatatableCssClasses` and `NgxDatatableMessages`. Angular emits local declaration references instead of a self-import, keeping the generated declaration bundle independent of the workspace package path mapping.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The public input types and API Extractor configuration are unchanged.