### PR TITLE
docs: align API JSDoc

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-def.component.ts
@@ -17,9 +17,18 @@ import {
 import { RowOrGroup } from '../../types/public.types';
 
 /**
- * This component is passed as ng-template and rendered by BodyComponent.
- * BodyComponent uses rowDefInternal to first inject actual row template.
- * This component will render that actual row template.
+ * Renders the datatable's normal row inside a custom row wrapper declared with
+ * {@link DatatableRowDefDirective}. Use this as the root content of the
+ * `ng-template` and apply row-level directives or classes to it.
+ *
+ * @example
+ * ```html
+ * <ngx-datatable>
+ *   <ng-template rowDef>
+ *     <datatable-row-def appCustomRowDirective class="custom-row" />
+ *   </ng-template>
+ * </ngx-datatable>
+ * ```
  */
 @Component({
   selector: 'datatable-row-def',
@@ -72,6 +81,22 @@ export class DatatableRowDefComponent {
   }
 }
 
+/**
+ * Marks an `ng-template` as the custom wrapper for each rendered table row.
+ *
+ * The template must contain a {@link DatatableRowDefComponent}, which renders
+ * the table's regular row inside the wrapper. Apply row-level directives or
+ * classes to that component.
+ *
+ * @example
+ * ```html
+ * <ngx-datatable>
+ *   <ng-template rowDef>
+ *     <datatable-row-def appCustomRowDirective class="custom-row" />
+ *   </ng-template>
+ * </ngx-datatable>
+ * ```
+ */
 @Directive({
   selector: '[rowDef]'
 })

--- a/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/columns/column.directive.ts
@@ -21,44 +21,118 @@ import { DataTableColumnCellTreeToggle } from './tree.directive';
   selector: 'ngx-datatable-column'
 })
 export class DataTableColumnDirective<TRow extends Row> {
+  /**
+   * Column label. When omitted, the property value is used and decamelized.
+   */
   readonly name = input<string>();
+
+  /**
+   * Property used to bind row values. When omitted, the name is converted to camel case.
+   */
   readonly prop = input<TableColumnProp>();
+
   readonly bindAsUnsafeHtml = input(false, { transform: booleanAttribute });
+
+  /**
+   * Whether the column is frozen to the left. Default value: `false`.
+   */
   readonly frozenLeft = input(false, { transform: booleanAttribute });
+
+  /**
+   * Whether the column is frozen to the right. Default value: `false`.
+   */
   readonly frozenRight = input(false, { transform: booleanAttribute });
+
+  /**
+   * Grow factor relative to other columns. Available extra width is distributed
+   * proportionally according to all columns' `flexGrow` values. Default value: `0`.
+   */
   readonly flexGrow = input<number, number | string | undefined>(undefined, {
     transform: numberAttribute
   });
+
+  /**
+   * Whether the user can manually resize the column. Default value: `true`.
+   */
   readonly resizeable = input<boolean, boolean | string | undefined>(undefined, {
     transform: booleanAttribute
   });
+
+  /**
+   * Custom client-side sort comparator. It receives cell values and their
+   * respective rows; a standard two-argument comparison function is also supported.
+   */
   readonly comparator = input<
     ((valueA: any, valueB: any, rowA: TRow, rowB: TRow) => number) | undefined
   >();
+
+  /**
+   * Custom pipe used to transform cell values.
+   */
   readonly pipe = input<PipeTransform | undefined>();
+
+  /**
+   * Whether row values can be sorted by this column. Default value: `true`.
+   */
   readonly sortable = input<boolean, boolean | string | undefined>(undefined, {
     transform: booleanAttribute
   });
+
+  /**
+   * Whether the column can be dragged to reorder it. Default value: `true`.
+   */
   readonly draggable = input<boolean, boolean | string | undefined>(undefined, {
     transform: booleanAttribute
   });
+
+  /**
+   * Whether the column can automatically resize to fill extra space. Default value: `true`.
+   */
   readonly canAutoResize = input<boolean, boolean | string | undefined>(undefined, {
     transform: booleanAttribute
   });
+
+  /**
+   * Minimum column width in pixels.
+   */
   readonly minWidth = input<number, number | string | undefined>(undefined, {
     transform: numberAttribute
   });
+
+  /**
+   * Default column width in pixels. Default value: `150`.
+   */
   readonly width = input<number, number | string | undefined>(undefined, {
     transform: numberAttribute
   });
+
+  /**
+   * Maximum column width in pixels.
+   */
   readonly maxWidth = input<number, number | string | undefined>(undefined, {
     transform: numberAttribute
   });
+
+  /**
+   * Whether the column displays a selection checkbox. Only applies when selection mode is `checkbox`.
+   */
   readonly checkboxable = input(false, { transform: booleanAttribute });
+
+  /**
+   * Whether the header displays a selection checkbox. Only applies when selection mode is `checkbox`.
+   */
   readonly headerCheckboxable = input(false, { transform: booleanAttribute });
+
+  /**
+   * CSS classes to apply to the header cell.
+   */
   readonly headerClass = input<
     string | ((data: { column: TableColumn }) => string | Record<string, boolean>) | undefined
   >();
+
+  /**
+   * CSS classes to apply to the body cell.
+   */
   readonly cellClass = input<
     | string
     | ((data: {
@@ -75,11 +149,17 @@ export class DataTableColumnDirective<TRow extends Row> {
   readonly summaryFunc = input<((cells: any[]) => any) | undefined>();
   readonly summaryTemplate = input<TemplateRef<any> | undefined>();
 
+  /**
+   * Template used to render body cells.
+   */
   readonly cellTemplateInput = input<TemplateRef<CellContext<TRow>> | undefined>(undefined, {
     alias: 'cellTemplate'
   });
   readonly cellTemplateQuery = contentChild(DataTableColumnCellDirective, { read: TemplateRef });
 
+  /**
+   * Template used to render header cells.
+   */
   readonly headerTemplateInput = input<TemplateRef<HeaderCellContext> | undefined>(undefined, {
     alias: 'headerTemplate'
   });

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -194,16 +194,17 @@ export class DatatableComponent<TRow extends Row = any>
   readonly scrollbarH = input(false, { transform: booleanAttribute });
 
   /**
-   * The row height; which is necessary
-   * to calculate the height for the lazy rendering.
+   * Height of each row. When virtual scrolling is disabled, use `'auto'` for
+   * fluid heights. With virtual scrolling enabled, provide a number or a
+   * function that calculates each row's height.
    */
   readonly rowHeight = input<number | 'auto' | ((row: TRow) => number)>(
     this.configuration?.rowHeight ?? 30
   );
 
   /**
-   * Type of column width distribution formula.
-   * Example: flex, force, standard
+   * Column width distribution mode. `standard` uses configured widths, `flex`
+   * uses the flex-grow algorithm, and `force` distributes space proportionally.
    */
   readonly columnMode = input<ColumnMode | keyof typeof ColumnMode>('standard');
 
@@ -292,7 +293,8 @@ export class DatatableComponent<TRow extends Row = any>
   readonly swapColumns = input(true, { transform: booleanAttribute });
 
   /**
-   * The type of sorting
+   * Sorting mode. In `single` mode, sorting a new column replaces existing
+   * sorts; in `multi` mode, it adds an additional column sort.
    */
   readonly sortType = input<SortType>('single');
 
@@ -303,7 +305,7 @@ export class DatatableComponent<TRow extends Row = any>
   readonly sorts = model<SortPropDir[]>([]);
 
   /**
-   * Css class overrides
+   * CSS class overrides for sort and pager icons.
    */
   readonly cssClasses = input<Partial<NgxDatatableCssClasses>>(
     this.configuration?.cssClasses ?? {}

--- a/projects/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
+++ b/projects/ngx-datatable/src/lib/components/row-detail/row-detail.directive.ts
@@ -13,6 +13,9 @@ export class DatatableRowDetailDirective<TRow extends Row = any> {
    */
   readonly rowHeight = input<number | ((row?: TRow, index?: number) => number)>(0);
 
+  /**
+   * Template used to render the detail row.
+   */
   readonly _templateInput = input<TemplateRef<RowDetailContext<TRow>>>(undefined, {
     alias: 'template'
   });

--- a/projects/ngx-datatable/src/lib/types/table-column.type.ts
+++ b/projects/ngx-datatable/src/lib/types/table-column.type.ts
@@ -14,84 +14,81 @@ export type TableColumnProp = string | number;
  */
 export interface TableColumn<TRow extends Row = any> {
   /**
-   * Determines if column is checkbox
+   * Whether the column displays a selection checkbox. Only applies when selection mode is `checkbox`.
    */
   checkboxable?: boolean;
 
   /**
-   * Determines if the column is frozen to the left
+   * Whether the column is frozen to the left. Default value: `false`.
    */
   frozenLeft?: boolean;
 
   /**
-   * Determines if the column is frozen to the right
+   * Whether the column is frozen to the right. Default value: `false`.
    */
   frozenRight?: boolean;
 
   /**
-   * The grow factor relative to other columns. Same as the flex-grow
-   * API from http =//www.w3.org/TR/css3-flexbox/. Basically;
-   * take any available extra width and distribute it proportionally
-   * according to all columns' flexGrow values.
+   * Grow factor relative to other columns. Available extra width is distributed
+   * proportionally according to all columns' `flexGrow` values. Default value: `0`.
    */
   flexGrow?: number;
 
   /**
-   * Min width of the column
+   * Minimum column width in pixels.
    */
   minWidth?: number;
 
   /**
-   * Max width of the column
+   * Maximum column width in pixels.
    */
   maxWidth?: number;
 
   /**
-   * The default width of the column, in pixels
+   * Default column width in pixels. Default value: `150`.
    */
   width?: number;
 
   /**
-   * Can the column be resized
+   * Whether the user can manually resize the column. Default value: `true`.
    */
   resizeable?: boolean;
 
   /**
-   * Custom sort comparator
+   * Custom client-side sort comparator. It receives cell values and their
+   * respective rows; a standard two-argument comparison function is also supported.
    */
   comparator?: (valueA: any, valueB: any, rowA: TRow, rowB: TRow) => number;
 
   /**
-   * Custom pipe transforms
+   * Custom pipe used to transform cell values.
    */
   pipe?: PipeTransform;
 
   /**
-   * Can the column be sorted
+   * Whether row values can be sorted by this column. Default value: `true`.
    */
   sortable?: boolean;
 
   /**
-   * Can the column be re-arranged by dragging
+   * Whether the column can be dragged to reorder it. Default value: `true`.
    */
   draggable?: boolean;
 
   /**
-   * Whether the column can automatically resize to fill space in the table.
+   * Whether the column can automatically resize to fill extra space. Default value: `true`.
    */
   canAutoResize?: boolean;
 
   /**
-   * Column name or label
+   * Column label. When omitted, the property value is used and decamelized.
    */
   name?: string;
 
   /**
-   * Property to bind to the row. Example:
+   * Property used to bind row values. It can be a nested property path or a numeric index.
    *
-   * `someField` or `some.field.nested`, 0 (numeric)
-   *
-   * If left blank, will use the name as camel case conversion
+   * When omitted, the name is converted to camel case.
    */
   prop?: TableColumnProp;
 
@@ -104,7 +101,7 @@ export interface TableColumn<TRow extends Row = any> {
   bindAsUnsafeHtml?: boolean;
 
   /**
-   * Cell template ref
+   * Template used to render body cells.
    */
   cellTemplate?: TemplateRef<CellContext<TRow>>;
 
@@ -114,7 +111,7 @@ export interface TableColumn<TRow extends Row = any> {
   ghostCellTemplate?: TemplateRef<any>;
 
   /**
-   * Header template ref
+   * Template used to render header cells.
    */
   headerTemplate?: TemplateRef<HeaderCellContext>;
 
@@ -124,7 +121,7 @@ export interface TableColumn<TRow extends Row = any> {
   treeToggleTemplate?: any;
 
   /**
-   * CSS Classes for the cell
+   * CSS classes to apply to the body cell.
    */
   cellClass?:
     | string
@@ -137,12 +134,12 @@ export interface TableColumn<TRow extends Row = any> {
       }) => string | Record<string, boolean>);
 
   /**
-   * CSS classes for the header
+   * CSS classes to apply to the header cell.
    */
   headerClass?: string | ((data: { column: TableColumn }) => string | Record<string, boolean>);
 
   /**
-   * Header checkbox enabled
+   * Whether the header displays a selection checkbox. Only applies when selection mode is `checkbox`.
    */
   headerCheckboxable?: boolean;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... API documentation

**What is the current behavior?** (You can also link to an open issue here)

Published API documentation contains details that are absent or incomplete in the corresponding source JSDoc.

**What is the new behavior?**

Public JSDoc now documents column configuration, table inputs, row-detail templates, and the complete custom row-wrapper usage within `ngx-datatable`.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Documentation-only change.