### PR TITLE
fix: support full-height empty content

### DIFF
--- a/playwright/e2e/empty-template.spec.ts
+++ b/playwright/e2e/empty-template.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '../support/test-helpers';
+
+test.describe('empty template', () => {
+  test('empty-template', async ({ si, page }) => {
+    await si.visitExample('empty-template');
+
+    await expect(page.getByText('My custom empty component')).toBeVisible();
+    await expect(page.getByText('uses two lines.')).toBeVisible();
+
+    await si.runVisualAndA11yTests({
+      axeRulesSet: [
+        {
+          id: 'aria-required-children',
+          enabled: false
+        },
+        {
+          id: 'aria-required-parent',
+          enabled: false
+        }
+      ]
+    });
+  });
+});

--- a/playwright/snapshots/e2e/empty-template.spec.ts-snapshots/empty-template-chromium-linux.png
+++ b/playwright/snapshots/e2e/empty-template.spec.ts-snapshots/empty-template-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49f9e1724db9c51dabcb67d531b5b31b01d2f7d465187acb175834a9d75ccfab
+size 17042

--- a/projects/ngx-datatable/src/lib/components/body/body.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.scss
@@ -20,6 +20,10 @@ datatable-scroller,
   }
 }
 
+.datatable-empty-scroller {
+  display: block;
+}
+
 .custom-loading-indicator-wrapper,
 ghost-loader {
   grid-column: 1 / -1;

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -238,6 +238,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
     }
     @if (!rows?.length && !loadingIndicator() && !ghostLoadingIndicator()) {
       <datatable-scroller
+        class="datatable-empty-scroller"
         [scrollbarV]="scrollbarV"
         [scrollbarH]="scrollbarH()"
         [scrollHeight]="scrollHeight()"

--- a/src/app/basic/empty-template.component.ts
+++ b/src/app/basic/empty-template.component.ts
@@ -9,16 +9,28 @@ import { DatatableComponent, TableColumn } from '@siemens/ngx-datatable';
       <ngx-datatable
         class="material"
         columnMode="force"
+        scrollbarV
         [rows]="[]"
         [columns]="columns"
         [headerHeight]="50"
         [footerHeight]="50"
       >
-        <div empty-content style="text-align: center;"
-          >My custom empty component<br />uses two lines.</div
-        >
+        <div empty-content>My custom empty component<br />uses two lines.</div>
       </ngx-datatable>
     </div>
+  `,
+  styles: `
+    ngx-datatable {
+      min-block-size: 50vh;
+    }
+
+    [empty-content] {
+      block-size: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+    }
   `
 })
 export class EmptyTemplateComponent {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Custom `empty-content` is constrained by the table body grid layout and can not fill the available body height.

**What is the new behavior?**

The `empty-state` scroller uses block layout, so custom empty content can fill the available height. The empty-template example demonstrates vertical and horizontal centering, with an e2e visual snapshot covering the example.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closes #691.