### PR TITLE
fix: proper ARIA roles for datatable table structure

### DIFF
--- a/playwright/e2e/custom-template.spec.ts
+++ b/playwright/e2e/custom-template.spec.ts
@@ -16,51 +16,19 @@ test.describe('summary row', () => {
       await enableSummaryRow.click();
       await expect(summaryRow).toHaveCount(0);
 
-      await si.runVisualAndA11yTests({
-        step: 'no-summary-row',
-        axeRulesSet: [
-          {
-            id: 'aria-required-children',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('no-summary-row');
 
       enableSummaryRow.click();
       await expect(summaryRow).toHaveCount(1);
 
-      await si.runVisualAndA11yTests({
-        step: 'show-summary-row',
-        axeRulesSet: [
-          {
-            id: 'aria-required-children',
-            enabled: false
-          },
-          {
-            id: 'aria-required-parent',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('show-summary-row');
 
       const scrollerElement = await page.locator('datatable-scroller').boundingBox();
       let summaryElementBox = await summaryRow.boundingBox();
 
       expect(scrollerElement.y).toBe(summaryElementBox.y);
 
-      await si.runVisualAndA11yTests({
-        step: 'summary-row-at-top',
-        axeRulesSet: [
-          {
-            id: 'aria-required-children',
-            enabled: false
-          },
-          {
-            id: 'aria-required-parent',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('summary-row-at-top');
 
       await page.getByLabel('Position').selectOption('bottom');
 
@@ -69,15 +37,7 @@ test.describe('summary row', () => {
 
       expect(summaryElementBox.y).toBe(lastElement.y + lastElement.height);
 
-      await si.runVisualAndA11yTests({
-        step: 'summary-row-at-bottom',
-        axeRulesSet: [
-          {
-            id: 'aria-required-children',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('summary-row-at-bottom');
 
       await testSummaryRowData(page);
     });
@@ -94,19 +54,7 @@ test.describe('summary row', () => {
 
       await testSummaryRowData(page);
 
-      await si.runVisualAndA11yTests({
-        step: 'custom-template-default',
-        axeRulesSet: [
-          {
-            id: 'aria-required-children',
-            enabled: false
-          },
-          {
-            id: 'aria-required-parent',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('custom-template-default');
     });
   });
 
@@ -140,19 +88,7 @@ test.describe('summary row', () => {
       await expect(genderColumn).toContainText(`${maleCells.length} males`);
       await expect(nameColumn).toContainText(`${maleCells.length + femaleCells.length} total`);
 
-      await si.runVisualAndA11yTests({
-        step: 'custom-template',
-        axeRulesSet: [
-          {
-            id: 'aria-required-children',
-            enabled: false
-          },
-          {
-            id: 'aria-required-parent',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('custom-template');
     });
   });
 
@@ -189,14 +125,6 @@ test.describe('summary row', () => {
       await si.runVisualAndA11yTests({
         step: 'custom-template-lastname-only',
         axeRulesSet: [
-          {
-            id: 'aria-required-children',
-            enabled: false
-          },
-          {
-            id: 'aria-required-parent',
-            enabled: false
-          },
           {
             id: 'scrollable-region-focusable',
             enabled: false

--- a/playwright/e2e/empty-template.spec.ts
+++ b/playwright/e2e/empty-template.spec.ts
@@ -7,17 +7,6 @@ test.describe('empty template', () => {
     await expect(page.getByText('My custom empty component')).toBeVisible();
     await expect(page.getByText('uses two lines.')).toBeVisible();
 
-    await si.runVisualAndA11yTests({
-      axeRulesSet: [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        },
-        {
-          id: 'aria-required-parent',
-          enabled: false
-        }
-      ]
-    });
+    await si.runVisualAndA11yTests({ ariaSnapshot: true });
   });
 });

--- a/playwright/e2e/paging.spec.ts
+++ b/playwright/e2e/paging.spec.ts
@@ -67,10 +67,6 @@ test.describe('paging', () => {
           {
             id: 'aria-progressbar-name',
             enabled: false
-          },
-          {
-            id: 'aria-required-children',
-            enabled: false
           }
         ]
       });
@@ -84,10 +80,6 @@ test.describe('paging', () => {
         axeRulesSet: [
           {
             id: 'aria-progressbar-name',
-            enabled: false
-          },
-          {
-            id: 'aria-required-children',
             enabled: false
           }
         ]
@@ -128,10 +120,6 @@ test.describe('paging', () => {
           },
           {
             id: 'aria-progressbar-name',
-            enabled: false
-          },
-          {
-            id: 'aria-required-children',
             enabled: false
           }
         ]

--- a/playwright/e2e/row-group.spec.ts
+++ b/playwright/e2e/row-group.spec.ts
@@ -7,31 +7,14 @@ test.describe('row grouping', () => {
     await si.visitExample(example);
 
     await expect(page.getByText('Ethel Price')).toBeVisible();
-    await si.runVisualAndA11yTests({
-      step: 'default',
-      axeRulesSet: [
-        // interactive elements< (<a/>, <input/> etc) within table cells are failing
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]
-    });
+    await si.runVisualAndA11yTests('default');
 
     const groupCheckbox = page.locator('.datatable-group-cell .datatable-checkbox input').first();
     groupCheckbox.check();
 
     await expect(page.getByText('4 selected')).toBeVisible();
 
-    await si.runVisualAndA11yTests({
-      step: 'group-selected',
-      axeRulesSet: [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]
-    });
+    await si.runVisualAndA11yTests({ step: 'group-selected', ariaSnapshot: true });
   });
 
   test(example + ' expand/collapse', async ({ si, page }) => {
@@ -41,25 +24,9 @@ test.describe('row grouping', () => {
     const groupHeader = page.getByTitle('Expand/Collapse Group').first();
     groupHeader.click();
     await expect(page.getByText('Ethel Price')).not.toBeVisible();
-    await si.runVisualAndA11yTests({
-      step: 'group-collapsed',
-      axeRulesSet: [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]
-    });
+    await si.runVisualAndA11yTests('group-collapsed');
     groupHeader.click();
     await expect(page.getByText('Ethel Price')).toBeVisible();
-    await si.runVisualAndA11yTests({
-      step: 'group-expanded',
-      axeRulesSet: [
-        {
-          id: 'aria-required-children',
-          enabled: false
-        }
-      ]
-    });
+    await si.runVisualAndA11yTests('group-expanded');
   });
 });

--- a/playwright/e2e/sorting.spec.ts
+++ b/playwright/e2e/sorting.spec.ts
@@ -125,10 +125,6 @@ test.describe('sorting', () => {
           {
             id: 'aria-progressbar-name',
             enabled: false
-          },
-          {
-            id: 'aria-required-children',
-            enabled: false
           }
         ]
       });

--- a/playwright/snapshots/e2e/empty-template.spec.ts-snapshots/empty-template.yaml
+++ b/playwright/snapshots/e2e/empty-template.spec.ts-snapshots/empty-template.yaml
@@ -1,0 +1,15 @@
+- main:
+  - heading "Empty Template Source" [level=3]:
+    - text: ""
+    - link "Source":
+      - /url: https://github.com/siemens/ngx-datatable/blob/main/src/app/basic/empty-template.component.ts
+  - table:
+    - rowgroup:
+      - row "Name Gender Company":
+        - columnheader "Name"
+        - columnheader "Gender"
+        - columnheader "Company"
+    - rowgroup:
+      - row "My custom empty component uses two lines.":
+        - cell "My custom empty component uses two lines."
+  - text: 0 total

--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-selected.yaml
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-selected.yaml
@@ -1,0 +1,175 @@
+- main:
+  - heading "Row Grouping Source" [level=3]:
+    - text: ""
+    - link "Source":
+      - /url: https://github.com/siemens/ngx-datatable/blob/main/src/app/basic/row-grouping.component.ts
+  - table:
+    - rowgroup:
+      - row "Select all rows Exp. Pay. Source Name Gender Age Comment":
+        - columnheader "Select all rows Exp. Pay.":
+          - checkbox "Select all rows"
+          - text: ""
+        - columnheader "Source"
+        - columnheader "Name"
+        - columnheader "Gender"
+        - columnheader "Age"
+        - columnheader "Comment"
+    - rowgroup:
+      - 'row /Select row group fAge: \d+/':
+        - 'cell /Select row group fAge: \d+/':
+          - checkbox "Select row group" [checked]
+          - 'link /fAge: \d+/':
+            - /url: javascript:void(0)
+      - row /Select row ex pay10 ex pay20 ex pay30 Funder Ethel Price female \d+ test1/:
+        - cell "Select row ex pay10 ex pay20 ex pay30":
+          - checkbox "Select row" [checked]
+          - checkbox "ex pay10" [checked]
+          - checkbox "ex pay20"
+          - checkbox "ex pay30"
+        - cell "Funder"
+        - cell "Ethel Price"
+        - cell "female"
+        - cell /\d+/
+        - cell "test1":
+          - textbox "comment": test1
+      - row /Select row ex pay10 ex pay20 ex pay30 Calculated Wilder Gonzales male \d+ test2/:
+        - cell "Select row ex pay10 ex pay20 ex pay30":
+          - checkbox "Select row" [checked]
+          - checkbox "ex pay10"
+          - checkbox "ex pay20" [checked]
+          - checkbox "ex pay30"
+        - cell "Calculated"
+        - cell "Wilder Gonzales"
+        - cell "male"
+        - cell /\d+/
+        - cell "test2":
+          - textbox "comment": test2
+      - row /Select row ex pay10 ex pay20 ex pay30 Manual Georgina Schultz female \d+ test3/:
+        - cell "Select row ex pay10 ex pay20 ex pay30":
+          - checkbox "Select row" [checked]
+          - checkbox "ex pay10"
+          - checkbox "ex pay20"
+          - checkbox "ex pay30" [checked]
+        - cell "Manual"
+        - cell "Georgina Schultz"
+        - cell "female"
+        - cell /\d+/
+        - cell "test3":
+          - textbox "comment": test3
+      - row /Select row ex pay10 ex pay20 ex pay30 Manual Carroll Buchanan male \d+ test4/:
+        - cell "Select row ex pay10 ex pay20 ex pay30":
+          - checkbox "Select row" [checked]
+          - checkbox "ex pay10"
+          - checkbox "ex pay20"
+          - checkbox "ex pay30"
+        - cell "Manual"
+        - cell "Carroll Buchanan"
+        - cell "male"
+        - cell /\d+/
+        - cell "test4":
+          - textbox "comment": test4
+      - 'row /Select row group fAge: \d+/':
+        - 'cell /Select row group fAge: \d+/':
+          - checkbox "Select row group"
+          - 'link /fAge: \d+/':
+            - /url: javascript:void(0)
+      - row /Select row ex pay11 ex pay21 ex pay31 Funder Claudine Neal female \d+/:
+        - cell "Select row ex pay11 ex pay21 ex pay31":
+          - checkbox "Select row"
+          - checkbox "ex pay11"
+          - checkbox "ex pay21"
+          - checkbox "ex pay31"
+        - cell "Funder"
+        - cell "Claudine Neal"
+        - cell "female"
+        - cell /\d+/
+        - cell:
+          - textbox "comment"
+      - row /Select row ex pay11 ex pay21 ex pay31 Calculated Valarie Atkinson female \d+/:
+        - cell "Select row ex pay11 ex pay21 ex pay31":
+          - checkbox "Select row"
+          - checkbox "ex pay11"
+          - checkbox "ex pay21"
+          - checkbox "ex pay31"
+        - cell "Calculated"
+        - cell "Valarie Atkinson"
+        - cell "female"
+        - cell /\d+/
+        - cell:
+          - textbox "comment"
+      - 'row /Select row group fAge: \d+/':
+        - 'cell /Select row group fAge: \d+/':
+          - checkbox "Select row group"
+          - 'link /fAge: \d+/':
+            - /url: javascript:void(0)
+      - row /Select row ex pay12 ex pay22 ex pay32 Beryl Rice female \d+/:
+        - cell "Select row ex pay12 ex pay22 ex pay32":
+          - checkbox "Select row"
+          - checkbox "ex pay12"
+          - checkbox "ex pay22"
+          - checkbox "ex pay32"
+        - cell
+        - cell "Beryl Rice"
+        - cell "female"
+        - cell /\d+/
+        - cell:
+          - textbox "comment"
+      - row /Select row ex pay12 ex pay22 ex pay32 Schroeder Mathews male \d+/:
+        - cell "Select row ex pay12 ex pay22 ex pay32":
+          - checkbox "Select row"
+          - checkbox "ex pay12"
+          - checkbox "ex pay22"
+          - checkbox "ex pay32"
+        - cell
+        - cell "Schroeder Mathews"
+        - cell "male"
+        - cell /\d+/
+        - cell:
+          - textbox "comment"
+      - 'row /Select row group fAge: \d+/':
+        - 'cell /Select row group fAge: \d+/':
+          - checkbox "Select row group"
+          - 'link /fAge: \d+/':
+            - /url: javascript:void(0)
+      - row /Select row ex pay13 ex pay23 ex pay33 Lynda Mendoza female \d+/:
+        - cell "Select row ex pay13 ex pay23 ex pay33":
+          - checkbox "Select row"
+          - checkbox "ex pay13"
+          - checkbox "ex pay23"
+          - checkbox "ex pay33"
+        - cell
+        - cell "Lynda Mendoza"
+        - cell "female"
+        - cell /\d+/
+        - cell:
+          - textbox "comment"
+      - row /Select row ex pay13 ex pay23 ex pay33 Sarah Massey female \d+/:
+        - cell "Select row ex pay13 ex pay23 ex pay33":
+          - checkbox "Select row"
+          - checkbox "ex pay13"
+          - checkbox "ex pay23"
+          - checkbox "ex pay33"
+        - cell
+        - cell "Sarah Massey"
+        - cell "female"
+        - cell /\d+/
+        - cell:
+          - textbox "comment"
+  - text: /4 selected \/ \d+ total/
+  - list:
+    - listitem:
+      - button "go to first page" [disabled]
+    - listitem:
+      - button "go to previous page" [disabled]
+    - listitem:
+      - button "page 1"
+    - listitem:
+      - button "page 2"
+    - listitem:
+      - button "page 3"
+    - listitem:
+      - button "page 4"
+    - listitem:
+      - button "go to next page"
+    - listitem:
+      - button "go to last page": q

--- a/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.ts
@@ -17,8 +17,8 @@ import { DatatableGroupHeaderDirective } from './body-group-header.directive';
   template: `
     @let groupHeader = this.groupHeader();
     @if (groupHeader && groupHeader.template()) {
-      <div class="datatable-group-header" [style.height.px]="groupHeaderRowHeight()">
-        <div class="datatable-group-cell">
+      <div role="row" class="datatable-group-header" [style.height.px]="groupHeaderRowHeight()">
+        <div role="cell" class="datatable-group-cell" [attr.aria-colspan]="allColumnsColspan()">
           @if (groupHeader.checkboxable()) {
             <div>
               <label class="datatable-checkbox">
@@ -47,7 +47,8 @@ import { DatatableGroupHeaderDirective } from './body-group-header.directive';
   styleUrl: './body-group-wrapper.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'datatable-group-wrapper'
+    class: 'datatable-group-wrapper',
+    role: 'presentation'
   }
 })
 export class DataTableGroupWrapperComponent<TRow extends Row = any> {
@@ -55,6 +56,7 @@ export class DataTableGroupWrapperComponent<TRow extends Row = any> {
   readonly groupHeaderRowHeight = input.required<number>();
   readonly group = input.required<Group<TRow>>();
   readonly groupedRows = input<Group<TRow>[]>();
+  readonly allColumnsColspan = input.required<number>();
   readonly selected = input.required<TRow[]>();
   readonly disabled = input<boolean>();
   readonly rowIndex = input.required<number>();

--- a/projects/ngx-datatable/src/lib/components/body/body.component.scss
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.scss
@@ -24,6 +24,11 @@ datatable-scroller,
   display: block;
 }
 
+.datatable-empty-row,
+.datatable-empty-cell {
+  block-size: 100%;
+}
+
 .custom-loading-indicator-wrapper,
 ghost-loader {
   grid-column: 1 / -1;

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -101,6 +101,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
             [rowHeight]="summaryHeight()"
             [rows]="rows"
             [columns]="columns"
+            [allColumnsColspan]="allColumnsColspan()"
             [template]="summaryRowTemplate()"
           />
         }
@@ -206,6 +207,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
                   [rowIndex]="indexes().first + i"
                   [selected]="selected()"
                   [ariaGroupHeaderCheckboxMessage]="ariaGroupHeaderCheckboxMessage()"
+                  [allColumnsColspan]="allColumnsColspan()"
                   (groupSelectedChange)="groupSelectedChange($event, group)"
                 >
                   @for (row of group.value; track rowTrackingFn($index, row)) {
@@ -232,6 +234,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
           [rowHeight]="summaryHeight()"
           [rows]="rows"
           [columns]="columns"
+          [allColumnsColspan]="allColumnsColspan()"
           [template]="summaryRowTemplate()"
         />
       }
@@ -244,7 +247,11 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
         [scrollHeight]="scrollHeight()"
         (scroll)="onBodyScroll($event)"
       >
-        <ng-content select="[empty-content]" />
+        <div role="row" class="datatable-empty-row">
+          <div role="cell" class="datatable-empty-cell" [attr.aria-colspan]="allColumnsColspan()">
+            <ng-content select="[empty-content]" />
+          </div>
+        </div>
       </datatable-scroller>
     }
   `,
@@ -323,6 +330,8 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   get selectEnabled(): boolean {
     return !!this.selectionType();
   }
+
+  protected readonly allColumnsColspan = computed(() => Math.max(1, this.columns().length));
 
   /**
    * Property that would calculate the height of scroll bar

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
@@ -158,7 +158,13 @@ describe('DataTableSummaryRowComponent', () => {
 @Component({
   imports: [DataTableSummaryRowComponent],
   template: `
-    <datatable-summary-row [rows]="rows" [columns]="columns" [rowHeight]="30" [template]="tpl()" />
+    <datatable-summary-row
+      [rows]="rows"
+      [columns]="columns"
+      [allColumnsColspan]="allColumnsColspan"
+      [rowHeight]="30"
+      [template]="tpl()"
+    />
     <ng-template #summaryTpl>
       <span class="custom-content">Custom summary content</span>
     </ng-template>
@@ -167,6 +173,7 @@ describe('DataTableSummaryRowComponent', () => {
 class TestHostComponent {
   rows = [{ col1: 10 }];
   columns: TableColumnInternal[] = toInternalColumn([{ prop: 'col1' }]);
+  readonly allColumnsColspan = Math.max(1, this.columns.length);
   readonly tpl = viewChild<TemplateRef<void>>('summaryTpl');
 }
 

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
@@ -28,7 +28,7 @@ const noopSumFunc = (cells: any[]): void => {
     @let template = this.template();
     @if (template) {
       <div class="datatable-body-row" role="row" [style.height.px]="rowHeight()">
-        <div class="datatable-body-cell" role="cell">
+        <div class="datatable-body-cell" role="cell" [attr.aria-colspan]="allColumnsColspan()">
           <ng-container [ngTemplateOutlet]="template" />
         </div>
       </div>
@@ -55,6 +55,7 @@ const noopSumFunc = (cells: any[]): void => {
 export class DataTableSummaryRowComponent {
   readonly rows = input.required<any[]>();
   readonly columns = input.required<TableColumnInternal[]>();
+  readonly allColumnsColspan = input.required<number>();
 
   readonly rowHeight = input.required<number>();
   readonly template = input<TemplateRef<void>>();

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -86,13 +86,7 @@
         <datatable-progress />
       </ng-content>
       <ng-content select="[empty-content]" ngProjectAs="[empty-content]">
-        <div role="row" class="datatable-empty-row">
-          <div
-            role="cell"
-            class="empty-row"
-            [innerHTML]="messages().emptyMessage ?? 'No data to display'"
-          ></div>
-        </div>
+        <div class="empty-row" [innerHTML]="messages().emptyMessage ?? 'No data to display'"></div>
       </ng-content>
     </datatable-body>
   </div>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**

The empty row content and group wrapper lacked proper ARIA roles, causing `aria-required-parent` and `aria-required-children` violations in axe-core a11y tests, which required disabling these rules across multiple e2e test specs.

**What is the new behavior?**

- Empty row content is wrapped with `role="row"` and `role="cell"` in `body.component.ts` to provide correct ARIA table hierarchy
- `body-group-wrapper` gets `role="presentation"` to remove the custom element from the accessibility tree
- Duplicate roles removed from the projected default empty content in `datatable.component.html`
- E2e test exclusions for `aria-required-parent` and `aria-required-children` are no longer needed and have been removed

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
