### PR TITLE
docs(a11y): hide row grouping icon

### DIFF
--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--default-chromium-linux.png
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--default-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e624fa4e85aad83118894e1a74d93300a47a5f7256e6772827f5a11d7e0520b
-size 50388
+oid sha256:d4bfc89f6a961227d873c91f2a30eaa31a268d448cda1f93e6ffcd6332e916ee
+size 50322

--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-collapsed-chromium-linux.png
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-collapsed-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efb1f9562237ab7bfcb6838ad5316ec3055b63130c3e2a76f0c5441e45b0cf3b
-size 36821
+oid sha256:56f86ed1676f29e67fbd9ab993ed2922b7fd5722bd0d99f6ac41469672d8ab83
+size 36761

--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-expanded-chromium-linux.png
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-expanded-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e624fa4e85aad83118894e1a74d93300a47a5f7256e6772827f5a11d7e0520b
-size 50388
+oid sha256:d4bfc89f6a961227d873c91f2a30eaa31a268d448cda1f93e6ffcd6332e916ee
+size 50322

--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-selected-chromium-linux.png
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-selected-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af52087d169bcd3c46ac578427f57f6d1dd69db610ed9bdcb6091cc3c3c49bc6
-size 50914
+oid sha256:07347b9dc6ae4699adeaaa0476c8e46565d7723bc3faa4640445484da2d9efc9
+size 50847

--- a/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-selected.yaml
+++ b/playwright/snapshots/e2e/row-group.spec.ts-snapshots/row-grouping--group-selected.yaml
@@ -15,10 +15,10 @@
         - columnheader "Age"
         - columnheader "Comment"
     - rowgroup:
-      - 'row /Select row group fAge: \d+/':
-        - 'cell /Select row group fAge: \d+/':
+      - 'row /Select row group Age: \d+/':
+        - 'cell /Select row group Age: \d+/':
           - checkbox "Select row group" [checked]
-          - 'link /fAge: \d+/':
+          - 'link /Age: \d+/':
             - /url: javascript:void(0)
       - row /Select row ex pay10 ex pay20 ex pay30 Funder Ethel Price female \d+ test1/:
         - cell "Select row ex pay10 ex pay20 ex pay30":
@@ -68,10 +68,10 @@
         - cell /\d+/
         - cell "test4":
           - textbox "comment": test4
-      - 'row /Select row group fAge: \d+/':
-        - 'cell /Select row group fAge: \d+/':
+      - 'row /Select row group Age: \d+/':
+        - 'cell /Select row group Age: \d+/':
           - checkbox "Select row group"
-          - 'link /fAge: \d+/':
+          - 'link /Age: \d+/':
             - /url: javascript:void(0)
       - row /Select row ex pay11 ex pay21 ex pay31 Funder Claudine Neal female \d+/:
         - cell "Select row ex pay11 ex pay21 ex pay31":
@@ -97,10 +97,10 @@
         - cell /\d+/
         - cell:
           - textbox "comment"
-      - 'row /Select row group fAge: \d+/':
-        - 'cell /Select row group fAge: \d+/':
+      - 'row /Select row group Age: \d+/':
+        - 'cell /Select row group Age: \d+/':
           - checkbox "Select row group"
-          - 'link /fAge: \d+/':
+          - 'link /Age: \d+/':
             - /url: javascript:void(0)
       - row /Select row ex pay12 ex pay22 ex pay32 Beryl Rice female \d+/:
         - cell "Select row ex pay12 ex pay22 ex pay32":
@@ -126,10 +126,10 @@
         - cell /\d+/
         - cell:
           - textbox "comment"
-      - 'row /Select row group fAge: \d+/':
-        - 'cell /Select row group fAge: \d+/':
+      - 'row /Select row group Age: \d+/':
+        - 'cell /Select row group Age: \d+/':
           - checkbox "Select row group"
-          - 'link /fAge: \d+/':
+          - 'link /Age: \d+/':
             - /url: javascript:void(0)
       - row /Select row ex pay13 ex pay23 ex pay33 Lynda Mendoza female \d+/:
         - cell "Select row ex pay13 ex pay23 ex pay33":

--- a/src/app/basic/row-grouping.component.ts
+++ b/src/app/basic/row-grouping.component.ts
@@ -53,10 +53,13 @@ import { DataService } from '../data.service';
               <a
                 href="javascript:void(0)"
                 title="Expand/Collapse Group"
-                [class.datatable-icon-right]="!expanded"
-                [class.datatable-icon-down]="expanded"
                 (click)="toggleExpandGroup(group)"
               >
+                <span
+                  aria-hidden="true"
+                  [class.datatable-icon-right]="!expanded"
+                  [class.datatable-icon-down]="expanded"
+                ></span>
                 <b>Age: {{ group ? group.value[0].age : '' }}</b>
               </a>
             </div>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: docs

**What is the current behavior?** (You can also link to an open issue here)

The collapse arrow icons in the group example are currently visible to screenreader as `f`.

**What is the new behavior?**

The collapse arrows are aria-hidden.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

I cannot see, why the screenshots are different.