### PR TITLE
fix: add loading indicator aria label

### DIFF
--- a/playwright/e2e/paging.spec.ts
+++ b/playwright/e2e/paging.spec.ts
@@ -63,10 +63,6 @@ test.describe('paging', () => {
           {
             id: 'empty-table-header',
             enabled: false
-          },
-          {
-            id: 'aria-progressbar-name',
-            enabled: false
           }
         ]
       });
@@ -75,15 +71,7 @@ test.describe('paging', () => {
 
       await page.mouse.wheel(0, 1000);
 
-      await si.runVisualAndA11yTests({
-        step: 'infinite-scroll-after-scroll',
-        axeRulesSet: [
-          {
-            id: 'aria-progressbar-name',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('infinite-scroll-after-scroll');
     });
   });
 
@@ -116,10 +104,6 @@ test.describe('paging', () => {
           },
           {
             id: 'empty-table-header',
-            enabled: false
-          },
-          {
-            id: 'aria-progressbar-name',
             enabled: false
           }
         ]

--- a/playwright/e2e/sorting.spec.ts
+++ b/playwright/e2e/sorting.spec.ts
@@ -119,15 +119,7 @@ test.describe('sorting', () => {
       await expect(companyHeader).toHaveClass(/sort-active/);
       await expect(companyHeader).toHaveClass(/sort-asc/);
 
-      await si.runVisualAndA11yTests({
-        step: 'sorting-asc-again',
-        axeRulesSet: [
-          {
-            id: 'aria-progressbar-name',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('sorting-asc-again');
     });
   });
 

--- a/projects/ngx-datatable/src/lib/components/body/progress-bar.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/progress-bar.component.ts
@@ -1,9 +1,9 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 @Component({
   selector: 'datatable-progress',
   template: `
-    <div class="progress-linear" role="progressbar">
+    <div class="progress-linear" role="progressbar" [attr.aria-label]="ariaLoadingMessage()">
       <div class="container">
         <div class="bar"></div>
       </div>
@@ -11,4 +11,6 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ProgressBarComponent {}
+export class ProgressBarComponent {
+  readonly ariaLoadingMessage = input.required<string>();
+}

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -83,7 +83,7 @@
       (treeAction)="onTreeAction($event)"
     >
       <ng-content select="[loading-indicator]" ngProjectAs="[loading-indicator]">
-        <datatable-progress />
+        <datatable-progress [ariaLoadingMessage]="messages().ariaLoadingMessage ?? 'Loading'" />
       </ng-content>
       <ng-content select="[empty-content]" ngProjectAs="[empty-content]">
         <div class="empty-row" [innerHTML]="messages().emptyMessage ?? 'No data to display'"></div>

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -327,7 +327,8 @@ export class DatatableComponent<TRow extends Row = any>
    *   ariaLastPageMessage: 'go to last page',
    *   ariaRowCheckboxMessage: 'Select row',
    *   ariaHeaderCheckboxMessage: 'Select all rows',
-   *   ariaGroupHeaderCheckboxMessage: 'Select row group'
+   *   ariaGroupHeaderCheckboxMessage: 'Select row group',
+   *   ariaLoadingMessage: 'Loading'
    * }
    * ```
    */

--- a/projects/ngx-datatable/src/lib/ngx-datatable.config.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.config.ts
@@ -27,6 +27,8 @@ export interface NgxDatatableMessages {
   ariaHeaderCheckboxMessage: string;
   /** Group header checkbox aria label */
   ariaGroupHeaderCheckboxMessage: string;
+  /** Loading indicator aria label */
+  ariaLoadingMessage: string;
 }
 
 /** CSS classes for icons that override the default table icons. */


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The loading indicator progressbar has no accessible name, causing an `aria-progressbar-name` accessibility violation.

**What is the new behavior?**

The progressbar has a configurable accessible name through `messages.ariaLoadingMessage`, defaulting to `Loading`. The paging accessibility tests no longer suppress the rule.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Validated with `./e2e-local.sh a11y playwright/e2e/paging.spec.ts` (6 passed).