### PR TITLE
test(a11y): enable table accessibility rules

### DIFF
--- a/playwright/e2e/paging.spec.ts
+++ b/playwright/e2e/paging.spec.ts
@@ -53,19 +53,7 @@ test.describe('paging', () => {
 
       await expect(page.locator('ghost-loader').first()).not.toBeVisible();
 
-      await si.runVisualAndA11yTests({
-        step: 'infinite-scroll-initial',
-        axeRulesSet: [
-          {
-            id: 'label',
-            enabled: false
-          },
-          {
-            id: 'empty-table-header',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('infinite-scroll-initial');
 
       await page.getByRole('row', { name: 'Sarah Massey' }).click();
 
@@ -95,19 +83,7 @@ test.describe('paging', () => {
 
       await page.waitForSelector('span[title="Freda Mason"]');
 
-      await si.runVisualAndA11yTests({
-        step: 'virtual-server-side-navigate',
-        axeRulesSet: [
-          {
-            id: 'label',
-            enabled: false
-          },
-          {
-            id: 'empty-table-header',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('virtual-server-side-navigate');
 
       await page.getByRole('row', { name: 'Freda Mason' }).click();
       await page.mouse.wheel(0, 500);

--- a/playwright/e2e/row-disabled.spec.ts
+++ b/playwright/e2e/row-disabled.spec.ts
@@ -7,10 +7,6 @@ test('disabled rows', async ({ si, page }) => {
     .getByRole('button', { name: 'Disable row' })
     .click();
   await si.runVisualAndA11yTests({
-    axeRulesSet: [
-      { id: 'color-contrast', enabled: false },
-      { id: 'label', enabled: false },
-      { id: 'select-name', enabled: false }
-    ]
+    axeRulesSet: [{ id: 'color-contrast', enabled: false }]
   });
 });

--- a/playwright/e2e/selection.spec.ts
+++ b/playwright/e2e/selection.spec.ts
@@ -172,38 +172,14 @@ test.describe('selection', () => {
       const selectedNamesLi = page.locator('.selected-column').locator('ul > li');
       await expect(selectedNamesLi).toHaveCount(4);
 
-      await si.runVisualAndA11yTests({
-        step: 'checkbox-selection-all-checked',
-        axeRulesSet: [
-          {
-            id: 'label',
-            enabled: false
-          },
-          {
-            id: 'empty-table-header',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('checkbox-selection-all-checked');
 
       await rowsWithCheckbox[0].uncheck();
       await rowsWithCheckbox[1].uncheck();
 
       await expect(selectedNamesLi).toHaveCount(2);
 
-      await si.runVisualAndA11yTests({
-        step: 'checkbox-selection-uncheck',
-        axeRulesSet: [
-          {
-            id: 'label',
-            enabled: false
-          },
-          {
-            id: 'empty-table-header',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('checkbox-selection-uncheck');
     });
   });
 
@@ -266,19 +242,7 @@ test.describe('selection', () => {
       const selectedNamesLi = page.locator('.selected-column').locator('ul > li');
       await expect(selectedNamesLi).toHaveCount(3);
 
-      await si.runVisualAndA11yTests({
-        step: 'navigation-using-tab-and-space',
-        axeRulesSet: [
-          {
-            id: 'label',
-            enabled: false
-          },
-          {
-            id: 'empty-table-header',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('navigation-using-tab-and-space');
 
       await page.keyboard.press('Shift+Tab');
       await page.keyboard.press('Space');
@@ -287,19 +251,7 @@ test.describe('selection', () => {
 
       await expect(selectedNamesLi).toHaveCount(2);
 
-      await si.runVisualAndA11yTests({
-        step: 'backward-navigation-shift+tab+space',
-        axeRulesSet: [
-          {
-            id: 'label',
-            enabled: false
-          },
-          {
-            id: 'empty-table-header',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('backward-navigation-shift+tab+space');
     });
   });
 });

--- a/playwright/e2e/summary-row.spec.ts
+++ b/playwright/e2e/summary-row.spec.ts
@@ -20,12 +20,6 @@ test.describe('summary-row', () => {
     await expect(summaryRow).toBeVisible();
     await expect(page.locator('.summary-row-actions-count')).toContainText('1 row(s) selected');
 
-    await si.runVisualAndA11yTests({
-      step: 'summary-row-actions',
-      axeRulesSet: [
-        { id: 'label', enabled: false },
-        { id: 'empty-table-header', enabled: false }
-      ]
-    });
+    await si.runVisualAndA11yTests('summary-row-actions');
   });
 });

--- a/src/app/basic/disabled.component.ts
+++ b/src/app/basic/disabled.component.ts
@@ -50,6 +50,7 @@ import { DataService } from '../data.service';
               ngx-datatable-cell-template
             >
               <select
+                [attr.aria-label]="'Gender for ' + row.name"
                 [style.height]="'auto'"
                 [value]="value"
                 [disabled]="disabled"
@@ -70,7 +71,11 @@ import { DataService } from '../data.service';
               ngx-datatable-cell-template
             >
               <div disable-row [disabled]="disabled">
-                <input [value]="value" (blur)="updateValue($event, 'age', rowIndex)" />
+                <input
+                  [attr.aria-label]="'Age for ' + row.name"
+                  [value]="value"
+                  (blur)="updateValue($event, 'age', rowIndex)"
+                />
                 <br />
                 <button type="button" (click)="disableRow(rowIndex)">Disable row</button>
               </div>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Test scope change

**What is the current behavior?** (You can also link to an open issue here)

Accessibility checks for `empty-table-header`, `label`, and `select-name` are disabled in several table E2E scenarios.

**What is the new behavior?**

The affected E2E scenarios run these accessibility rules. The disabled-row example labels its Gender and Age form controls with the employee name. `color-contrast` remains disabled only for the intentionally subdued disabled-row presentation.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: N/A

**Other information**:

Validated with:

`./e2e-local.sh a11y playwright/e2e/paging.spec.ts playwright/e2e/selection.spec.ts playwright/e2e/summary-row.spec.ts playwright/e2e/row-disabled.spec.ts`