### PR TITLE
docs(a11y): enable scrollable region rule

### DIFF
--- a/playwright/e2e/custom-template.spec.ts
+++ b/playwright/e2e/custom-template.spec.ts
@@ -103,34 +103,10 @@ test.describe('summary row', () => {
 
       await testSummaryRowData(page);
 
-      const rows = await page.locator('datatable-row-wrapper').locator('datatable-body-row').all();
-
       const nameColumn = summaryRow.locator('datatable-body-cell').first().locator('span');
+      await expect(nameColumn).toHaveText('5 total');
 
-      expect(rows).toHaveLength(5);
-
-      const names: string[] = [];
-
-      for (const row of rows) {
-        const fullName = await row.locator('datatable-body-cell').first().innerText();
-        names.push(fullName.split(' ')[1]);
-      }
-
-      expect(names).toHaveLength(rows.length);
-
-      for (let name of names) {
-        await expect(nameColumn.getByText(name, { exact: true })).toHaveCount(1);
-      }
-
-      await si.runVisualAndA11yTests({
-        step: 'custom-template-lastname-only',
-        axeRulesSet: [
-          {
-            id: 'scrollable-region-focusable',
-            enabled: false
-          }
-        ]
-      });
+      await si.runVisualAndA11yTests('custom-template-total-count');
     });
   });
 });

--- a/playwright/snapshots/e2e/custom-template.spec.ts-snapshots/inline-html-summary--custom-template-lastname-only-chromium-linux.png
+++ b/playwright/snapshots/e2e/custom-template.spec.ts-snapshots/inline-html-summary--custom-template-lastname-only-chromium-linux.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef9bf6358aed7c8bb59228a45f969c4672d3d7518a382c7389eefb27d0b1bd2b
-size 27108

--- a/playwright/snapshots/e2e/custom-template.spec.ts-snapshots/inline-html-summary--custom-template-total-count-chromium-linux.png
+++ b/playwright/snapshots/e2e/custom-template.spec.ts-snapshots/inline-html-summary--custom-template-total-count-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:164bf3277bf7a54413f2c76309a3d97291a3cf617cc9c299b733b32faf232479
+size 24738

--- a/src/app/summary/inline-html-summary.component.ts
+++ b/src/app/summary/inline-html-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { DataTableColumnDirective, DatatableComponent } from '@siemens/ngx-datatable';
 
 import { Employee } from '../data.model';
@@ -24,13 +24,7 @@ import { DataService } from '../data.service';
         <ngx-datatable-column prop="age" [summaryFunc]="avgAge" />
       </ngx-datatable>
       <ng-template #nameSummaryCell>
-        <div class="name-container">
-          @for (name of names(); track name) {
-            <div class="chip">
-              <span class="chip-content">{{ name }}</span>
-            </div>
-          }
-        </div>
+        <span>{{ rows().length }} total</span>
       </ng-template>
     </div>
   `
@@ -38,12 +32,6 @@ import { DataService } from '../data.service';
 export class InlineHtmlSummaryComponent {
   private dataService = inject(DataService);
   readonly rows = signal<Employee[]>([]);
-
-  readonly names = computed(() =>
-    this.rows()
-      .map(row => row.name)
-      .map(fullName => fullName.split(' ')[1])
-  );
 
   enableSummary = true;
   summaryPosition = 'top';


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Accessibility documentation/example update

**What is the current behavior?** (You can also link to an open issue here)

The inline HTML summary example renders every surname as a chip in the Name summary cell. This creates a horizontally scrollable, non-focusable region and requires the `scrollable-region-focusable` axe rule to be disabled for its E2E test.

**What is the new behavior?**

The Name summary now displays the current row count (for example, `5 total`). The E2E test verifies that count and runs with `scrollable-region-focusable` enabled.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Validated with `./e2e-local.sh a11y playwright/e2e/custom-template.spec.ts` (4 passed).