### PR TITLE
build(e2e): skip report outside interactive terminals

### DIFF
--- a/e2e-local.sh
+++ b/e2e-local.sh
@@ -101,5 +101,9 @@ else
     test \
     $UPDATE_ARGS \
     "$@" \
-  || yarn playwright show-report playwright/results/preview
+  || {
+    status=$?
+    [ -t 1 ] && npx playwright show-report playwright/results/preview
+    exit "$status"
+  }
 fi


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

`e2e-local.sh` starts Playwright's HTML report server after a failed test run even when it is executed non-interactively, causing agent and CI-style executions to block.

**What is the new behavior?**

The report server starts only when the test run fails and stdout is an interactive terminal. The script uses `npx playwright show-report`, so non-interactive agents can complete without a long-running report process.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Validated with `./e2e-local.sh`: 34 Playwright tests passed and no report server was started.