### PR TITLE
refactor: centralize datatable configuration

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.spec.ts
@@ -2,6 +2,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component, ComponentRef, computed, signal, TemplateRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { provideDatatableConfigurationMock } from '../../../testing/datatable-configuration.mock';
 import { toInternalColumn } from '../../utils/column-helper';
 import { numericIndexGetter } from '../../utils/column-prop-getters';
 import { DataTableBodyCellComponent } from './body-cell.component';
@@ -11,16 +12,7 @@ import { BodyCellHarness } from './testing/body-cell.harness';
   selector: 'mock-cell-template',
   imports: [DataTableBodyCellComponent],
   template: `<ng-template #template let-row="row">Custom Cell Template {{ row.id }} </ng-template>
-    <datatable-body-cell
-      ariaRowCheckboxMessage="checkbox message"
-      [row]="row()"
-      [column]="column()"
-      [cssClasses]="{
-        treeStatusLoading: 'icon datatable-icon-loading',
-        treeStatusExpanded: 'icon datatable-icon-down',
-        treeStatusCollapsed: 'icon datatable-icon-up'
-      }"
-    /> `
+    <datatable-body-cell [row]="row()" [column]="column()" /> `
 })
 class MockCellTemplateComponent {
   readonly row = signal({ id: 1 });
@@ -36,16 +28,13 @@ describe('DataTableBodyCellComponent', () => {
   let harness: BodyCellHarness;
 
   beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [provideDatatableConfigurationMock()]
+    });
     fixture = TestBed.createComponent(DataTableBodyCellComponent);
     component = fixture.componentRef;
     component.setInput('row', ['Hello']);
     component.setInput('column', { width: signal(0) });
-    component.setInput('ariaRowCheckboxMessage', 'checkbox message');
-    component.setInput('cssClasses', {
-      treeStatusLoading: 'icon datatable-icon-loading',
-      treeStatusExpanded: 'icon datatable-icon-down',
-      treeStatusCollapsed: 'icon datatable-icon-up'
-    });
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, BodyCellHarness);
   });
 

--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -13,12 +13,12 @@ import {
   signal
 } from '@angular/core';
 
-import { NgxDatatableConfig } from '../../ngx-datatable.config';
 import { CellActiveEvent, RowIndex, TableColumnInternal } from '../../types/internal.types';
 import { ActivateEvent, CellContext, Row, RowOrGroup, TreeStatus } from '../../types/public.types';
 import { TableColumn } from '../../types/table-column.type';
 import { toPublicColumn } from '../../utils/column-helper';
 import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../utils/keys';
+import { DatatableConfiguration } from '../datatable-configuration';
 
 @Component({
   selector: 'datatable-body-cell',
@@ -32,7 +32,7 @@ import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../util
         <label class="datatable-checkbox">
           <input
             type="checkbox"
-            [attr.aria-label]="ariaRowCheckboxMessage()"
+            [attr.aria-label]="configuration().messages.ariaRowCheckboxMessage"
             [disabled]="disabled()"
             [checked]="isSelected()"
             (click)="onCheckboxChange($event)"
@@ -51,13 +51,13 @@ import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../util
           >
             <span>
               @if (treeStatus === 'loading') {
-                <i [class]="cssClasses().treeStatusLoading ?? 'icon datatable-icon-collapse'"></i>
+                <i [class]="configuration().cssClasses.treeStatusLoading"></i>
               }
               @if (treeStatus === 'collapsed') {
-                <i [class]="cssClasses().treeStatusCollapsed ?? 'icon datatable-icon-up'"></i>
+                <i [class]="configuration().cssClasses.treeStatusCollapsed"></i>
               }
               @if (treeStatus === 'expanded' || treeStatus === 'disabled') {
-                <i [class]="cssClasses().treeStatusExpanded ?? 'icon datatable-icon-down'"></i>
+                <i [class]="configuration().cssClasses.treeStatusExpanded"></i>
               }
             </span>
           </button>
@@ -99,6 +99,7 @@ import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../util
 })
 export class DataTableBodyCellComponent<TRow extends Row = any> implements DoCheck {
   private _element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
+  protected readonly configuration = inject(DatatableConfiguration).configuration;
 
   readonly displayCheck = input<(row: TRow, column: TableColumn, value: any) => boolean>();
 
@@ -117,10 +118,6 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
   readonly row = input.required<TRow>();
 
   readonly treeStatus = input<TreeStatus | undefined>('collapsed');
-
-  readonly ariaRowCheckboxMessage = input.required<string>();
-
-  readonly cssClasses = input.required<Partial<Required<NgxDatatableConfig>['cssClasses']>>();
 
   readonly expanded = input(false, { transform: booleanAttribute });
 

--- a/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-group-wrapper.component.ts
@@ -4,11 +4,13 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  inject,
   input,
   output
 } from '@angular/core';
 
 import { Group, GroupContext, Row } from '../../types/public.types';
+import { DatatableConfiguration } from '../datatable-configuration';
 import { DatatableGroupHeaderDirective } from './body-group-header.directive';
 
 @Component({
@@ -25,7 +27,7 @@ import { DatatableGroupHeaderDirective } from './body-group-header.directive';
                 <input
                   #select
                   type="checkbox"
-                  [attr.aria-label]="ariaGroupHeaderCheckboxMessage()"
+                  [attr.aria-label]="configuration().messages.ariaGroupHeaderCheckboxMessage"
                   [checked]="checked()"
                   [indeterminate]="indeterminate()"
                   (change)="onCheckboxChange(select.checked)"
@@ -52,6 +54,7 @@ import { DatatableGroupHeaderDirective } from './body-group-header.directive';
   }
 })
 export class DataTableGroupWrapperComponent<TRow extends Row = any> {
+  protected readonly configuration = inject(DatatableConfiguration).configuration;
   readonly groupHeader = input.required<DatatableGroupHeaderDirective | undefined>();
   readonly groupHeaderRowHeight = input.required<number>();
   readonly group = input.required<Group<TRow>>();
@@ -61,7 +64,6 @@ export class DataTableGroupWrapperComponent<TRow extends Row = any> {
   readonly disabled = input<boolean>();
   readonly rowIndex = input.required<number>();
   readonly expanded = input(false, { transform: booleanAttribute });
-  readonly ariaGroupHeaderCheckboxMessage = input.required<string>();
   readonly groupSelectedChange = output<boolean>();
 
   readonly context = computed<GroupContext<TRow>>(() => {

--- a/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row-wrapper.component.ts
@@ -51,7 +51,6 @@ export class DataTableRowWrapperComponent<TRow extends Row = any> implements DoC
   readonly rowIndex = input.required<number>();
 
   readonly expanded = input(false, { transform: booleanAttribute });
-  readonly ariaGroupHeaderCheckboxMessage = input.required<string>();
   readonly checkRowPropertyChanges = input(true, { transform: booleanAttribute });
 
   readonly detailsRowHeight = computed(() => this.detailRowHeightFn()(this.row(), this.rowIndex()));

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.spec.ts
@@ -2,6 +2,7 @@ import { Component, computed, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { provideDatatableConfigurationMock } from '../../../testing/datatable-configuration.mock';
 import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
 import { RowIndex } from '../../types/internal.types';
 import { columnsByPinArr, gridColumnTemplate } from '../../utils/column';
@@ -14,8 +15,6 @@ describe('DataTableBodyRowComponent', () => {
     template: `
       <div style="display: grid" [style.grid-template-columns]="gridTemplate()">
         <datatable-body-row
-          ariaRowCheckboxMessage=""
-          [cssClasses]="{}"
           [rowHeight]="40"
           [rowIndex]="rowIndex()"
           [row]="row()"
@@ -36,7 +35,7 @@ describe('DataTableBodyRowComponent', () => {
 
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      providers: [ScrollbarHelper]
+      providers: [ScrollbarHelper, provideDatatableConfigurationMock()]
     });
     fixture = TestBed.createComponent(TestHostComponent);
     component = fixture.componentInstance;

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -14,7 +14,6 @@ import {
   output
 } from '@angular/core';
 
-import { NgxDatatableConfig } from '../../ngx-datatable.config';
 import { CellActiveEvent, RowIndex, TableColumnInternal } from '../../types/internal.types';
 import { ActivateEvent, Row, RowOrGroup, TreeStatus } from '../../types/public.types';
 import { TableColumn } from '../../types/table-column.type';
@@ -48,8 +47,6 @@ import { DataTableBodyCellComponent } from './body-cell.component';
               [displayCheck]="displayCheck()"
               [disabled]="disabled()"
               [treeStatus]="treeStatus()"
-              [ariaRowCheckboxMessage]="ariaRowCheckboxMessage()"
-              [cssClasses]="cssClasses()"
               (activate)="onActivate($event, ii)"
               (treeAction)="onTreeAction()"
             />
@@ -88,10 +85,8 @@ export class DataTableBodyRowComponent<TRow extends Row = any> implements DoChec
   readonly rowIndex = input.required<RowIndex>();
   readonly displayCheck = input<(row: TRow, column: TableColumn, value?: any) => boolean>();
   readonly treeStatus = input<TreeStatus | undefined>('collapsed');
-  readonly ariaRowCheckboxMessage = input.required<string>();
 
   readonly disabled = input<boolean>();
-  readonly cssClasses = input.required<Partial<Required<NgxDatatableConfig>['cssClasses']>>();
   readonly checkRowPropertyChanges = input(true, { transform: booleanAttribute });
 
   protected readonly cssClass = computed(() => {

--- a/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.spec.ts
@@ -1,7 +1,8 @@
-import { EventEmitter } from '@angular/core';
+import { EventEmitter, signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { provideDatatableConfigurationMock } from '../../../testing/datatable-configuration.mock';
 import { ScrollContainerDirective } from '../../directives/scroll-container.directive';
 import { ScrollbarHelper } from '../../services/scrollbar-helper.service';
 import { toInternalColumn } from '../../utils/column-helper';
@@ -27,13 +28,16 @@ const scrollContainerStub: Partial<ScrollContainerDirective> = {
 describe('DataTableBodyComponent', () => {
   let fixture: ComponentFixture<DataTableBodyComponent>;
   let component: DataTableBodyComponent;
+  let rowHeight: WritableSignal<any>;
 
   // provide our implementations or mocks to the dependency injector
   beforeEach(async () => {
+    rowHeight = signal('auto');
     TestBed.configureTestingModule({
       providers: [
         ScrollbarHelper,
         { provide: DATATABLE_COMPONENT_TOKEN, useValue: {} },
+        provideDatatableConfigurationMock({ rowHeight }),
         { provide: ScrollContainerDirective, useValue: scrollContainerStub }
       ]
     });
@@ -42,10 +46,6 @@ describe('DataTableBodyComponent', () => {
     fixture.componentRef.setInput('rowIdentity', (row: any) => row);
     fixture.componentRef.setInput('summaryPosition', 'top');
     fixture.componentRef.setInput('summaryHeight', 50);
-    fixture.componentRef.setInput('ariaGroupHeaderCheckboxMessage', 'Select all rows');
-    fixture.componentRef.setInput('ariaRowCheckboxMessage', 'Select row');
-    fixture.componentRef.setInput('cssClasses', {});
-    fixture.componentRef.setInput('rowHeight', 'auto');
     fixture.componentRef.setInput('offsetX', 0);
     component = fixture.componentInstance;
   });
@@ -126,7 +126,7 @@ describe('DataTableBodyComponent', () => {
       fixture.componentRef.setInput('externalPaging', true);
       fixture.componentRef.setInput('scrollbarV', true);
       fixture.componentRef.setInput('virtualization', true);
-      fixture.componentRef.setInput('rowHeight', 50);
+      rowHeight.set(50);
       fixture.componentRef.setInput('ghostLoadingIndicator', true);
       fixture.componentRef.setInput('bodyHeight', 200);
       fixture.componentRef.setInput('pageSize', 5);

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -24,7 +24,6 @@ import {
   viewChild
 } from '@angular/core';
 
-import { NgxDatatableConfig } from '../../ngx-datatable.config';
 import { TableColumnInternal } from '../../types/internal.types';
 import {
   ActivateEvent,
@@ -42,6 +41,7 @@ import { TableColumn } from '../../types/table-column.type';
 import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP, ENTER } from '../../utils/keys';
 import { RowHeightCache } from '../../utils/row-height-cache';
 import { selectRows, selectRowsBetween } from '../../utils/selection';
+import { DatatableConfiguration } from '../datatable-configuration';
 import { DatatableRowDetailDirective } from '../row-detail/row-detail.directive';
 import { DatatableGroupHeaderDirective } from './body-group-header.directive';
 import { DataTableGroupWrapperComponent } from './body-group-wrapper.component';
@@ -84,7 +84,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
         class="ghost-overlay"
         [columns]="columns"
         [pageSize]="pageSize()"
-        [rowHeight]="rowHeight()"
+        [rowHeight]="configuration().rowHeight"
         [ghostBodyHeight]="bodyHeight"
       />
     }
@@ -126,7 +126,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
             [disabled]="disabled"
             [expanded]="getRowExpanded(row)"
             [rowIndex]="indexes().first + index"
-            [ariaGroupHeaderCheckboxMessage]="ariaGroupHeaderCheckboxMessage()"
             [checkRowPropertyChanges]="checkRowPropertyChanges()"
             (rowContextmenu)="rowContextmenu.emit($event)"
           >
@@ -144,8 +143,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
               [displayCheck]="displayCheck()"
               [treeStatus]="row?.treeStatus"
               [draggable]="rowDraggable()"
-              [ariaRowCheckboxMessage]="ariaRowCheckboxMessage()"
-              [cssClasses]="cssClasses()"
               [checkRowPropertyChanges]="checkRowPropertyChanges()"
               (treeAction)="onTreeAction(row)"
               (activate)="onActivate($event, index)"
@@ -162,7 +159,11 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
         <div class="datatable-row-render-wrapper" [style.transform]="renderOffset()">
           @for (group of rowsToRender(); track rowTrackingFn(i, group); let i = $index) {
             @if (!group && ghostLoadingIndicator()) {
-              <ghost-loader [columns]="columns" [pageSize]="1" [rowHeight]="rowHeight()" />
+              <ghost-loader
+                [columns]="columns"
+                [pageSize]="1"
+                [rowHeight]="configuration().rowHeight"
+              />
             } @else if (group) {
               @let disableRowCheck = this.disableRowCheck();
               @let disabled = isRow(group) && disableRowCheck && disableRowCheck(group);
@@ -206,7 +207,6 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
                   [expanded]="getGroupExpanded(group)"
                   [rowIndex]="indexes().first + i"
                   [selected]="selected()"
-                  [ariaGroupHeaderCheckboxMessage]="ariaGroupHeaderCheckboxMessage()"
                   [allColumnsColspan]="allColumnsColspan()"
                   (groupSelectedChange)="groupSelectedChange($event, group)"
                 >
@@ -264,6 +264,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
 export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, OnChanges {
   cd = inject(ChangeDetectorRef);
   destroyRef = inject(DestroyRef);
+  protected readonly configuration = inject(DatatableConfiguration).configuration;
 
   readonly rowDefTemplate = input<TemplateRef<any>>();
   readonly scrollbarV = input(false, { transform: booleanAttribute });
@@ -271,7 +272,6 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   readonly loadingIndicator = input<boolean>();
   readonly ghostLoadingIndicator = input<boolean>();
   readonly externalPaging = input<boolean>();
-  readonly rowHeight = input.required<number | 'auto' | ((row?: any) => number)>();
   readonly offsetX = model.required<number>();
   readonly selectionType = input<SelectionType>();
   readonly selected = model<TRow[]>([]);
@@ -294,7 +294,6 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   readonly rowDraggable = input<boolean>();
   readonly rowDragEvents = input.required<OutputEmitterRef<DragEventData>>();
   readonly disableRowCheck = input<(row: TRow) => boolean | undefined>();
-  readonly ariaGroupHeaderCheckboxMessage = input.required<string>();
   readonly checkRowPropertyChanges = input(true, { transform: booleanAttribute });
 
   readonly pageSize = input.required<number>();
@@ -309,8 +308,6 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
 
   readonly bodyHeight = input<string | number>();
   readonly verticalScrollVisible = input(false);
-  readonly ariaRowCheckboxMessage = input.required<string>();
-  readonly cssClasses = input.required<Partial<Required<NgxDatatableConfig>['cssClasses']>>();
 
   readonly scroll = output<ScrollEvent>();
   readonly page = output<number>();
@@ -607,7 +604,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
    */
   getRowHeight(row: RowOrGroup<TRow>): number {
     // if its a function return it
-    const rowHeight = this.rowHeight();
+    const rowHeight = this.configuration().rowHeight;
     if (typeof rowHeight === 'function') {
       return rowHeight(row);
     }
@@ -621,7 +618,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
       return 0;
     }
     const rowHeightValue = groupHeader?.rowHeight();
-    const rowHeight = rowHeightValue === 0 ? this.rowHeight() : rowHeightValue;
+    const rowHeight = rowHeightValue === 0 ? this.configuration().rowHeight : rowHeightValue;
     return typeof rowHeight === 'function' ? rowHeight(row, index) : (rowHeight as number);
   };
 
@@ -682,7 +679,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     if (this.rows().length) {
       cache.initCache({
         rows: this.rows() as TRow[], // TODO: RowHeightCache does not support grouping
-        rowHeight: this.rowHeight(),
+        rowHeight: this.configuration().rowHeight,
         detailRowHeight: this.detailRowHeightFn(),
         externalVirtual: this.scrollbarV() && this.externalPaging(),
         indexOffset: this.externalPaging() ? this.offset() * this.pageSize() : 0,

--- a/projects/ngx-datatable/src/lib/components/body/progress-bar.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/progress-bar.component.ts
@@ -1,9 +1,15 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+
+import { DatatableConfiguration } from '../datatable-configuration';
 
 @Component({
   selector: 'datatable-progress',
   template: `
-    <div class="progress-linear" role="progressbar" [attr.aria-label]="ariaLoadingMessage()">
+    <div
+      class="progress-linear"
+      role="progressbar"
+      [attr.aria-label]="configuration().messages.ariaLoadingMessage"
+    >
       <div class="container">
         <div class="bar"></div>
       </div>
@@ -12,5 +18,5 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ProgressBarComponent {
-  readonly ariaLoadingMessage = input.required<string>();
+  protected readonly configuration = inject(DatatableConfiguration).configuration;
 }

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.spec.ts
@@ -2,6 +2,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component, ComponentRef, TemplateRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { provideDatatableConfigurationMock } from '../../../../testing/datatable-configuration.mock';
 import { TableColumnInternal } from '../../../types/internal.types';
 import { toInternalColumn } from '../../../utils/column-helper';
 import { DataTableSummaryRowComponent } from './summary-row.component';
@@ -24,6 +25,9 @@ describe('DataTableSummaryRowComponent', () => {
   });
 
   beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [provideDatatableConfigurationMock()]
+    });
     fixture = TestBed.createComponent(DataTableSummaryRowComponent);
 
     // Set required inputs before creating harness and detecting changes

--- a/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/summary/summary-row.component.ts
@@ -42,7 +42,6 @@ const noopSumFunc = (cells: any[]): void => {
           [rowHeight]="rowHeight()"
           [row]="summaryRow"
           [rowIndex]="{ index: -1 }"
-          [cssClasses]="{}"
         />
       }
     }

--- a/projects/ngx-datatable/src/lib/components/body/testing/body-cell.harness.ts
+++ b/projects/ngx-datatable/src/lib/components/body/testing/body-cell.harness.ts
@@ -13,7 +13,7 @@ export class BodyCellHarness extends ComponentHarness {
   }
 
   private async getCheckbox(): Promise<TestElement | null> {
-    const checkbox = await this.locatorForOptional('[aria-label="checkbox message"]')();
+    const checkbox = await this.locatorForOptional('input[type="checkbox"]')();
     return checkbox;
   }
 

--- a/projects/ngx-datatable/src/lib/components/datatable-configuration.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable-configuration.ts
@@ -1,0 +1,54 @@
+import { computed } from '@angular/core';
+
+import type { AllPartial, NgxDatatableConfig } from '../ngx-datatable.config';
+import type { DatatableComponent } from './datatable.component';
+
+/** @internal */
+export class DatatableConfiguration {
+  readonly configuration = computed(() => {
+    const configuration = this.globalConfiguration;
+
+    return {
+      ...configuration,
+      defaultColumnWidth: configuration.defaultColumnWidth ?? 150,
+      rowHeight: this.datatable.rowHeight(),
+      headerHeight: this.datatable.headerHeight(),
+      footerHeight: this.datatable.footerHeight() ?? 0,
+      cssClasses: {
+        sortAscending: 'datatable-icon-up',
+        sortDescending: 'datatable-icon-down',
+        sortUnset: 'datatable-icon-sort-unset',
+        pagerLeftArrow: 'datatable-icon-left',
+        pagerRightArrow: 'datatable-icon-right',
+        pagerPrevious: 'datatable-icon-prev',
+        pagerNext: 'datatable-icon-skip',
+        treeStatusLoading: 'icon datatable-icon-collapse',
+        treeStatusExpanded: 'icon datatable-icon-down',
+        treeStatusCollapsed: 'icon datatable-icon-up',
+        ...configuration.cssClasses,
+        ...this.datatable.cssClasses()
+      },
+      messages: {
+        emptyMessage: 'No data to display',
+        totalMessage: 'total',
+        selectedMessage: 'selected',
+        ariaFirstPageMessage: 'go to first page',
+        ariaPageNMessage: 'page',
+        ariaPreviousPageMessage: 'go to previous page',
+        ariaNextPageMessage: 'go to next page',
+        ariaLastPageMessage: 'go to last page',
+        ariaRowCheckboxMessage: 'Select row',
+        ariaHeaderCheckboxMessage: 'Select all rows',
+        ariaGroupHeaderCheckboxMessage: 'Select row group',
+        ariaLoadingMessage: 'Loading',
+        ...configuration.messages,
+        ...this.datatable.messages()
+      }
+    };
+  });
+
+  constructor(
+    private readonly datatable: DatatableComponent,
+    private readonly globalConfiguration: AllPartial<NgxDatatableConfig>
+  ) {}
+}

--- a/projects/ngx-datatable/src/lib/components/datatable.component.html
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.html
@@ -14,17 +14,12 @@
         [scrollbarH]="scrollbarH()"
         [dealsWithGroup]="_internalGroupedRows() !== undefined"
         [columns]="_internalColumns()"
-        [headerHeight]="headerHeight()"
         [reorderable]="reorderable()"
         [targetMarkerTemplate]="targetMarkerTemplate()"
-        [sortAscendingIcon]="cssClasses().sortAscending"
-        [sortDescendingIcon]="cssClasses().sortDescending"
-        [sortUnsetIcon]="cssClasses().sortUnset"
         [allRowsSelected]="allRowsSelected()"
         [selectionType]="selectionType()"
         [verticalScrollVisible]="verticalScrollVisible"
         [enableClearingSortState]="enableClearingSortState()"
-        [ariaHeaderCheckboxMessage]="messages().ariaHeaderCheckboxMessage ?? 'Select all rows'"
         (sort)="onColumnSort($event)"
         (resize)="onColumnResize($event)"
         (resizing)="onColumnResizing($event)"
@@ -45,7 +40,6 @@
       [loadingIndicator]="loadingIndicator()"
       [ghostLoadingIndicator]="ghostLoadingIndicator()"
       [externalPaging]="externalPaging()"
-      [rowHeight]="rowHeight()"
       [rowCount]="rowCount()"
       [offset]="correctedOffset()"
       [trackByProp]="trackByProp()"
@@ -65,16 +59,11 @@
       [summaryPosition]="summaryPosition()"
       [summaryRowTemplate]="summaryRowDirective()?.template"
       [verticalScrollVisible]="verticalScrollVisible"
-      [ariaRowCheckboxMessage]="messages().ariaRowCheckboxMessage ?? 'Select row'"
-      [ariaGroupHeaderCheckboxMessage]="
-        messages().ariaGroupHeaderCheckboxMessage ?? 'Select row group'
-      "
       [disableRowCheck]="disableRowCheck()"
       [checkRowPropertyChanges]="checkRowPropertyChanges()"
       [rowDraggable]="rowDraggable()"
       [rowDragEvents]="rowDragEvents"
       [rowDefTemplate]="_rowDefTemplate()"
-      [cssClasses]="cssClasses()"
       [(selected)]="selected"
       (page)="onBodyPage($event)"
       (activate)="activate.emit($event)"
@@ -83,10 +72,10 @@
       (treeAction)="onTreeAction($event)"
     >
       <ng-content select="[loading-indicator]" ngProjectAs="[loading-indicator]">
-        <datatable-progress [ariaLoadingMessage]="messages().ariaLoadingMessage ?? 'Loading'" />
+        <datatable-progress />
       </ng-content>
       <ng-content select="[empty-content]" ngProjectAs="[empty-content]">
-        <div class="empty-row" [innerHTML]="messages().emptyMessage ?? 'No data to display'"></div>
+        <div class="empty-row" [innerHTML]="configuration().messages.emptyMessage"></div>
       </ng-content>
     </datatable-body>
   </div>
@@ -96,15 +85,13 @@
       [groupCount]="_internalGroupedRows() !== undefined ? rowCount() : undefined"
       [pageSize]="pageSize()"
       [offset]="correctedOffset()"
-      [footerHeight]="footerHeight()"
       [footerTemplate]="_footer()"
-      [totalMessage]="messages().totalMessage ?? 'total'"
-      [pagerLeftArrowIcon]="cssClasses().pagerLeftArrow"
-      [pagerRightArrowIcon]="cssClasses().pagerRightArrow"
-      [pagerPreviousIcon]="cssClasses().pagerPrevious"
+      [pagerLeftArrowIcon]="configuration().cssClasses.pagerLeftArrow"
+      [pagerRightArrowIcon]="configuration().cssClasses.pagerRightArrow"
+      [pagerPreviousIcon]="configuration().cssClasses.pagerPrevious"
       [selectedCount]="selected().length"
-      [selectedMessage]="!!selectionType() && (messages().selectedMessage ?? 'selected')"
-      [pagerNextIcon]="cssClasses().pagerNext"
+      [selectedMessage]="!!selectionType()"
+      [pagerNextIcon]="configuration().cssClasses.pagerNext"
       (page)="onFooterPage($event)"
     />
   }

--- a/projects/ngx-datatable/src/lib/components/datatable.component.ts
+++ b/projects/ngx-datatable/src/lib/components/datatable.component.ts
@@ -30,6 +30,7 @@ import { Subscription } from 'rxjs';
 
 import { ScrollContainerDirective } from '../directives/scroll-container.directive';
 import {
+  AllPartial,
   NGX_DATATABLE_CONFIG,
   NgxDatatableConfig,
   NgxDatatableCssClasses,
@@ -80,6 +81,7 @@ import { DataTableBodyComponent } from './body/body.component';
 import { ProgressBarComponent } from './body/progress-bar.component';
 import { DatatableSummaryRowDirective } from './body/summary/summary-row.directive';
 import { DataTableColumnDirective } from './columns/column.directive';
+import { DatatableConfiguration } from './datatable-configuration';
 import { DataTableFooterComponent } from './footer/footer.component';
 import { DatatableFooterDirective } from './footer/footer.directive';
 import { DataTableHeaderComponent } from './header/header.component';
@@ -100,6 +102,10 @@ import { DatatableRowDetailDirective } from './row-detail/row-detail.directive';
     {
       provide: DATATABLE_COMPONENT_TOKEN,
       useExisting: DatatableComponent
+    },
+    {
+      provide: DatatableConfiguration,
+      useFactory: () => inject(DatatableComponent).datatableConfiguration
     }
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -124,12 +130,15 @@ export class DatatableComponent<TRow extends Row = any>
 {
   private scrollbarHelper = inject(ScrollbarHelper);
   private cd = inject(ChangeDetectorRef);
-  private configuration =
-    inject(NGX_DATATABLE_CONFIG, { optional: true }) ??
-    // This is the old injection token for backward compatibility.
-    inject<NgxDatatableConfig>('configuration' as any, { optional: true });
   element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
   rowDiffer: IterableDiffer<TRow | undefined> = inject(IterableDiffers).find([]).create();
+  private readonly globalConfiguration: AllPartial<NgxDatatableConfig> =
+    inject(NGX_DATATABLE_CONFIG, { optional: true }) ??
+    // This is the old injection token for backward compatibility.
+    inject<AllPartial<NgxDatatableConfig>>('configuration' as any, { optional: true }) ??
+    {};
+  readonly datatableConfiguration = new DatatableConfiguration(this, this.globalConfiguration);
+  protected readonly configuration = this.datatableConfiguration.configuration;
 
   /**
    * Template for the target marker of drag target columns.
@@ -199,7 +208,7 @@ export class DatatableComponent<TRow extends Row = any>
    * function that calculates each row's height.
    */
   readonly rowHeight = input<number | 'auto' | ((row: TRow) => number)>(
-    this.configuration?.rowHeight ?? 30
+    this.globalConfiguration.rowHeight ?? 30
   );
 
   /**
@@ -212,13 +221,13 @@ export class DatatableComponent<TRow extends Row = any>
    * The minimum header height in pixels.
    * Pass a falsey for no header
    */
-  readonly headerHeight = input<number | 'auto'>(this.configuration?.headerHeight ?? 30);
+  readonly headerHeight = input<number | 'auto'>(this.globalConfiguration.headerHeight ?? 30);
 
   /**
    * The minimum footer height in pixels.
    * Pass falsey for no footer
    */
-  readonly footerHeight = input(this.configuration?.footerHeight ?? 0, {
+  readonly footerHeight = input(this.globalConfiguration.footerHeight ?? 0, {
     transform: numberAttribute
   });
 
@@ -307,9 +316,7 @@ export class DatatableComponent<TRow extends Row = any>
   /**
    * CSS class overrides for sort and pager icons.
    */
-  readonly cssClasses = input<Partial<NgxDatatableCssClasses>>(
-    this.configuration?.cssClasses ?? {}
-  );
+  readonly cssClasses = input<Partial<NgxDatatableCssClasses>>({});
 
   /**
    * Message overrides for localization
@@ -332,7 +339,7 @@ export class DatatableComponent<TRow extends Row = any>
    * }
    * ```
    */
-  readonly messages = input<Partial<NgxDatatableMessages>>(this.configuration?.messages ?? {});
+  readonly messages = input<Partial<NgxDatatableMessages>>({});
 
   /**
    * A function which is called with the row and should return either:
@@ -683,7 +690,7 @@ export class DatatableComponent<TRow extends Row = any>
   });
 
   _subscriptions: Subscription[] = [];
-  _defaultColumnWidth = this.configuration?.defaultColumnWidth ?? 150;
+  _defaultColumnWidth = this.globalConfiguration.defaultColumnWidth ?? 150;
   /**
    * To have this available for all components.
    * The Footer itself is not available in the injection context in templates,

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.spec.ts
@@ -1,7 +1,8 @@
-import { Component, DebugElement, signal, TemplateRef, viewChild } from '@angular/core';
+import { Component, DebugElement, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { provideDatatableConfigurationMock } from '../../../testing/datatable-configuration.mock';
 import { DATATABLE_COMPONENT_TOKEN } from '../../utils/table-token';
 import { DataTableFooterTemplateDirective } from './footer-template.directive';
 import { DataTableFooterComponent } from './footer.component';
@@ -10,9 +11,11 @@ import { DatatableFooterDirective } from './footer.directive';
 let fixture: ComponentFixture<TestFixtureComponent>;
 let component: TestFixtureComponent;
 let page: Page;
+const footerHeight = signal(0);
 
 describe('DataTableFooterComponent', () => {
   beforeEach(async () => {
+    footerHeight.set(0);
     fixture = TestBed.createComponent(TestFixtureComponent);
     component = fixture.componentInstance;
     page = new Page();
@@ -21,14 +24,14 @@ describe('DataTableFooterComponent', () => {
 
   describe('div.datatable-footer-inner', () => {
     it(`should have a height`, async () => {
-      component.footerHeight.set(123);
+      footerHeight.set(123);
       await page.detectChangesAndRunQueries();
 
       expect(page.datatableFooterInner.nativeElement.style.height).toEqual('123px');
     });
 
     it('should have `.selected-count` class when selectedMessage is set', async () => {
-      component.selectedMessage.set('selected');
+      component.selectedMessage.set(true);
       component.selectedCount.set(1);
       await page.detectChangesAndRunQueries();
 
@@ -38,7 +41,7 @@ describe('DataTableFooterComponent', () => {
     });
 
     it('should not have `.selected-count` class if selectedMessage is not set', async () => {
-      component.selectedMessage.set(undefined);
+      component.selectedMessage.set(false);
       await page.detectChangesAndRunQueries();
 
       expect(page.datatableFooterInner.nativeElement.classList.contains('selected-count')).toBe(
@@ -57,10 +60,9 @@ describe('DataTableFooterComponent', () => {
 
     it('should display the selected count and total if selectedMessage set', async () => {
       component.footerTemplate.set(undefined);
-      component.selectedMessage.set('selected');
+      component.selectedMessage.set(true);
       component.selectedCount.set(7);
       component.rowCount.set(10);
-      component.totalMessage.set('total');
       await page.detectChangesAndRunQueries();
 
       expect(page.pageCount.nativeElement.innerText).toEqual('7 selected / 10 total');
@@ -68,9 +70,8 @@ describe('DataTableFooterComponent', () => {
 
     it('should display only the total if selectedMessage is not set', async () => {
       component.footerTemplate.set(undefined);
-      component.selectedMessage.set(undefined);
+      component.selectedMessage.set(false);
       component.rowCount.set(100);
-      component.totalMessage.set('total');
       await page.detectChangesAndRunQueries();
 
       expect(page.pageCount.nativeElement.innerText).toEqual('100 total');
@@ -145,9 +146,7 @@ describe('DataTableFooterComponent', () => {
       [groupCount]="undefined"
       [pageSize]="pageSize()"
       [offset]="offset()"
-      [footerHeight]="footerHeight()"
       [footerTemplate]="footerTemplate()"
-      [totalMessage]="totalMessage()"
       [pagerLeftArrowIcon]="pagerLeftArrowIcon()"
       [pagerRightArrowIcon]="pagerRightArrowIcon()"
       [pagerPreviousIcon]="pagerPreviousIcon()"
@@ -177,7 +176,10 @@ describe('DataTableFooterComponent', () => {
       </ng-template>
     </ngx-datatable-footer>
   `,
-  providers: [{ provide: DATATABLE_COMPONENT_TOKEN, useExisting: TestFixtureComponent }]
+  providers: [
+    { provide: DATATABLE_COMPONENT_TOKEN, useExisting: TestFixtureComponent },
+    provideDatatableConfigurationMock({ footerHeight })
+  ]
 })
 class TestFixtureComponent {
   readonly footerHeight = signal(0);
@@ -188,10 +190,9 @@ class TestFixtureComponent {
   readonly pagerRightArrowIcon = signal('');
   readonly pagerPreviousIcon = signal('');
   readonly pagerNextIcon = signal('');
-  readonly totalMessage = signal('');
   readonly footerTemplate = signal<DatatableFooterDirective | undefined>(undefined);
   readonly selectedCount = signal(0);
-  readonly selectedMessage = signal<string | undefined>(undefined);
+  readonly selectedMessage = signal(false);
   readonly messages = signal({});
 
   /**

--- a/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/footer.component.ts
@@ -1,7 +1,16 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, input, output, Signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  Signal
+} from '@angular/core';
 
 import { FooterContext, PagerPageEvent } from '../../types/public.types';
+import { DatatableConfiguration } from '../datatable-configuration';
 import { DatatableFooterDirective } from './footer.directive';
 import { DatatablePagerComponent } from './pager.component';
 
@@ -12,7 +21,7 @@ import { DatatablePagerComponent } from './pager.component';
     <div
       class="datatable-footer-inner"
       [class.selected-count]="selectedMessage()"
-      [style.height.px]="footerHeight()"
+      [style.height.px]="configuration().footerHeight"
     >
       @let footerTemplate = this.footerTemplate()?.template();
       @if (footerTemplate) {
@@ -23,9 +32,12 @@ import { DatatablePagerComponent } from './pager.component';
       } @else {
         <div class="page-count">
           @if (selectedMessage()) {
-            <span> {{ selectedCount().toLocaleString() }} {{ selectedMessage() }} / </span>
+            <span>
+              {{ selectedCount().toLocaleString() }}
+              {{ configuration().messages.selectedMessage }} /
+            </span>
           }
-          {{ rowCount().toLocaleString() }} {{ totalMessage() }}
+          {{ rowCount().toLocaleString() }} {{ configuration().messages.totalMessage }}
         </div>
         @if (isVisible()) {
           <ngx-datatable-pager />
@@ -40,7 +52,7 @@ import { DatatablePagerComponent } from './pager.component';
   }
 })
 export class DataTableFooterComponent {
-  readonly footerHeight = input.required<number>();
+  protected readonly configuration = inject(DatatableConfiguration).configuration;
   readonly rowCount = input.required<number>();
   readonly groupCount = input.required<number | undefined>();
   readonly pageSize = input.required<number>();
@@ -49,11 +61,10 @@ export class DataTableFooterComponent {
   readonly pagerRightArrowIcon = input<string | undefined>();
   readonly pagerPreviousIcon = input<string | undefined>();
   readonly pagerNextIcon = input<string | undefined>();
-  readonly totalMessage = input.required<string>();
   readonly footerTemplate = input<DatatableFooterDirective | undefined>();
 
   readonly selectedCount = input(0);
-  readonly selectedMessage = input<string | boolean | undefined>(undefined);
+  readonly selectedMessage = input(false);
 
   readonly page = output<PagerPageEvent>();
 

--- a/projects/ngx-datatable/src/lib/components/footer/pager.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/pager.component.spec.ts
@@ -10,6 +10,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DatatableComponent } from '@siemens/ngx-datatable';
 
+import { provideDatatableConfigurationMock } from '../../../testing/datatable-configuration.mock';
 import { DATATABLE_COMPONENT_TOKEN } from '../../utils/table-token';
 import { DatatablePagerComponent } from './pager.component';
 import { PagerHarness } from './testing/pager.harness';
@@ -51,6 +52,7 @@ describe('DataTablePagerComponent', () => {
       set: {
         changeDetection: ChangeDetectionStrategy.Default,
         providers: [
+          provideDatatableConfigurationMock({ messages }),
           {
             provide: DATATABLE_COMPONENT_TOKEN,
             useValue: { _footerComponent: signal(footer), messages }

--- a/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
+++ b/projects/ngx-datatable/src/lib/components/footer/pager.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/c
 
 import { Page } from '../../types/internal.types';
 import { DATATABLE_COMPONENT_TOKEN } from '../../utils/table-token';
-import { DatatableComponent } from '../datatable.component';
+import { DatatableConfiguration } from '../datatable-configuration';
 
 /**
  * Use this component to construct custom table footer with standard pagination.
@@ -32,10 +32,10 @@ import { DatatableComponent } from '../datatable.component';
           type="button"
           class="page-button"
           [disabled]="!canPrevious()"
-          [attr.aria-label]="messages.ariaFirstPageMessage ?? 'go to first page'"
+          [attr.aria-label]="configuration().messages.ariaFirstPageMessage"
           (click)="selectPage(1)"
         >
-          <i [class]="pagerPreviousIcon() ?? 'datatable-icon-prev'"></i>
+          <i [class]="pagerPreviousIcon()"></i>
         </button>
       </li>
       <li>
@@ -43,10 +43,10 @@ import { DatatableComponent } from '../datatable.component';
           type="button"
           class="page-button"
           [disabled]="!canPrevious()"
-          [attr.aria-label]="messages.ariaPreviousPageMessage ?? 'go to previous page'"
+          [attr.aria-label]="configuration().messages.ariaPreviousPageMessage"
           (click)="prevPage()"
         >
-          <i [class]="pagerLeftArrowIcon() ?? 'datatable-icon-left'"></i>
+          <i [class]="pagerLeftArrowIcon()"></i>
         </button>
       </li>
       @for (pg of pages(); track pg.number) {
@@ -55,7 +55,7 @@ import { DatatableComponent } from '../datatable.component';
             type="button"
             class="page-button"
             [class.active]="pg.number === page()"
-            [attr.aria-label]="(messages.ariaPageNMessage ?? 'page') + ' ' + pg.number"
+            [attr.aria-label]="configuration().messages.ariaPageNMessage + ' ' + pg.number"
             (click)="selectPage(pg.number)"
           >
             {{ pg.text }}
@@ -67,10 +67,10 @@ import { DatatableComponent } from '../datatable.component';
           type="button"
           class="page-button"
           [disabled]="!canNext()"
-          [attr.aria-label]="messages.ariaNextPageMessage ?? 'go to next page'"
+          [attr.aria-label]="configuration().messages.ariaNextPageMessage"
           (click)="nextPage()"
         >
-          <i [class]="pagerRightArrowIcon() ?? 'datatable-icon-right'"></i>
+          <i [class]="pagerRightArrowIcon()"></i>
         </button>
       </li>
       <li>
@@ -78,10 +78,10 @@ import { DatatableComponent } from '../datatable.component';
           type="button"
           class="page-button"
           [disabled]="!canNext()"
-          [attr.aria-label]="messages.ariaLastPageMessage ?? 'go to last page'"
+          [attr.aria-label]="configuration().messages.ariaLastPageMessage"
           (click)="selectPage(totalPages())"
         >
-          <i [class]="pagerNextIcon() ?? 'datatable-icon-skip'"></i>
+          <i [class]="pagerNextIcon()"></i>
         </button>
       </li>
     </ul>
@@ -98,9 +98,7 @@ export class DatatablePagerComponent {
   // Ideally we can one day fetch those attributes from a global state, but for now this is fine.
   private datatable = inject(DATATABLE_COMPONENT_TOKEN);
 
-  protected get messages(): ReturnType<DatatableComponent['messages']> {
-    return this.datatable?.messages() ?? {};
-  }
+  protected readonly configuration = inject(DatatableConfiguration).configuration;
 
   protected readonly page = computed(() => this.datatable._footerComponent()!.curPage());
   protected readonly pageSize = computed(() => this.datatable._footerComponent()!.pageSize());

--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.spec.ts
@@ -2,6 +2,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import {
   AfterViewInit,
   Component,
+  computed,
   inputBinding,
   outputBinding,
   signal,
@@ -12,6 +13,7 @@ import {
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { userEvent } from '@vitest/browser/context';
 
+import { provideDatatableConfigurationMock } from '../../../testing/datatable-configuration.mock';
 import {
   InnerSortEvent,
   SortableTableColumnInternal,
@@ -28,8 +30,10 @@ describe('DataTableHeaderCellComponent', () => {
   let harness: HeaderCellHarness;
 
   beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [provideDatatableConfigurationMock()]
+    });
     fixture = TestBed.createComponent(DataTableHeaderCellComponent);
-    fixture.componentRef.setInput('ariaHeaderCheckboxMessage', 'Select All');
     fixture.componentRef.setInput('sortType', 'single');
     component = fixture.componentInstance;
     fixture.componentRef.setInput('column', {
@@ -40,7 +44,6 @@ describe('DataTableHeaderCellComponent', () => {
       width: signal(0)
     });
     fixture.componentRef.setInput('sortType', 'single');
-    fixture.componentRef.setInput('ariaHeaderCheckboxMessage', 'Select all rows');
     fixture.componentInstance.sort.subscribe(sort => {
       fixture.componentRef.setInput('sorts', [
         {
@@ -114,12 +117,7 @@ describe('DataTableHeaderCellComponent', () => {
 @Component({
   imports: [DataTableHeaderCellComponent],
   template: `
-    <datatable-header-cell
-      sortType="single"
-      ariaHeaderCheckboxMessage="checked"
-      [column]="column()"
-      (sort)="sort($event)"
-    />
+    <datatable-header-cell sortType="single" [column]="column()" (sort)="sort($event)" />
     <ng-template #headerCellTemplate let-sort="sortFn" let-column="column">
       <span class="custom-header">Custom Header for {{ column.name }}</span>
       <button class="custom-sort-button" type="button" (click)="sort($event)">
@@ -152,6 +150,9 @@ describe('DataTableHeaderCellComponent with template', () => {
   let harness: HeaderCellHarness;
 
   beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [provideDatatableConfigurationMock()]
+    });
     fixture = TestBed.createComponent(TestHeaderCellComponent);
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, HeaderCellHarness);
   });
@@ -187,12 +188,19 @@ describe('DataTableHeaderCellComponent - custom sort icons', () => {
 
   beforeEach(async () => {
     sorts = signal<SortPropDir[]>([]);
+    TestBed.configureTestingModule({
+      providers: [
+        provideDatatableConfigurationMock({
+          cssClasses: computed(() => ({
+            sortAscending: sortAscendingIcon(),
+            sortDescending: sortDescendingIcon()
+          }))
+        })
+      ]
+    });
     fixture = TestBed.createComponent(DataTableHeaderCellComponent, {
       bindings: [
         inputBinding('sortType', () => 'single'),
-        inputBinding('ariaHeaderCheckboxMessage', () => 'Select All'),
-        inputBinding('sortAscendingIcon', sortAscendingIcon),
-        inputBinding('sortDescendingIcon', sortDescendingIcon),
         inputBinding('column', column),
         inputBinding('sorts', sorts),
         inputBinding('showResizeHandle', () => false),

--- a/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header-cell.component.ts
@@ -33,6 +33,7 @@ import {
 } from '../../types/public.types';
 import { toPublicColumn } from '../../utils/column-helper';
 import { nextSortDir } from '../../utils/sort';
+import { DatatableConfiguration } from '../datatable-configuration';
 
 @Component({
   selector: 'datatable-header-cell',
@@ -49,7 +50,7 @@ import { nextSortDir } from '../../utils/sort';
         <label class="datatable-checkbox">
           <input
             type="checkbox"
-            [attr.aria-label]="ariaHeaderCheckboxMessage()"
+            [attr.aria-label]="configuration().messages.ariaHeaderCheckboxMessage"
             [checked]="allRowsSelected()"
             (change)="select.emit()"
           />
@@ -98,18 +99,15 @@ import { nextSortDir } from '../../utils/sort';
 })
 export class DataTableHeaderCellComponent implements OnInit, OnDestroy {
   private element = inject(ElementRef).nativeElement;
+  protected readonly configuration = inject(DatatableConfiguration).configuration;
 
   readonly sortType = input.required<SortType>();
-  readonly sortAscendingIcon = input<string>();
-  readonly sortDescendingIcon = input<string>();
-  readonly sortUnsetIcon = input<string>();
 
   readonly isTarget = input<boolean>();
   readonly showResizeHandle = input<boolean | undefined>(true);
   readonly targetMarkerTemplate = input<TemplateRef<any>>();
   readonly targetMarkerContext = input<any>();
   readonly enableClearingSortState = input(false);
-  readonly ariaHeaderCheckboxMessage = input.required<string>();
   readonly allRowsSelected = input(false, { transform: booleanAttribute });
   readonly selectionType = input<SelectionType>();
   readonly column = input.required<TableColumnInternal>();
@@ -239,11 +237,11 @@ export class DataTableHeaderCellComponent implements OnInit, OnDestroy {
 
     switch (sortDir) {
       case 'asc':
-        return `${base} sort-asc ${this.sortAscendingIcon() ?? 'datatable-icon-up'}`;
+        return `${base} sort-asc ${this.configuration().cssClasses.sortAscending}`;
       case 'desc':
-        return `${base} sort-desc ${this.sortDescendingIcon() ?? 'datatable-icon-down'}`;
+        return `${base} sort-desc ${this.configuration().cssClasses.sortDescending}`;
       default:
-        return `${base} ${this.sortUnsetIcon() ?? 'datatable-icon-sort-unset'}`;
+        return `${base} ${this.configuration().cssClasses.sortUnset}`;
     }
   }
 

--- a/projects/ngx-datatable/src/lib/components/header/header.component.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { vi } from 'vitest';
 
+import { provideDatatableConfigurationMock } from '../../../testing/datatable-configuration.mock';
 import { columnsByPinArr, gridColumnTemplate } from '../../utils/column';
 import { toInternalColumn } from '../../utils/column-helper';
 import { DataTableHeaderComponent } from './header.component';
@@ -22,12 +23,13 @@ describe('DataTableHeaderComponent', () => {
   };
 
   beforeEach(async () => {
+    TestBed.configureTestingModule({
+      providers: [provideDatatableConfigurationMock()]
+    });
     fixture = TestBed.createComponent(DataTableHeaderComponent);
     fixture.componentRef.setInput('columns', []);
     fixture.componentRef.setInput('sorts', []);
     fixture.componentRef.setInput('sortType', 'single');
-    fixture.componentRef.setInput('headerHeight', 50);
-    fixture.componentRef.setInput('ariaHeaderCheckboxMessage', 'Select all rows');
 
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, HeaderHarness);
     componentRef = fixture.componentRef;

--- a/projects/ngx-datatable/src/lib/components/header/header.component.ts
+++ b/projects/ngx-datatable/src/lib/components/header/header.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  inject,
   input,
   output,
   TemplateRef
@@ -27,6 +28,7 @@ import {
 } from '../../types/public.types';
 import { columnsByPinArr } from '../../utils/column';
 import { toPublicColumn } from '../../utils/column-helper';
+import { DatatableConfiguration } from '../datatable-configuration';
 import { DataTableHeaderCellComponent } from './header-cell.component';
 
 @Component({
@@ -61,12 +63,8 @@ import { DataTableHeaderCellComponent } from './header-cell.component';
                 [sortType]="sortType()"
                 [sorts]="sorts()"
                 [selectionType]="selectionType()"
-                [sortAscendingIcon]="sortAscendingIcon()"
-                [sortDescendingIcon]="sortDescendingIcon()"
-                [sortUnsetIcon]="sortUnsetIcon()"
                 [allRowsSelected]="allRowsSelected()"
                 [enableClearingSortState]="enableClearingSortState()"
-                [ariaHeaderCheckboxMessage]="ariaHeaderCheckboxMessage()"
                 (resize)="onColumnResized($event)"
                 (resizing)="onColumnResizing($event)"
                 (sort)="onSort($event)"
@@ -83,15 +81,13 @@ import { DataTableHeaderCellComponent } from './header-cell.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'datatable-header',
-    '[style.height.px]': 'headerHeight()'
+    '[style.height.px]': 'configuration().headerHeight'
   }
 })
 export class DataTableHeaderComponent {
+  protected readonly configuration = inject(DatatableConfiguration).configuration;
   readonly lastColumnId = computed(() => this.columns().at(-1)?.$$id);
 
-  readonly sortAscendingIcon = input<string>();
-  readonly sortDescendingIcon = input<string>();
-  readonly sortUnsetIcon = input<string>();
   readonly scrollbarH = input<boolean>();
   readonly dealsWithGroup = input<boolean>();
   readonly targetMarkerTemplate = input<TemplateRef<unknown>>();
@@ -102,9 +98,7 @@ export class DataTableHeaderComponent {
   readonly selectionType = input<SelectionType>();
   readonly reorderable = input<boolean>();
   readonly verticalScrollVisible = input(false);
-  readonly ariaHeaderCheckboxMessage = input.required<string>();
 
-  readonly headerHeight = input.required<'auto' | number>();
   readonly columns = input.required<TableColumnInternal[]>();
 
   readonly sort = output<SortEvent>();

--- a/projects/ngx-datatable/src/lib/ngx-datatable.config.ts
+++ b/projects/ngx-datatable/src/lib/ngx-datatable.config.ts
@@ -48,24 +48,27 @@ export interface NgxDatatableCssClasses {
 /**
  * Interface definition for ngx-datatable global configuration
  */
-// TODO those properties should all be required in the interface. Should be changed with signal migration.
 export interface NgxDatatableConfig {
-  messages?: NgxDatatableMessages;
-  cssClasses?: NgxDatatableCssClasses;
-  headerHeight?: number;
-  footerHeight?: number;
-  rowHeight?: number;
-  defaultColumnWidth?: number;
+  messages: NgxDatatableMessages;
+  cssClasses: NgxDatatableCssClasses;
+  headerHeight: number | 'auto';
+  footerHeight: number;
+  rowHeight: number | 'auto' | ((row: any) => number);
+  defaultColumnWidth: number;
 }
 
-export const NGX_DATATABLE_CONFIG = new InjectionToken<NgxDatatableConfig>('ngx-datatable.config');
+export const NGX_DATATABLE_CONFIG = new InjectionToken<AllPartial<NgxDatatableConfig>>(
+  'ngx-datatable.config'
+);
 
 /**
  * This makes all properties recursively optional.
  *
  * @internal
  */
-export type AllPartial<T> = { [K in keyof T]?: AllPartial<T[K]> };
+export type AllPartial<T> = T extends (...args: any[]) => any
+  ? T
+  : { [K in keyof T]?: AllPartial<T[K]> };
 
 /**
  * Interface definition for INgxDatatableConfig global configuration.

--- a/projects/ngx-datatable/src/testing/datatable-configuration.mock.ts
+++ b/projects/ngx-datatable/src/testing/datatable-configuration.mock.ts
@@ -1,0 +1,38 @@
+import { Provider, Signal, signal } from '@angular/core';
+
+import { DatatableConfiguration } from '../lib/components/datatable-configuration';
+import { DatatableComponent } from '../lib/components/datatable.component';
+import { AllPartial, NgxDatatableConfig } from '../lib/ngx-datatable.config';
+
+export interface DatatableConfigurationOverrides {
+  rowHeight?: Signal<NgxDatatableConfig['rowHeight']>;
+  headerHeight?: Signal<NgxDatatableConfig['headerHeight']>;
+  footerHeight?: Signal<NgxDatatableConfig['footerHeight']>;
+  cssClasses?: Signal<AllPartial<NgxDatatableConfig['cssClasses']>>;
+  messages?: Signal<AllPartial<NgxDatatableConfig['messages']>>;
+}
+
+export const provideDatatableConfigurationMock = (
+  overrides: DatatableConfigurationOverrides = {}
+): Provider => {
+  const {
+    rowHeight = signal(30),
+    headerHeight = signal(30),
+    footerHeight = signal(0),
+    cssClasses = signal({}),
+    messages = signal({})
+  } = overrides;
+  const table = {
+    rowHeight,
+    headerHeight,
+    footerHeight,
+    cssClasses,
+    messages
+  };
+  const configuration = new DatatableConfiguration(table as unknown as DatatableComponent, {});
+
+  return {
+    provide: DatatableConfiguration,
+    useValue: configuration
+  };
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Configuration defaults and overrides are forwarded through nested table components.

**What is the new behavior?**

A table-scoped internal `DatatableConfiguration` resolves global configuration, table overrides, and defaults. Child components inject the resolved configuration directly, removing configuration-related input forwarding.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: N/A

**Other information**:

Unit-test helpers use the production configuration resolver with signal-backed input overrides.