### PR TITLE
fix(body): move arrow-key focus between grouped rows

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-cell.component.ts
@@ -177,6 +177,10 @@ export class DataTableBodyCellComponent<TRow extends Row = any> implements DoChe
     }
   }
 
+  focus(): void {
+    this._element.focus();
+  }
+
   private getComputedValue(): any {
     let value = '';
     const column = this.column();

--- a/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body-row.component.ts
@@ -11,7 +11,8 @@ import {
   input,
   KeyValueDiffer,
   KeyValueDiffers,
-  output
+  output,
+  viewChildren
 } from '@angular/core';
 
 import { CellActiveEvent, RowIndex, TableColumnInternal } from '../../types/internal.types';
@@ -106,6 +107,7 @@ export class DataTableBodyRowComponent<TRow extends Row = any> implements DoChec
   readonly _columnsByPin = computed(() => {
     return columnsByPinArr(this.columns());
   });
+  private readonly cells = viewChildren(DataTableBodyCellComponent);
 
   ngDoCheck(): void {
     if (!this.checkRowPropertyChanges()) {
@@ -118,6 +120,14 @@ export class DataTableBodyRowComponent<TRow extends Row = any> implements DoChec
 
   onActivate(event: CellActiveEvent<TRow>, index: number): void {
     this.activate.emit({ ...event, rowElement: this._element, cellIndex: index });
+  }
+
+  focus(): void {
+    this._element.focus();
+  }
+
+  focusCell(index: number): void {
+    this.cells()[index]?.focus();
   }
 
   @HostListener('keydown', ['$event'])

--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -145,7 +145,7 @@ import { DataTableSummaryRowComponent } from './summary/summary-row.component';
               [draggable]="rowDraggable()"
               [checkRowPropertyChanges]="checkRowPropertyChanges()"
               (treeAction)="onTreeAction(row)"
-              (activate)="onActivate($event, index)"
+              (activate)="onActivate($event, index, indexInGroup)"
               (drop)="drop($event, row, rowElement)"
               (dragover)="dragOver($event, row)"
               (dragenter)="dragEnter($event, row, rowElement)"
@@ -320,6 +320,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
 
   private readonly scroller = viewChild(ScrollerComponent);
   private readonly rowWrappers = viewChildren(DataTableRowWrapperComponent);
+  private readonly rowComponents = viewChildren(DataTableBodyRowComponent);
 
   /**
    * Returns if selection is enabled.
@@ -901,7 +902,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     this.prevIndex = index;
   }
 
-  onActivate(modelObject: ActivateEvent<TRow>, index: number): void {
+  onActivate(modelObject: ActivateEvent<TRow>, index: number, indexInGroup?: number): void {
     const { type, event, row } = modelObject;
     const chkbox = this.selectionType() === 'checkbox';
     const select =
@@ -918,7 +919,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
       ) {
         this.selectRow(event, 0, row); // The row property is ignored in this case. So we can pass anything.
       } else {
-        this.onKeyboardFocus(modelObject);
+        this.onKeyboardFocus(modelObject, index, indexInGroup);
       }
     }
     this.activate.emit(modelObject);
@@ -934,7 +935,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     this.selected.set(Array.from(selectedSet));
   }
 
-  onKeyboardFocus(modelObject: ActivateEvent<TRow>): void {
+  onKeyboardFocus(modelObject: ActivateEvent<TRow>, index: number, indexInGroup?: number): void {
     const { key } = modelObject.event as KeyboardEvent;
     const shouldFocus =
       key === ARROW_UP || key === ARROW_DOWN || key === ARROW_RIGHT || key === ARROW_LEFT;
@@ -948,67 +949,60 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
           return;
         }
       }
-      if (!modelObject.cellElement || !isCellSelection) {
-        this.focusRow(modelObject.rowElement, key);
+      if (!isCellSelection) {
+        this.focusRow(index, key, indexInGroup);
       } else if (isCellSelection && modelObject.cellIndex !== undefined) {
-        this.focusCell(modelObject.cellElement, modelObject.rowElement, key, modelObject.cellIndex);
+        this.focusCell(index, key, modelObject.cellIndex, indexInGroup);
       }
     }
   }
 
-  focusRow(rowElement: HTMLElement, key: string): void {
-    const nextRowElement = this.getPrevNextRow(rowElement, key);
-    if (nextRowElement) {
-      nextRowElement.focus();
+  focusRow(index: number, key: string, indexInGroup?: number): void {
+    const nextRow = this.getPrevNextRow(index, key, indexInGroup);
+    if (nextRow) {
+      nextRow.focus();
     }
   }
 
-  getPrevNextRow(rowElement: HTMLElement, key: string): any {
-    const parentElement = rowElement.parentElement;
-
-    if (parentElement) {
-      let focusElement: Element | null = null;
-      if (key === ARROW_UP) {
-        focusElement = parentElement.previousElementSibling;
-      } else if (key === ARROW_DOWN) {
-        focusElement = parentElement.nextElementSibling;
-      }
-
-      if (focusElement?.children.length) {
-        return focusElement.children[0];
-      }
-    }
-  }
-
-  focusCell(
-    cellElement: HTMLElement,
-    rowElement: HTMLElement,
+  getPrevNextRow(
+    index: number,
     key: string,
-    cellIndex: number
-  ): void {
-    let nextCellElement: Element | null = null;
+    indexInGroup?: number
+  ): DataTableBodyRowComponent | undefined {
+    // It is safe to assume, the currentRow always exists since this is called by a keypress an event on that row.
+    const currentRow = this.getRow(index, indexInGroup)!;
+    const currentRowIndex = this.rowComponents().indexOf(currentRow);
+
+    if (key === ARROW_UP) {
+      return this.rowComponents()[currentRowIndex - 1];
+    }
+    if (key === ARROW_DOWN) {
+      return this.rowComponents()[currentRowIndex + 1];
+    }
+
+    return undefined;
+  }
+
+  focusCell(index: number, key: string, cellIndex: number, indexInGroup?: number): void {
+    let nextRow = this.getRow(index, indexInGroup);
+    let nextCellIndex = cellIndex;
 
     if (key === ARROW_LEFT) {
-      nextCellElement = cellElement.previousElementSibling;
+      nextCellIndex--;
     } else if (key === ARROW_RIGHT) {
-      nextCellElement = cellElement.nextElementSibling;
+      nextCellIndex++;
     } else if (key === ARROW_UP || key === ARROW_DOWN) {
-      const nextRowElement = this.getPrevNextRow(rowElement, key);
-      if (nextRowElement) {
-        const children = nextRowElement.getElementsByClassName('datatable-body-cell');
-        if (children.length) {
-          nextCellElement = children[cellIndex];
-        }
-      }
+      nextRow = this.getPrevNextRow(index, key, indexInGroup);
     }
 
-    if (
-      nextCellElement &&
-      'focus' in nextCellElement &&
-      typeof nextCellElement.focus === 'function'
-    ) {
-      nextCellElement.focus();
-    }
+    nextRow?.focusCell(nextCellIndex);
+  }
+
+  private getRow(index: number, indexInGroup?: number): DataTableBodyRowComponent | undefined {
+    return this.rowComponents().find(row => {
+      const rowIndex = row.rowIndex();
+      return rowIndex.index === index && rowIndex.indexInGroup === indexInGroup;
+    });
   }
 
   getRowSelected(row: TRow): boolean {

--- a/projects/ngx-datatable/src/lib/components/body/keyboard-navigation.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/keyboard-navigation.spec.ts
@@ -14,6 +14,8 @@ import { DatatableComponent } from '../datatable.component';
       [rows]="rows()"
       [selectionType]="selectionType()"
       [disableRowCheck]="disableRowCheck()"
+      [groupRowsBy]="groupRowsBy()"
+      [groupExpansionDefault]="groupExpansionDefault()"
       [selected]="selected()"
       (selectedChange)="selected.set($event)"
     />
@@ -34,6 +36,8 @@ class KeyboardNavigationTestComponent {
   ]);
   readonly selected = signal<Record<string, string>[]>([]);
   readonly selectionType = signal<SelectionType>('single');
+  readonly groupRowsBy = signal<string | undefined>(undefined);
+  readonly groupExpansionDefault = signal(false);
   readonly disableRowCheck = signal<((row: Record<string, string>) => boolean) | undefined>(
     undefined
   );
@@ -99,6 +103,30 @@ describe('keyboard navigation', () => {
     await userEvent.keyboard('{ArrowDown}');
     await fixture.whenStable();
     expect(graceRow.classList).toContain('row-disabled');
+    expect(document.activeElement).toBe(graceRow);
+  });
+
+  it('moves row focus between grouped rows in rendered order', async () => {
+    fixture.componentInstance.rows.set([
+      { name: 'Ada', city: 'London' },
+      { name: 'Grace', city: 'London' },
+      { name: 'Linus', city: 'Helsinki' },
+      { name: 'Margaret', city: 'Helsinki' }
+    ]);
+    fixture.componentInstance.groupRowsBy.set('city');
+    fixture.componentInstance.groupExpansionDefault.set(true);
+    await fixture.whenStable();
+
+    const graceRow = page.getByRole('row', { name: 'Grace London' }).element();
+    const linusRow = page.getByRole('row', { name: 'Linus Helsinki' }).element();
+    graceRow.focus();
+
+    await userEvent.keyboard('{ArrowDown}');
+    await fixture.whenStable();
+    expect(document.activeElement).toBe(linusRow);
+
+    await userEvent.keyboard('{ArrowUp}');
+    await fixture.whenStable();
     expect(document.activeElement).toBe(graceRow);
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Arrow-key navigation does not move between grouped rows correctly, including at group boundaries.

**What is the new behavior?**

Arrow-key navigation resolves the focused row through Angular `viewChildren` and follows the rendered row order. Focus now moves between rows within a group and from the final row of one expanded group to the first row of the next group, while retaining cell column focus.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Includes keyboard-navigation regression coverage for grouped rows.