### PR TITLE
build: share example routes with web components

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -21,7 +21,7 @@
         <h4>Basic</h4>
         <ul>
           <li>
-            <a routerLink="10k-rows">10k Rows</a>
+            <a routerLink="ten-k-rows">10k Rows</a>
           </li>
           <li>
             <a routerLink="full-screen">Full Screen</a>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,15 +1,21 @@
 import { Routes } from '@angular/router';
 
+// Route paths must match their component selectors without the `-demo` suffix.
 export const routes: Routes = [
   {
     path: '',
+    redirectTo: 'fluid-row-height',
+    pathMatch: 'full'
+  },
+  {
+    path: 'fluid-row-height',
     data: { title: 'Fluid Row Height', sourcePath: 'basic/fluid-row-height.component.ts' },
     loadComponent: () =>
       import('./basic/fluid-row-height.component').then(c => c.FluidRowHeightComponent)
   },
   // Basic
   {
-    path: '10k-rows',
+    path: 'ten-k-rows',
     data: { title: '10k Rows', sourcePath: 'basic/10k-rows.component.ts' },
     loadComponent: () => import('./basic/10k-rows.component').then(c => c.TenKRowsComponent)
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,8 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { provideRouter, withHashLocation } from '@angular/router';
 import { providedNgxDatatableConfig } from '@siemens/ngx-datatable';
 
-import { routes } from './app/app-routing.module';
 import { AppComponent } from './app/app.component';
+import { routes } from './app/app.routes';
 
 bootstrapApplication(AppComponent, {
   providers: [

--- a/src/main.web-components.ts
+++ b/src/main.web-components.ts
@@ -9,7 +9,14 @@ import { createCustomElement } from '@angular/elements';
 import { createApplication } from '@angular/platform-browser';
 import { providedNgxDatatableConfig } from '@siemens/ngx-datatable';
 
+import { routes } from './app/app.routes';
 import { DATA_ASSETS_URL } from './app/data.service';
+
+const exampleLoaders = new Map(
+  routes.flatMap(route =>
+    route.path && route.loadComponent ? [[route.path, route.loadComponent] as const] : []
+  )
+);
 
 declare global {
   interface Window {
@@ -27,44 +34,19 @@ createApplication({
 })
   .then(appRef => {
     window.loadDatatableExample = async example => {
-      switch (example) {
-        case 'fluid-row-height': {
-          registerExample(
-            'ngx-datatable-fluid-row-height',
-            await import('./app/basic/fluid-row-height.component').then(
-              c => c.FluidRowHeightComponent
-            ),
-            appRef
-          );
-          return;
-        }
-        case 'standard-column': {
-          registerExample(
-            'ngx-datatable-standard-column',
-            await import('./app/columns/fixed-column.component').then(c => c.FixedColumnComponent),
-            appRef
-          );
-          return;
-        }
-        case 'flex-column': {
-          registerExample(
-            'ngx-datatable-flex-column',
-            await import('./app/columns/flex-column.component').then(c => c.FlexColumnComponent),
-            appRef
-          );
-          return;
-        }
-        case 'force-column': {
-          registerExample(
-            'ngx-datatable-force-column',
-            await import('./app/columns/force-column.component').then(c => c.ForceColumnComponent),
-            appRef
-          );
-          return;
-        }
-        default:
-          throw new Error(`Unknown datatable example: ${example}`);
+      const loadComponent = exampleLoaders.get(example);
+      if (!loadComponent) {
+        throw new Error(`Unknown datatable example: ${example}`);
       }
+
+      const componentPromise = loadComponent();
+      if (!(componentPromise instanceof Promise)) {
+        throw new Error(`Invalid datatable example component: ${example}`);
+      }
+
+      const componentResult = await componentPromise;
+      const component = 'default' in componentResult ? componentResult.default : componentResult;
+      registerExample(`ngx-datatable-${example}`, component, appRef);
     };
 
     window.dispatchEvent(new Event('ngx-datatable-examples-ready'));


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Web-component examples are registered through a separate switch statement and do not share the application route configuration.

**What is the new behavior?**

Web-component examples load their components from the shared lazy route map. Route paths now follow the component selector convention without the `-demo` suffix.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
