### PR TITLE
fix(body): support keyboard interaction with virtual scrolling

### DIFF
--- a/projects/ngx-datatable/src/lib/components/body/body.component.ts
+++ b/projects/ngx-datatable/src/lib/components/body/body.component.ts
@@ -359,6 +359,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
   readonly rowHeightsCache = computed(() => this.computeRowHeightsCache());
   readonly offsetY = signal(0);
   readonly indexes = computed(() => this.computeIndexes());
+  private readonly pendingFocus = signal<{ index: number; cellIndex?: number } | undefined>(undefined);
   rowTrackingFn: TrackByFunction<RowOrGroup<TRow> | undefined>;
   readonly rowExpansions = signal<TRow[]>([]);
   readonly groupExpansions = signal<Group<TRow>[]>([]);
@@ -506,6 +507,7 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
 
     this.updatePage(event.direction);
     this.cd.detectChanges();
+    this.focusPendingRow();
   }
 
   /**
@@ -961,6 +963,8 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
     const nextRow = this.getPrevNextRow(index, key, indexInGroup);
     if (nextRow) {
       nextRow.focus();
+    } else {
+      this.focusVirtualRow(index, key);
     }
   }
 
@@ -995,7 +999,44 @@ export class DataTableBodyComponent<TRow extends Row = any> implements OnInit, O
       nextRow = this.getPrevNextRow(index, key, indexInGroup);
     }
 
-    nextRow?.focusCell(nextCellIndex);
+    if (nextRow) {
+      nextRow.focusCell(nextCellIndex);
+    } else if (key === ARROW_UP || key === ARROW_DOWN) {
+      this.focusVirtualRow(index, key, nextCellIndex);
+    }
+  }
+
+  private focusVirtualRow(index: number, key: string, cellIndex?: number): void {
+    if (!this.virtualization() || !this.scrollbarV()) {
+      return;
+    }
+
+    const nextIndex = this.indexes().first + index + (key === ARROW_DOWN ? 1 : -1);
+    if (nextIndex < 0 || nextIndex >= this.rowCount()) {
+      return;
+    }
+
+    this.pendingFocus.set({ index: nextIndex, cellIndex });
+    this.scrollToIndex(nextIndex, { block: key === ARROW_DOWN ? 'end' : 'start' });
+  }
+
+  private focusPendingRow(): void {
+    const pendingFocus = this.pendingFocus();
+    if (!pendingFocus) {
+      return;
+    }
+
+    const nextRow = this.getRow(pendingFocus.index);
+    if (!nextRow) {
+      return;
+    }
+
+    if (pendingFocus.cellIndex === undefined) {
+      nextRow.focus();
+    } else {
+      nextRow.focusCell(pendingFocus.cellIndex);
+    }
+    this.pendingFocus.set(undefined);
   }
 
   private getRow(index: number, indexInGroup?: number): DataTableBodyRowComponent | undefined {

--- a/projects/ngx-datatable/src/lib/components/body/keyboard-navigation.spec.ts
+++ b/projects/ngx-datatable/src/lib/components/body/keyboard-navigation.spec.ts
@@ -10,12 +10,15 @@ import { DatatableComponent } from '../datatable.component';
   imports: [DatatableComponent],
   template: `
     <ngx-datatable
+      style="height: 400px"
       [columns]="columns()"
       [rows]="rows()"
       [selectionType]="selectionType()"
       [disableRowCheck]="disableRowCheck()"
       [groupRowsBy]="groupRowsBy()"
       [groupExpansionDefault]="groupExpansionDefault()"
+      [scrollbarV]="true"
+      [virtualization]="true"
       [selected]="selected()"
       (selectedChange)="selected.set($event)"
       (activate)="activate.set($event)"
@@ -130,6 +133,52 @@ describe('keyboard navigation', () => {
     await userEvent.keyboard('{ArrowUp}');
     await fixture.whenStable();
     expect(document.activeElement).toBe(graceRow);
+  });
+
+  it('scrolls and focuses the next virtual row', async () => {
+    fixture.componentInstance.rows.set(
+      Array.from({ length: 100 }, (_, index) => ({ name: `Name ${index}`, city: `City ${index}` }))
+    );
+    await fixture.whenStable();
+
+    const lastRenderedRow = page.getByRole('row', { name: 'Name 12 City 12' });
+    const targetRow = page.getByRole('row', { name: 'Name 13 City 13' });
+    lastRenderedRow.element().focus();
+
+    await expect.element(targetRow).not.toBeInTheDocument();
+    await userEvent.keyboard('{ArrowDown}');
+    await fixture.whenStable();
+
+    await expect.element(targetRow).toBeInTheDocument();
+    await expect.element(targetRow).toHaveFocus();
+
+    await userEvent.keyboard('{ArrowUp}');
+    await expect.element(lastRenderedRow).toHaveFocus();
+  });
+
+  it('navigates virtual rows after scrolling to a nonzero offset', async () => {
+    const rows = Array.from({ length: 100 }, (_, index) => ({
+      name: `Name ${index}`,
+      city: `City ${index}`
+    }));
+    fixture.componentInstance.rows.set(rows);
+    await fixture.whenStable();
+
+    const table = page.getByRole('table').element();
+    table.scrollTop = 1500;
+    table.dispatchEvent(new Event('scroll'));
+    await fixture.whenStable();
+
+    const lastRenderedRow = page.getByRole('row', { name: 'Name 62 City 62' });
+    const targetRow = page.getByRole('row', { name: 'Name 63 City 63' });
+    lastRenderedRow.element().focus();
+
+    await expect.element(targetRow).not.toBeInTheDocument();
+    await userEvent.keyboard('{ArrowDown}');
+    await expect.element(targetRow).toHaveFocus();
+
+    await userEvent.keyboard('{ArrowUp}');
+    await expect.element(lastRenderedRow).toHaveFocus();
   });
 
   it('selects the focused row with Enter', async () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Keyboard interaction cannot move between rows or cells once the next target is outside the rendered virtual-scroll range.

**What is the new behavior?**

Keyboard interaction scrolls to and focuses adjacent offscreen virtual rows. Row and cell navigation retain the correct absolute row index after the table has already been scrolled.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Tests: `npm run test:unit -- --include='**/keyboard-navigation.spec.ts'`